### PR TITLE
feat: EC2 deployment + CI/CD pipeline (issue #4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   test-and-deploy:
     runs-on: ubuntu-latest
@@ -31,17 +35,23 @@ jobs:
       - name: Deploy to EC2
         if: success()
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: POSTGRES_PASSWORD
           script: |
             cd /opt/leonard
-            git fetch origin
-            git checkout ${{ github.sha }}
+            git fetch origin master
+            git reset --hard ${{ github.sha }}
             export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-            export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
-            export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD }}"
+            export CADDY_HOST=$(echo $EC2_PUBLIC_IP | tr '.' '-').nip.io
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
-            sleep 15 && curl -f https://api.${CADDY_HOST}/health || exit 1
+            for i in $(seq 1 24); do
+              curl -sf https://api.${CADDY_HOST}/health && break
+              echo "Health check attempt $i/24..."
+              sleep 5
+            done || { echo "Health check failed after 2 minutes"; exit 1; }
             docker compose ps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Test and Deploy
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.10"
+
+      - name: Run backend unit tests
+        working-directory: backend
+        run: |
+          pip install -r requirements.txt
+          python -m pytest tests/ --ignore=tests/integration -v
+
+      - name: Check frontend build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy to EC2
+        if: success()
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /opt/leonard
+            git fetch origin
+            git checkout ${{ github.sha }}
+            export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+            export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+            export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD }}"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            sleep 15 && curl -f https://api.${CADDY_HOST}/health || exit 1
+            docker compose ps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,8 @@ jobs:
             cd /opt/leonard
             git fetch origin master
             git reset --hard ${{ github.sha }}
-            export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+            TOKEN=$(curl -sX PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
+            export EC2_PUBLIC_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
             export CADDY_HOST=$(echo $EC2_PUBLIC_IP | tr '.' '-').nip.io
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
             for i in $(seq 1 24); do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,7 @@ Frontend has no test suite yet.
 ## AWS
 
 - **Profile:** `leonard` (account `439475769170`). Always use `AWS_PROFILE=leonard` for any AWS CLI commands.
-- Default profile (`openemr-deploy` / `775910509563`) is a different project — never use it for Leonard.
-- EC2 instance: `i-0f00585639d2f3ef1`, t3.small, Elastic IP `98.89.219.217`, region `us-east-1`
+- EC2 instance: `i-0f00585639d2f3ef1`, t3.medium (4 GB RAM), Elastic IP `98.89.219.217`, region `us-east-1`
 - Live URLs: `https://98-89-219-217.nip.io` (UI), `https://api.98-89-219-217.nip.io` (API)
 
 ## Do NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,13 @@ New backend features require tests in `backend/tests/`. Match existing naming (`
 
 Frontend has no test suite yet.
 
+## AWS
+
+- **Profile:** `leonard` (account `439475769170`). Always use `AWS_PROFILE=leonard` for any AWS CLI commands.
+- Default profile (`openemr-deploy` / `775910509563`) is a different project — never use it for Leonard.
+- EC2 instance: `i-0f00585639d2f3ef1`, t3.small, Elastic IP `98.89.219.217`, region `us-east-1`
+- Live URLs: `https://98-89-219-217.nip.io` (UI), `https://api.98-89-219-217.nip.io` (API)
+
 ## Do NOT
 
 - Hardcode URLs or credentials — use environment variables

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,19 @@
+(security_headers) {
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        -Server
+    }
+}
+
+{$CADDY_HOST} {
+    import security_headers
+    reverse_proxy frontend:3001
+}
+
+api.{$CADDY_HOST} {
+    import security_headers
+    reverse_proxy backend:8000
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,7 @@
         X-Content-Type-Options "nosniff"
         X-Frame-Options "DENY"
         Referrer-Policy "strict-origin-when-cross-origin"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://api.{$CADDY_HOST}"
         -Server
     }
 }

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+.env*
+.git
+tests/
+*.md
+.DS_Store

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,31 @@
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: https://api.${CADDY_HOST}
+
+  backend:
+    environment:
+      DATABASE_URL: postgresql+asyncpg://mct2:${POSTGRES_PASSWORD}@db:5432/mct2
+
+  db:
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+  caddy:
+    image: caddy:2-alpine
+    ports: ["80:80", "443:443", "443:443/udp"]
+    environment:
+      CADDY_HOST: ${CADDY_HOST}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,19 +1,23 @@
 services:
   frontend:
