### PR TITLE
fix: move test_full_workflow to nightly, cut PR gate ~17m → ~8m (issue #93)

### DIFF
--- a/.github/workflows/connectathon-measures.yml
+++ b/.github/workflows/connectathon-measures.yml
@@ -42,4 +42,4 @@ jobs:
         run: pip install -r requirements.txt -r requirements-test.txt
 
       - name: Run connectathon measure evaluation tests
-        run: ./scripts/run-integration-tests.sh tests/integration/test_connectathon_measures.py
+        run: ./scripts/run-integration-tests.sh tests/integration/test_connectathon_measures.py tests/integration/test_full_workflow.py

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,7 @@ jobs:
         run: pip install -r requirements.txt -r requirements-test.txt
 
       - name: Run integration tests
-        run: ./scripts/run-integration-tests.sh --ignore=tests/integration/test_connectathon_measures.py --durations=25
+        run: ./scripts/run-integration-tests.sh --ignore=tests/integration/test_connectathon_measures.py --ignore=tests/integration/test_full_workflow.py --durations=25
 
   frontend-build:
     name: Frontend Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ New backend features require tests in `backend/tests/`. Match existing naming (`
 
 Frontend has no test suite yet.
 
+**Full workflow tests on large changes:** `tests/integration/test_full_workflow.py` runs nightly, not on PRs. For any change that touches the measure evaluation pipeline, FHIR data flow, or job orchestration, run these locally before merging:
+
+```bash
+./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py
+```
+
+Or trigger the nightly workflow manually via GitHub Actions → Connectathon Measures → Run workflow.
+
 ## AWS
 
 - **Profile:** `leonard` (account `439475769170`). Always use `AWS_PROFILE=leonard` for any AWS CLI commands.


### PR DESCRIPTION
## Summary

- Removes `test_full_workflow.py` from the PR gate (`pr-checks.yml`) by adding a second `--ignore` flag alongside the existing connectathon ignore.
- Adds `test_full_workflow.py` to the nightly `connectathon-measures.yml` run so these tests still execute daily.
- Adds a note to `CLAUDE.md` reminding devs to run the full-workflow suite locally (or trigger the nightly manually) before merging changes that touch the measure evaluation pipeline.

**Expected PR gate improvement:** ~17m 31s → ~8m (saves ~520s — the two `test_full_workflow` tests account for 49% of integration runtime per Phase 1 data on #93).

## Context

Phase 1 instrumentation (PR #94) revealed the two full-workflow tests (`test_create_and_run_job`: 284s, `test_results_aggregate_populations`: 234s) dominate the integration job. This follows the same pattern as #90, which moved `test_connectathon_measures.py` to nightly. The tradeoff: these tests won't catch regressions in the measure evaluation pipeline before merge — they catch it overnight. The `CLAUDE.md` note and nightly run preserve the coverage signal.

## Test plan

- [ ] PR CI passes and integration step completes in under 10 minutes
- [ ] Confirm `test_full_workflow` tests do NOT appear in the PR integration log
- [ ] Nightly `connectathon-measures.yml` workflow includes `test_full_workflow.py` in its invocation (verify by checking the workflow file or triggering manually)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)