### PR TITLE
Fix settings status, HAPI persistence, seed verification, and results display

### DIFF
--- a/backend/app/routes/results.py
+++ b/backend/app/routes/results.py
@@ -67,11 +67,11 @@ async def get_results(
             }
         )
 
-    # Performance rate = numerator / (denominator - denominator_exclusion)
-    effective_denominator = pops["denominator"] - pops["denominator_exclusion"]
+    # Performance rate = numerator / denominator
+    # The denominator already excludes denominator-exclusion patients.
     performance_rate = None
-    if effective_denominator > 0:
-        performance_rate = round(pops["numerator"] / effective_denominator * 100, 1)
+    if pops["denominator"] > 0:
+        performance_rate = round(pops["numerator"] / pops["denominator"] * 100, 1)
 
     return {
         "job_id": job_id,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,18 +44,26 @@ services:
 
   hapi-fhir-cdr:
     image: hapiproject/hapi:v7.4.0
+    user: root
     volumes: ["cdrdata:/data/hapi"]
     environment:
       - hapi.fhir.server_address=http://hapi-fhir-cdr:8080/fhir
       - hapi.fhir.defer_indexing_for_codesystems_of_size=0
+      - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
+      - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.dialect=ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
 
   hapi-fhir-measure:
     image: hapiproject/hapi:v7.4.0
+    user: root
     volumes: ["measuredata:/data/hapi"]
     environment:
       - hapi.fhir.server_address=http://hapi-fhir-measure:8080/fhir
       - hapi.fhir.defer_indexing_for_codesystems_of_size=0
       - hapi.fhir.cr.enabled=true
+      - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
+      - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.dialect=ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
 
   seed:
     build: ./seed

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -212,8 +212,9 @@ export default function ResultsPage() {
           {/* Population cards */}
           <div className={styles.cardsRow}>
             <PopulationCard label="Initial Population" count={initialPop} variant="default" />
-            <PopulationCard label="Denominator" count={denominator} variant="default" />
             <PopulationCard label="Numerator" count={numerator} variant="accent" />
+            <PopulationCard label="Denominator" count={denominator} variant="default" />
+            <PopulationCard label="Denominator Exclusions" count={denomExclusion} variant="default" />
           </div>
 
           {/* Performance Rate */}
@@ -222,17 +223,10 @@ export default function ResultsPage() {
               <span className={styles.perfLabel}>Performance Rate</span>
               <span className={styles.perfValue}>
                 {typeof performanceRate === 'number'
-                  ? `${(performanceRate * (performanceRate <= 1 ? 100 : 1)).toFixed(1)}%`
+                  ? `${performanceRate.toFixed(1)}%`
                   : performanceRate}
               </span>
             </div>
-          )}
-
-          {/* Denominator Exclusions */}
-          {denomExclusion !== undefined && denomExclusion !== null && (
-            <p className={styles.exclusions}>
-              Denominator Exclusions: {denomExclusion.toLocaleString()}
-            </p>
           )}
 
           {/* Patient list */}

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -279,17 +279,17 @@ export default function SettingsPage() {
             />
             <StatusIndicator
               label="Measure Engine"
-              status={health?.measure_engine_connected ?? health?.measure_engine}
+              status={health?.measure_engine?.status}
               detail={health?.measure_engine_url}
             />
             <StatusIndicator
               label="CDR"
-              status={health?.cdr_connected ?? health?.cdr}
+              status={health?.cdr?.status}
               detail={health?.cdr_response_time ? `${health.cdr_response_time}ms` : null}
             />
             <StatusIndicator
               label="Database"
-              status={health?.database_connected ?? health?.database}
+              status={health?.database?.status}
             />
           </div>
         </section>

--- a/seed/load-seed-data.sh
+++ b/seed/load-seed-data.sh
@@ -63,13 +63,20 @@ verify_data() {
   local url="$1"
   local resource_type="$2"
   local name="$3"
+  local attempt=1
 
-  count=$(curl -s "$url/${resource_type}?_summary=count" | sed -n 's/.*"total":\([0-9]*\).*/\1/p')
-  if [ -n "$count" ] && [ "$count" -gt 0 ]; then
-    log "Verified: $count $resource_type resource(s) found on $name."
-  else
-    log "WARNING: Could not verify $resource_type resources on $name (count: ${count:-unknown})."
-  fi
+  while [ "$attempt" -le "$MAX_RETRIES" ]; do
+    count=$(curl -s "$url/${resource_type}?_summary=count" | sed -n 's/.*"total":\([0-9]*\).*/\1/p')
+    if [ -n "$count" ] && [ "$count" -gt 0 ]; then
+      log "Verified: $count $resource_type resource(s) found on $name."
+      return 0
+    fi
+    log "Waiting for $resource_type indexing on $name (attempt $attempt/$MAX_RETRIES)..."
+    sleep "$RETRY_INTERVAL"
+    attempt=$((attempt + 1))
+  done
+
+  log "WARNING: Could not verify $resource_type resources on $name after $MAX_RETRIES attempts."
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary
- **Settings page**: Fix connection status indicators always showing "Disconnected" by reading the nested `status` field from the health API response
- **HAPI FHIR persistence**: Configure both HAPI instances to use file-backed H2 databases so seed data survives container restarts
- **Seed verification**: Add retry polling (60 attempts, 5s interval) to the seed verification step to wait for HAPI's async indexing
- **Results page**: Fix performance rate calculation (denominator already excludes exclusions, so don't double-subtract) and promote denominator exclusions to a full population card

## Test plan
- [ ] Run `docker compose down -v && docker compose up -d` and verify seed data persists after `docker compose restart hapi-fhir-cdr`
- [ ] Verify Settings page shows all three services as "Connected"
- [ ] Run a CMS122 measure job and confirm performance rate displays as ~97.4% (38/39)
- [ ] Confirm Results page shows four population cards: Initial Population, Numerator, Denominator, Denominator Exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)