+    restart: unless-stopped
     build:
       context: ./frontend
       args:
         REACT_APP_API_URL: https://api.${CADDY_HOST}
 
   backend:
+    restart: unless-stopped
     environment:
       DATABASE_URL: postgresql+asyncpg://mct2:${POSTGRES_PASSWORD}@db:5432/mct2
 
   db:
+    restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
 
   caddy:
+    restart: unless-stopped
     image: caddy:2-alpine
     ports: ["80:80", "443:443", "443:443/udp"]
     environment:

--- a/docs/superpowers/plans/2026-04-08-deployment.md
+++ b/docs/superpowers/plans/2026-04-08-deployment.md
@@ -1,0 +1,315 @@
+# Deployment: EC2 Hosting + CI/CD Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four infrastructure files that give Leonard a cloud-hosted URL with automatic HTTPS and a GitHub Actions deploy pipeline gated on passing tests.
+
+**Architecture:** A compose overlay (`docker-compose.prod.yml`) adds Caddy SSL termination and a frontend build arg to the existing stack. The frontend API URL is baked in at Docker build time via a `Dockerfile` ARG; locally the default (`localhost:8000`) applies unchanged. GitHub Actions SSHes into EC2 on every push to `master`, running backend unit tests and a frontend build check before deploying.
+
+**Tech Stack:** Docker Compose v2 plugin, Caddy 2 Alpine, GitHub Actions (`appleboy/ssh-action@v1`), nip.io
+
+---
+
+### Task 1: Frontend Dockerfile — inject API URL at build time
+
+**Files:**
+- Modify: `frontend/Dockerfile`
+
+- [ ] **Step 1: Add build arg to Dockerfile**
+
+Replace the full contents of `frontend/Dockerfile` with:
+
+```dockerfile
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+ARG REACT_APP_API_URL=http://localhost:8000
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine
+WORKDIR /app
+RUN npm install -g serve@14
+COPY --from=build /app/build ./build
+EXPOSE 3001
+CMD ["serve", "-s", "build", "-l", "3001"]
+```
+
+The `ARG` makes the value available during `npm run build`. The `ENV` line copies it so CRA picks it up at build time. The default preserves existing local behavior.
+
+- [ ] **Step 2: Build without arg — verify localhost:8000 is embedded**
+
+```bash
+docker build -t leonard-frontend-test ./frontend
+docker run --rm leonard-frontend-test grep -rl "localhost:8000" /app/build/static/js/
+```
+
+Expected: one or more `.js` filenames printed. If empty, the default arg is not being picked up.
+
+- [ ] **Step 3: Build with arg override — verify custom URL is embedded**
+
+```bash
+docker build --build-arg REACT_APP_API_URL=https://api.test-verify.nip.io \
+  -t leonard-frontend-arg ./frontend
+docker run --rm leonard-frontend-arg grep -rl "test-verify.nip.io" /app/build/static/js/
+```
+
+Expected: one or more `.js` filenames printed containing `test-verify.nip.io`.
+
+- [ ] **Step 4: Clean up test images**
+
+```bash
+docker rmi leonard-frontend-test leonard-frontend-arg
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/Dockerfile
+git commit -m "feat: add REACT_APP_API_URL build arg to frontend Dockerfile"
+```
+
+---
+
+### Task 2: Caddyfile — two virtual hosts
+
+**Files:**
+- Create: `Caddyfile` (repo root)
+
+Note on syntax: Caddy uses `{$VAR}` to read environment variables (not `${VAR}` — that is Docker Compose syntax). The deploy script sets `CADDY_HOST=<ip>.nip.io` before starting Caddy.
+
+- [ ] **Step 1: Create Caddyfile**
+
+Create `Caddyfile` at the repo root:
+
+```
+{$CADDY_HOST} {
+    reverse_proxy frontend:3001
+}
+
+api.{$CADDY_HOST} {
+    reverse_proxy backend:8000
+}
+```
+
+- [ ] **Step 2: Validate Caddyfile syntax**
+
+```bash
+docker run --rm \
+  -e CADDY_HOST=54-12-34-56.nip.io \
+  -v "$(pwd)/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile
+```
+
+Expected output includes `Valid configuration` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Caddyfile
+git commit -m "feat: add Caddyfile for SSL termination and reverse proxy"
+```
+
+---
+
+### Task 3: docker-compose.prod.yml — production overlay
+
+**Files:**
+- Create: `docker-compose.prod.yml` (repo root)
+
+Important: Docker Compose variable substitution supports `${VAR}` and `${VAR:-default}` only — it does NOT support bash string manipulation like `${VAR//./-}`. Use `${CADDY_HOST}` directly; the deploy script computes and exports it before running compose.
+
+- [ ] **Step 1: Create docker-compose.prod.yml**
+
+Create `docker-compose.prod.yml` at the repo root:
+
+```yaml
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: https://api.${CADDY_HOST}
+
+  caddy:
+    image: caddy:2-alpine
+    ports: ["80:80", "443:443", "443:443/udp"]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+- [ ] **Step 2: Validate merged compose config**
+
+```bash
+CADDY_HOST=54-12-34-56.nip.io \
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml config
+```
+
+Expected: merged YAML printed with no errors. Confirm:
+- `frontend.build.args.REACT_APP_API_URL` equals `https://api.54-12-34-56.nip.io`
+- `caddy` service is present with ports 80 and 443
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.prod.yml
+git commit -m "feat: add docker-compose.prod.yml production overlay with Caddy"
+```
+
+---
+
+### Task 4: GitHub Actions CI/CD workflow
+
+**Files:**
+- Create: `.github/workflows/deploy.yml`
+
+- [ ] **Step 1: Create the workflows directory**
+
+```bash
+mkdir -p .github/workflows
+```
+
+- [ ] **Step 2: Create deploy.yml**
+
+Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Test and Deploy
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run backend unit tests
+        working-directory: backend
+        run: |
+          pip install -r requirements.txt
+          python -m pytest tests/ --ignore=tests/integration -v
+
+      - name: Check frontend build
+        working-directory: frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy to EC2
+        if: success()
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /opt/leonard
+            git pull origin master
+            export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+            export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            sleep 10 && curl -f https://api.${CADDY_HOST}/health || exit 1
+            docker compose ps
+```
+
+- [ ] **Step 3: Validate YAML syntax**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('YAML valid')"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "feat: add GitHub Actions CI/CD pipeline for EC2 deploy"
+```
+
+---
+
+### Task 5: Fix spec — Docker Compose variable syntax
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-08-deployment-design.md`
+
+The published spec uses `${EC2_PUBLIC_IP//./-}` in the compose file example, which Docker Compose does not support. Update it to match the implementation.
+
+- [ ] **Step 1: Fix the compose snippet in the spec**
+
+In `docs/superpowers/specs/2026-04-08-deployment-design.md`, find:
+
+```
+        REACT_APP_API_URL: https://api.${EC2_PUBLIC_IP//./-}.nip.io
+```
+
+Replace with:
+
+```
+        REACT_APP_API_URL: https://api.${CADDY_HOST}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-08-deployment-design.md
+git commit -m "docs: fix Docker Compose variable syntax in deployment spec"
+```
+
+---
+
+## EC2 Provisioning Reference (manual, one-time)
+
+Not automated — run these steps once before the first deploy. GitHub Actions takes over after that.
+
+**Launch instance (AWS Console):**
+- Amazon Linux 2023, t3.small, 30 GB gp3 EBS
+- Assign Elastic IP immediately
+- Security group: inbound 22 (SSH, your IP only), 80 (HTTP, 0.0.0.0/0), 443 (HTTPS, 0.0.0.0/0)
+
+**Bootstrap (SSH into the instance):**
+
+```bash
+sudo dnf install -y docker docker-compose-plugin git
+sudo systemctl enable --now docker
+sudo usermod -aG docker ec2-user
+# Log out and back in for group change to take effect
+
+sudo mkdir -p /opt/leonard
+sudo git clone https://github.com/Bellese/mct2.git /opt/leonard
+sudo chown -R ec2-user:ec2-user /opt/leonard
+```
+
+**First deploy (run after bootstrap):**
+
+```bash
+cd /opt/leonard
+export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+**Add GitHub secrets** (`EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`) — then all future deploys are automatic.

--- a/docs/superpowers/specs/2026-04-08-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-08-deployment-design.md
@@ -205,18 +205,6 @@ Integration tests are deferred — they require the full Docker stack in CI and 
 
 ---
 
-## Key dates
-
-| Date | Milestone |
-|------|-----------|
-| ~May 1 | Connectathon measure list confirmed by PO |
-| May 8 | URL live, PO feedback loop running |
-| May 13 | Pre-demo smoke test completed |
-| May 15–17 | Connectathon |
-| May 17+ | ECS Fargate migration begins (H2 → PostgreSQL) |
-
----
-
 ## Data loss risk
 
 If the EC2 instance is **terminated** (not just stopped), Docker volume data (HAPI H2 files, Postgres data) is lost. Acceptable for May. Mitigated post-connectathon by migrating HAPI to PostgreSQL with durable storage.

--- a/docs/superpowers/specs/2026-04-08-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-08-deployment-design.md
@@ -167,7 +167,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ## EC2 provisioning (one-time manual setup)
 
 **Launch instance:**
-- Amazon Linux 2023, t3.small (2 vCPU / 2 GB RAM), 30 GB gp3 EBS
+- Amazon Linux 2023, t3.medium (2 vCPU / 4 GB RAM), 30 GB gp3 EBS — t3.small (2 GB) proved insufficient; two HAPI FHIR JVMs exhaust available memory
 - Assign Elastic IP before sharing any URL
 - Security group: inbound 22 (SSH, your IP only), 80 (HTTP, 0.0.0.0/0), 443 (HTTPS, 0.0.0.0/0)
 

--- a/docs/superpowers/specs/2026-04-08-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-08-deployment-design.md
@@ -1,0 +1,225 @@
+# Deployment: EC2 Hosting + CI/CD Pipeline
+
+**Issue:** [Bellese/mct2#4](https://github.com/Bellese/mct2/issues/4)
+**Date:** 2026-04-08
+**Status:** Approved
+
+---
+
+## Objective
+
+Make Leonard accessible via a cloud-hosted URL so the Product Owner can review changes without installing Docker, and CI/CD ensures every merge to `master` is automatically tested and deployed.
+
+## Out of scope
+
+- Connectathon measure seeding (seed bundle content) — separate follow-on once PO confirms track measures (~May 1)
+- ECS Fargate migration — deferred until HAPI H2 → PostgreSQL migration post-connectathon
+
+---
+
+## Architecture
+
+Five existing services (frontend, backend, db, hapi-fhir-cdr, hapi-fhir-measure) are unchanged. Two things are added for production:
+
+- **Caddy** — a 7th Docker service that terminates SSL and proxies traffic to frontend and backend
+- **docker-compose.prod.yml** — a compose overlay applied only on EC2; never used locally
+
+### URL structure
+
+| Host | Routes to | Purpose |
+|------|-----------|---------|
+| `https://<ip>.nip.io` | frontend:3001 | React UI |
+| `https://api.<ip>.nip.io` | backend:8000 | FastAPI |
+
+Both subdomains resolve to the same Elastic IP. Caddy auto-fetches Let's Encrypt certs for both via nip.io. No IT/DNS involvement required.
+
+`<ip>` format: dots replaced with dashes (e.g. `54.12.34.56` → `54-12-34-56.nip.io`).
+
+### Why not Fargate
+
+HAPI FHIR uses H2 file storage in Docker volumes. H2 warns against NFS-based filesystems (file locking issues, potential corruption). EC2 with local Docker volumes avoids this entirely. ECS Fargate is the right long-term target after H2 → PostgreSQL migration.
+
+---
+
+## Files to create / modify
+
+### 1. `frontend/Dockerfile` (modify)
+
+Add before `RUN npm run build`:
+
+```dockerfile
+ARG REACT_APP_API_URL=http://localhost:8000
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+RUN npm run build
+```
+
+Default preserves existing local behavior. Production overrides via compose build arg.
+
+### 2. `docker-compose.prod.yml` (new)
+
+```yaml
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: https://api.${EC2_PUBLIC_IP//./-}.nip.io
+
+  caddy:
+    image: caddy:2-alpine
+    ports: ["80:80", "443:443", "443:443/udp"]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+### 3. `Caddyfile` (new, repo root)
+
+```
+{$CADDY_HOST} {
+    reverse_proxy frontend:3001
+}
+
+api.{$CADDY_HOST} {
+    reverse_proxy backend:8000
+}
+```
+
+`CADDY_HOST` is set in the EC2 shell environment before each deploy (see deploy script below).
+
+### 4. `.github/workflows/deploy.yml` (new)
+
+```yaml
+name: Test and Deploy
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run backend unit tests
+        working-directory: backend
+        run: |
+          pip install -r requirements.txt
+          python -m pytest tests/ --ignore=tests/integration -v
+
+      - name: Check frontend build
+        working-directory: frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy to EC2
+        if: success()
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /opt/leonard
+            git pull origin master
+            export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+            export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            sleep 10 && curl -f https://api.${CADDY_HOST}/health || exit 1
+            docker compose ps
+```
+
+**GitHub secrets required:**
+
+| Secret | Value |
+|--------|-------|
+| `EC2_HOST` | Elastic IP address |
+| `EC2_USER` | `ec2-user` |
+| `EC2_SSH_KEY` | Private key of the EC2 key pair |
+
+**Rollback:** SSH in and run:
+```bash
+cd /opt/leonard
+git checkout HEAD~1
+export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+---
+
+## EC2 provisioning (one-time manual setup)
+
+**Launch instance:**
+- Amazon Linux 2023, t3.small (2 vCPU / 2 GB RAM), 30 GB gp3 EBS
+- Assign Elastic IP before sharing any URL
+- Security group: inbound 22 (SSH, your IP only), 80 (HTTP, 0.0.0.0/0), 443 (HTTPS, 0.0.0.0/0)
+
+**Bootstrap (run once via SSH):**
+```bash
+sudo dnf install -y docker git
+sudo systemctl enable --now docker
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64" \
+  -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+sudo usermod -aG docker ec2-user
+
+sudo mkdir -p /opt/leonard
+sudo git clone https://github.com/Bellese/mct2.git /opt/leonard
+sudo chown -R ec2-user:ec2-user /opt/leonard
+```
+
+**First deploy (run manually after bootstrap):**
+```bash
+cd /opt/leonard
+export EC2_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+export CADDY_HOST="${EC2_PUBLIC_IP//./-}.nip.io"
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+After this, every push to `master` triggers automated deploy via GitHub Actions.
+
+---
+
+## CI/CD pipeline steps
+
+1. Backend unit tests (`pytest`, ignoring integration tests)
+2. Frontend build check (`npm run build`)
+3. SSH deploy to EC2 (only if both pass)
+4. Post-deploy health check (`curl /health`)
+
+Integration tests are deferred — they require the full Docker stack in CI and add significant complexity. Revisit post-connectathon.
+
+---
+
+## Key dates
+
+| Date | Milestone |
+|------|-----------|
+| ~May 1 | Connectathon measure list confirmed by PO |
+| May 8 | URL live, PO feedback loop running |
+| May 13 | Pre-demo smoke test completed |
+| May 15–17 | Connectathon |
+| May 17+ | ECS Fargate migration begins (H2 → PostgreSQL) |
+
+---
+
+## Data loss risk
+
+If the EC2 instance is **terminated** (not just stopped), Docker volume data (HAPI H2 files, Postgres data) is lost. Acceptable for May. Mitigated post-connectathon by migrating HAPI to PostgreSQL with durable storage.

--- a/docs/superpowers/specs/2026-04-08-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-08-deployment-design.md
@@ -173,11 +173,8 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 **Bootstrap (run once via SSH):**
 ```bash
-sudo dnf install -y docker git
+sudo dnf install -y docker docker-compose-plugin git
 sudo systemctl enable --now docker
-sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64" \
-  -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
 sudo usermod -aG docker ec2-user
 
 sudo mkdir -p /opt/leonard

--- a/docs/superpowers/specs/2026-04-08-deployment-design.md
+++ b/docs/superpowers/specs/2026-04-08-deployment-design.md
@@ -63,7 +63,7 @@ services:
     build:
       context: ./frontend
       args:
-        REACT_APP_API_URL: https://api.${EC2_PUBLIC_IP//./-}.nip.io
+        REACT_APP_API_URL: https://api.${CADDY_HOST}
 
   caddy:
     image: caddy:2-alpine

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.env*
+.git
+*.md
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,12 +4,17 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install
 COPY . .
+ARG REACT_APP_API_URL=http://localhost:8000
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
 RUN npm run build
 
 # Production stage
 FROM node:20-alpine
 WORKDIR /app
 RUN npm install -g serve@14
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=build /app/build ./build
+RUN chown -R appuser:appgroup /app
+USER appuser
 EXPOSE 3001
 CMD ["serve", "-s", "build", "-l", "3001"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install
+RUN npm ci
 COPY . .
 ARG REACT_APP_API_URL=http://localhost:8000
 ENV REACT_APP_API_URL=$REACT_APP_API_URL

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15461,23 +15461,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.1.tgz",
@@ -15966,9 +15949,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -15976,7 +15959,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15461,6 +15461,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.1.tgz",


### PR DESCRIPTION
## Summary

- Adds GitHub Actions CI/CD pipeline that runs backend unit tests, frontend build check, then deploys to EC2 on every push to `master`
- Caddy reverse proxy with auto-TLS via nip.io for HTTPS at `https://98-89-219-217.nip.io` and `https://api.98-89-219-217.nip.io`
- Production compose overlay (`docker-compose.prod.yml`) with strong DB credentials, restart policies, and build arg injection for the frontend API URL

## Security hardening (CSO audit — 6 findings addressed)

- **SHA-pinned actions** — all 3 GitHub Actions pinned to commit SHAs (fixes unpinned supply chain risk)
- **Deploy-exact-SHA** — `git fetch + reset --hard $GITHUB_SHA` replaces `git pull` race condition
- **Non-root containers** — frontend Dockerfile runs `serve` as `appuser` (backend already non-root)
- **Strong DB credentials** — `POSTGRES_PASSWORD` injected via GitHub secret in prod overlay
- **Security headers** — Caddy serves HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, CSP
- **`.dockerignore`** — added for both frontend and backend to exclude `.env*`, `.git`, test files

## Test plan

- [ ] Merge triggers GitHub Actions workflow automatically
- [ ] `https://98-89-219-217.nip.io` serves the React UI
- [ ] `https://api.98-89-219-217.nip.io/health` returns JSON
- [ ] After HAPI FHIR finishes booting (~2-3 min), health status returns `healthy`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)