### PR TITLE
fix: cleanup workflow uses docker exec (no compose env deps)

### DIFF
--- a/.github/workflows/cleanup-legacy-measures.yml
+++ b/.github/workflows/cleanup-legacy-measures.yml
@@ -21,7 +21,6 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             set -e
-            cd /opt/leonard
             IDS=(
               measure-exm165-FHIR4
               measure-EXM529-FHIR4-1.0.000
@@ -33,11 +32,17 @@ jobs:
               measure-EXM130-FHIR4-7.2.000
               measure-EXM506-FHIR4-2.1.000
             )
+            BACKEND=$(docker ps --filter 'label=com.docker.compose.service=backend' --format '{{.Names}}' | head -1)
+            if [ -z "$BACKEND" ]; then
+              echo "ERROR: no running backend container found"
+              docker ps
+              exit 1
+            fi
+            echo "Using backend container: $BACKEND"
             BEFORE=$(curl -sf https://api.98-89-219-217.nip.io/measures | python3 -c 'import sys,json; print(json.load(sys.stdin)["total"])')
             echo "Before: $BEFORE measures"
             for id in "${IDS[@]}"; do
-              code=$(docker compose -f docker-compose.yml -f docker-compose.prod.yml exec -T backend \
-                curl -s -o /dev/null -w "%{http_code}" \
+              code=$(docker exec "$BACKEND" curl -s -o /dev/null -w "%{http_code}" \
                 -X DELETE "http://hapi-fhir-measure:8080/fhir/Measure/$id")
               case "$code" in
                 200|204) echo "  [OK]    $id (HTTP $code)" ;;


### PR DESCRIPTION
The initial attempt failed with exit 126 because \`docker compose exec\` on the prod host needed CADDY_HOST and POSTGRES_PASSWORD env vars that the workflow didn't provide. Switch to \`docker exec\` against the backend container (found via compose service label) so compose interpolation is not involved at all.

Failing run: https://github.com/Bellese/mct2/actions/runs/24743783122

## Summary
<!-- 1-3 bullet points: WHAT changed and WHY -->

-

## Related issue
<!-- Closes #N for each issue. Omit this section entirely if no linked issue. -->

## Type of change
<!-- These are for reviewer context, not strict enforcement.
     They roughly map to conventional commit prefixes (feat, fix, chore, docs). -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI/CD
- [ ] Chore (deps, tooling, lockfile)

## Checklist

- [ ] Tests added or updated (N/A for docs/infra/chore)
- [ ] docs/ updated (if architecture or API changed)
- [ ] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
      <!-- ADR triggers: new external dependency, schema change, changed auth/security behavior, new service, reversibility-impacting decision -->
- [ ] Security implications considered (N/A for pure refactor/docs)

## Test plan
<!-- How can a reviewer verify this works? Include commands, URLs, or steps. -->

- [ ]

<!-- OPTIONAL -- remove HTML comments to use:

## Screenshots / recordings

## Breaking changes

-->
