### PR TITLE
fix: real error messages and dismissible test result in ConnectionModal

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,9 +82,7 @@ async def _run_schema_migrations(conn) -> None:
             await conn.execute(text(stmt))
 
         # Unique constraint on name (required for ON CONFLICT (name) seed upsert)
-        await conn.execute(
-            text("CREATE UNIQUE INDEX IF NOT EXISTS uq_cdr_configs_name ON cdr_configs (name)")
-        )
+        await conn.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS uq_cdr_configs_name ON cdr_configs (name)"))
 
         # Add new columns to jobs
         for stmt in [

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -33,7 +33,21 @@ async function request(path, options = {}) {
     } catch {
       // Response may not be JSON
     }
-    const message = body?.detail || body?.message || `Request failed: ${response.status} ${response.statusText}`;
+    const raw = body?.detail || body?.message;
+    let message;
+    if (!raw) {
+      message = `Request failed: ${response.status} ${response.statusText}`;
+    } else if (typeof raw === 'string') {
+      message = raw;
+    } else if (raw?.issue?.[0]?.diagnostics) {
+      // FHIR OperationOutcome
+      message = raw.issue[0].diagnostics;
+    } else if (Array.isArray(raw)) {
+      // FastAPI validation error array
+      message = raw.map(e => e.msg || JSON.stringify(e)).join('; ');
+    } else {
+      message = `Request failed: ${response.status} ${response.statusText}`;
+    }
     throw new ApiError(message, response.status, body);
   }
 

--- a/frontend/src/components/ConnectionModal.js
+++ b/frontend/src/components/ConnectionModal.js
@@ -179,10 +179,11 @@ export default function ConnectionModal({ connection, onClose, onSaved }) {
           {testResult && (
             <div className={`${styles.testResult} ${testResult.success ? styles.testSuccess : styles.testFailure}`} role="status">
               <span aria-hidden="true">{testResult.success ? '\u2713' : '\u2717'}</span>
-              <div>
+              <div className={styles.testContent}>
                 <p className={styles.testMessage}>{testResult.message}</p>
                 {testResult.response_time && <p className={styles.testDetail}>Response time: {testResult.response_time}ms</p>}
               </div>
+              <button className={styles.testDismiss} onClick={() => setTestResult(null)} aria-label="Dismiss">&#x2715;</button>
             </div>
           )}
 

--- a/frontend/src/components/ConnectionModal.module.css
+++ b/frontend/src/components/ConnectionModal.module.css
@@ -121,6 +121,27 @@
   border-radius: var(--radius-md);
 }
 
+.testContent {
+  flex: 1;
+}
+
+.testDismiss {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: inherit;
+  opacity: 0.6;
+  transition: opacity var(--transition);
+}
+
+.testDismiss:hover {
+  opacity: 1;
+}
+
 .testSuccess {
   background: var(--color-success-light);
   border: 1px solid var(--color-success);


### PR DESCRIPTION
## Summary

- **`[object Object]` error messages**: `client.js` was passing `body.detail` directly as the `Error` message. When the backend returns a FHIR OperationOutcome, `detail` is an object — `new Error(object)` coerces it to `"[object Object]"`. Now extracts the string from `.issue[0].diagnostics` for OperationOutcome, maps `.msg` fields for FastAPI validation arrays, and falls back to the HTTP status text.
- **Non-clickable ✗**: The test result failure indicator was a static `<span>`. Looks like a close button but does nothing. Added an actual dismiss button so users can clear the banner.

## Test plan

- [ ] Open Edit Connection for a working connection (e.g. Local CDR), click Test Connection — should show green success banner with a dismiss ✕
- [ ] Open Add Connection with a bad URL, click Test Connection — should show the actual error message (e.g. "Connection failed: ..."), not `[object Object]`, with a working dismiss ✕
- [ ] Click the ✕ dismiss button — banner clears
- [ ] Try Save with invalid data — save error banner still shows the human-readable diagnostics string

🤖 Generated with [Claude Code](https://claude.com/claude-code)