### PR TITLE
fix: cleanup workflow uses python stdlib (no curl in backend image)

### DIFF
--- a/.github/workflows/cleanup-legacy-measures.yml
+++ b/.github/workflows/cleanup-legacy-measures.yml
@@ -21,17 +21,6 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             set -e
-            IDS=(
-              measure-exm165-FHIR4
-              measure-EXM529-FHIR4-1.0.000
-              measure-EXM104-FHIR4-8.1.000
-              measure-EXM105-FHIR4-8.1.000
-              measure-EXM108-FHIR4-8.2.000
-              measure-EXM124-FHIR4-8.2.000
-              measure-EXM125-FHIR4-7.2.000
-              measure-EXM130-FHIR4-7.2.000
-              measure-EXM506-FHIR4-2.1.000
-            )
             BACKEND=$(docker ps --filter 'label=com.docker.compose.service=backend' --format '{{.Names}}' | head -1)
             if [ -z "$BACKEND" ]; then
               echo "ERROR: no running backend container found"
@@ -41,14 +30,41 @@ jobs:
             echo "Using backend container: $BACKEND"
             BEFORE=$(curl -sf https://api.98-89-219-217.nip.io/measures | python3 -c 'import sys,json; print(json.load(sys.stdin)["total"])')
             echo "Before: $BEFORE measures"
-            for id in "${IDS[@]}"; do
-              code=$(docker exec "$BACKEND" curl -s -o /dev/null -w "%{http_code}" \
-                -X DELETE "http://hapi-fhir-measure:8080/fhir/Measure/$id")
-              case "$code" in
-                200|204) echo "  [OK]    $id (HTTP $code)" ;;
-                404)     echo "  [SKIP]  $id (already gone)" ;;
-                *)       echo "  [FAIL]  $id (HTTP $code)"; exit 1 ;;
-              esac
-            done
+
+            docker exec -i "$BACKEND" python - <<'PY'
+            import urllib.request, urllib.error
+            IDS = [
+                "measure-exm165-FHIR4",
+                "measure-EXM529-FHIR4-1.0.000",
+                "measure-EXM104-FHIR4-8.1.000",
+                "measure-EXM105-FHIR4-8.1.000",
+                "measure-EXM108-FHIR4-8.2.000",
+                "measure-EXM124-FHIR4-8.2.000",
+                "measure-EXM125-FHIR4-7.2.000",
+                "measure-EXM130-FHIR4-7.2.000",
+                "measure-EXM506-FHIR4-2.1.000",
+            ]
+            failures = 0
+            for id_ in IDS:
+                url = f"http://hapi-fhir-measure:8080/fhir/Measure/{id_}"
+                try:
+                    r = urllib.request.urlopen(urllib.request.Request(url, method="DELETE"), timeout=30)
+                    code = r.status
+                except urllib.error.HTTPError as e:
+                    code = e.code
+                except Exception as e:
+                    print(f"  [ERROR] {id_}: {e}")
+                    failures += 1
+                    continue
+                if code in (200, 204):
+                    print(f"  [OK]    {id_} (HTTP {code})")
+                elif code == 404:
+                    print(f"  [SKIP]  {id_} (already gone)")
+                else:
+                    print(f"  [FAIL]  {id_} (HTTP {code})")
+                    failures += 1
+            raise SystemExit(1 if failures else 0)
+            PY
+
             AFTER=$(curl -sf https://api.98-89-219-217.nip.io/measures | python3 -c 'import sys,json; print(json.load(sys.stdin)["total"])')
             echo "After: $AFTER measures"


### PR DESCRIPTION
Previous run (24752840089) hit exit 126 on `docker exec backend curl ...` because backend image is python:3.12-slim without curl. Switches to `docker exec python -` with urllib.request. No extra deps.