### PR TITLE
fix: improve mobile layout for nav bar and data tables

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -184,6 +184,7 @@
   background: var(--color-bg-primary);
   border-top: 1px solid var(--color-border);
   z-index: 100;
+  -webkit-overflow-scrolling: touch;
 }
 
 .bottomTabList {
@@ -192,6 +193,11 @@
   height: 100%;
   padding: 0;
   margin: 0;
+}
+
+.bottomTabList li {
+  flex: 1;
+  display: flex;
 }
 
 .bottomTabLink {

--- a/frontend/src/pages/MeasuresPage.module.css
+++ b/frontend/src/pages/MeasuresPage.module.css
@@ -36,9 +36,14 @@
 
 .tableWrapper {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--color-bg-primary);
+}
+
+.tableWrapper table {
+  min-width: 480px;
 }
 
 .measureName {

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -125,10 +125,15 @@
 /* Patient table */
 .tableWrapper {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--color-bg-primary);
   margin-top: var(--space-6);
+}
+
+.tableWrapper table {
+  min-width: 640px;
 }
 
 .patientId {
@@ -233,11 +238,11 @@
   }
 
   .cardsRow {
-    flex-direction: column;
+    flex-wrap: wrap;
   }
 
   .card {
-    min-width: auto;
+    min-width: 140px;
   }
 
   .jobSelector {


### PR DESCRIPTION
## Summary

- **Bottom nav labels no longer run together** — `li` items in the mobile tab bar now have `flex: 1; display: flex`, giving each tab equal width and making the column layout inside work correctly
- **Measures table scrolls horizontally on mobile** — added `min-width: 480px` to the table so it overflows its wrapper and the existing `overflow-x: auto` kicks in; Actions column is no longer clipped
- **Results table scrolls horizontally on mobile** — same fix with `min-width: 640px` for the 6-column patient table; population cards now wrap 2-up on narrow screens instead of stacking vertically
- Added `-webkit-overflow-scrolling: touch` to both table wrappers and the bottom tab bar for smooth iOS momentum scrolling

No JS changes — all fixes are pure CSS.

## Test plan

- [ ] Open DevTools device emulator at iPhone SE width (375px)
- [ ] **Bottom nav**: verify four tabs are evenly spaced with labels centered under icons
- [ ] **Measures page**: swipe table left to confirm Actions column is reachable
- [ ] **Results page**: swipe table left to confirm all 6 columns are reachable; verify population cards appear 2-per-row
- [ ] **Desktop regression**: confirm layout is unchanged at full browser width

https://claude.ai/code/session_01PpuEWbwFLqXdfM2N5QmkYg