### PR TITLE
fix: explicit volume mount and restart policies in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,11 +11,19 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://mct2:${POSTGRES_PASSWORD}@db:5432/mct2
       ALLOWED_ORIGINS: https://${CADDY_HOST}
+    volumes:
+      - ./seed/connectathon-bundles:/seed/connectathon-bundles:ro
 
   db:
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+  hapi-fhir-cdr:
+    restart: unless-stopped
+
+  hapi-fhir-measure:
+    restart: unless-stopped
 
   caddy:
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Defensive hardening for `docker-compose.prod.yml` found during investigation of why measures weren't showing on the /measures page (root cause was a stale browser cache — all 13 measures are loading correctly). Two issues patched:

- **Volume mount for connectathon bundles** — the startup bundle loader (`bundle_loader.py`) reads from `/seed/connectathon-bundles` inside the backend container. The base `docker-compose.yml` mounts this path, but the prod override file didn't declare it explicitly. If anyone ever deploys using only `docker-compose.prod.yml`, the loader silently no-ops. Now it's explicit in both files.

- **`restart: unless-stopped` for both HAPI services** — `hapi-fhir-cdr` and `hapi-fhir-measure` were missing from `docker-compose.prod.yml`, meaning an EC2 reboot would leave both FHIR servers stopped and the whole app broken until manual intervention. Added alongside the other services.

## Changes

- `docker-compose.prod.yml`: +8 lines (volume mount, two restart policies)

## Pre-Landing Review

No code changed — YAML config only. No security surface, no logic, no tests needed.

## Test plan
- [x] Deploy to EC2 and verify all 13 measures load on startup
- [x] Verify `docker compose ps` shows all 6 services running after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)