### PR TITLE
chore: one-shot cleanup of 9 legacy EXM measures on prod

### DIFF
--- a/.github/workflows/cleanup-legacy-measures.yml
+++ b/.github/workflows/cleanup-legacy-measures.yml
@@ -1,0 +1,49 @@
+name: Cleanup Legacy Measures (one-shot)
+
+# One-shot manual cleanup: deletes 9 legacy CQL 1.3 EXM Measure resources that
+# remain in the Measure Engine volume after PR #95 removed their bundle files
+# from the repo. Run once via the Actions UI, then delete this workflow file.
+#
+# Uses only trusted inputs (static IDs + org secrets). No user-controlled data.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete legacy measures via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/leonard
+            IDS=(
+              measure-exm165-FHIR4
+              measure-EXM529-FHIR4-1.0.000
+              measure-EXM104-FHIR4-8.1.000
+              measure-EXM105-FHIR4-8.1.000
+              measure-EXM108-FHIR4-8.2.000
+              measure-EXM124-FHIR4-8.2.000
+              measure-EXM125-FHIR4-7.2.000
+              measure-EXM130-FHIR4-7.2.000
+              measure-EXM506-FHIR4-2.1.000
+            )
+            BEFORE=$(curl -sf https://api.98-89-219-217.nip.io/measures | python3 -c 'import sys,json; print(json.load(sys.stdin)["total"])')
+            echo "Before: $BEFORE measures"
+            for id in "${IDS[@]}"; do
+              code=$(docker compose -f docker-compose.yml -f docker-compose.prod.yml exec -T backend \
+                curl -s -o /dev/null -w "%{http_code}" \
+                -X DELETE "http://hapi-fhir-measure:8080/fhir/Measure/$id")
+              case "$code" in
+                200|204) echo "  [OK]    $id (HTTP $code)" ;;
+                404)     echo "  [SKIP]  $id (already gone)" ;;
+                *)       echo "  [FAIL]  $id (HTTP $code)"; exit 1 ;;
+              esac
+            done
+            AFTER=$(curl -sf https://api.98-89-219-217.nip.io/measures | python3 -c 'import sys,json; print(json.load(sys.stdin)["total"])')
+            echo "After: $AFTER measures"


### PR DESCRIPTION
## Summary

Adds a manually-triggered GitHub Actions workflow that deletes 9 legacy CQL 1.3 EXM Measure resources still lingering in the prod Measure Engine volume. PR #95 removed the bundle files from the repo; this cleans up the leftover resources in HAPI.

The 9 IDs being removed:
- `measure-exm165-FHIR4`
- `measure-EXM529-FHIR4-1.0.000`
- `measure-EXM104-FHIR4-8.1.000`, `EXM105-FHIR4-8.1.000`, `EXM108-FHIR4-8.2.000`
- `measure-EXM124-FHIR4-8.2.000`, `EXM125-FHIR4-7.2.000`, `EXM130-FHIR4-7.2.000`
- `measure-EXM506-FHIR4-2.1.000`

After this ships, a follow-up PR will delete the workflow file — it is one-shot.

## Test plan

- [x] Workflow uses only trusted inputs (static IDs + org secrets)
- [ ] After merge, trigger `Cleanup Legacy Measures (one-shot)` via Actions UI
- [ ] Verify measure count drops from 21 → 12 (see `Before:` / `After:` in job logs)
- [ ] Follow-up PR removes the workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)