### PR TITLE
fix: disable HAPI search cache and add retry for indexing lag

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -485,6 +485,9 @@ async def _resolve_measure_id(measure_url: str) -> Optional[str]:
     Handles two formats:
     - Canonical URL (http/https): queries HAPI ?url= search parameter
     - Relative reference ("Measure/{id}"): fetches resource directly by ID
+
+    Includes a retry loop and Cache-Control: no-cache to mitigate HAPI search
+    indexing lag and search result caching.
     """
     async with httpx.AsyncClient(timeout=30.0) as client:
         if not measure_url.startswith("http"):
@@ -497,13 +500,41 @@ async def _resolve_measure_id(measure_url: str) -> Optional[str]:
                 resp.raise_for_status()
                 return resp.json().get("id")
             return None
+
         # Canonical URL — search by ?url= parameter
-        resp = await client.get(f"{settings.MEASURE_ENGINE_URL}/Measure?url={measure_url}&_count=1")
-        resp.raise_for_status()
-        bundle = resp.json()
-        entries = bundle.get("entry", [])
-        if entries:
-            return entries[0].get("resource", {}).get("id")
+        # Retry up to 3 times with 1s delay to handle search indexing lag
+        headers = {"Cache-Control": "no-cache", "Accept": "application/fhir+json"}
+        params = {"url": measure_url, "_count": 1}
+
+        for attempt in range(3):
+            try:
+                resp = await client.get(
+                    f"{settings.MEASURE_ENGINE_URL}/Measure",
+                    params=params,
+                    headers=headers,
+                )
+                resp.raise_for_status()
+                bundle = resp.json()
+                entries = bundle.get("entry", [])
+                if entries:
+                    return entries[0].get("resource", {}).get("id")
+
+                if attempt < 2:
+                    logger.info(
+                        "Measure search returned no results — retrying",
+                        extra={"measure_url": measure_url, "attempt": attempt + 1},
+                    )
+                    await asyncio.sleep(1.0)
+            except Exception as exc:
+                if attempt < 2:
+                    logger.warning(
+                        "Measure search failed — retrying",
+                        extra={"measure_url": measure_url, "attempt": attempt + 1, "error": str(exc)},
+                    )
+                    await asyncio.sleep(1.0)
+                else:
+                    raise
+
     return None
 
 

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -958,8 +958,6 @@ class TestResolveMeasureId:
 
     async def test_resolve_measure_id_retries_on_empty_bundle(self):
         """Verify that _resolve_measure_id retries when HAPI returns an empty bundle (lag/cache)."""
-        import asyncio
-
         # First two calls return empty bundle
         empty_bundle = {"resourceType": "Bundle", "entry": []}
         # Third call returns the measure
@@ -998,8 +996,6 @@ class TestResolveMeasureId:
 
     async def test_resolve_measure_id_retries_on_exception(self):
         """Verify that _resolve_measure_id retries when HAPI request fails."""
-        import asyncio
-
         mock_resp_success = MagicMock()
         mock_resp_success.raise_for_status = MagicMock()
         mock_resp_success.json.return_value = {

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -956,6 +956,73 @@ class TestResolveMeasureId:
             with pytest.raises(httpx.HTTPStatusError):
                 await _resolve_measure_id("Measure/measure-EXM130-FHIR4-7.2.000")
 
+    async def test_resolve_measure_id_retries_on_empty_bundle(self):
+        """Verify that _resolve_measure_id retries when HAPI returns an empty bundle (lag/cache)."""
+        import asyncio
+
+        # First two calls return empty bundle
+        empty_bundle = {"resourceType": "Bundle", "entry": []}
+        # Third call returns the measure
+        success_bundle = {
+            "resourceType": "Bundle",
+            "entry": [{"resource": {"resourceType": "Measure", "id": "hapi-id-123"}}],
+        }
+
+        mock_resp_empty = MagicMock()
+        mock_resp_empty.raise_for_status = MagicMock()
+        mock_resp_empty.json.return_value = empty_bundle
+
+        mock_resp_success = MagicMock()
+        mock_resp_success.raise_for_status = MagicMock()
+        mock_resp_success.json.return_value = success_bundle
+
+        mock_client = AsyncMock()
+        # Side effect: two empties, then success
+        mock_client.get = AsyncMock(side_effect=[mock_resp_empty, mock_resp_empty, mock_resp_success])
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
+            with patch("app.services.validation.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                result = await _resolve_measure_id("http://example.com/Measure/123")
+
+                assert result == "hapi-id-123"
+                assert mock_client.get.call_count == 3
+                assert mock_sleep.call_count == 2
+
+                # Verify Cache-Control: no-cache was sent
+                last_call_headers = mock_client.get.call_args_list[-1].kwargs["headers"]
+                assert last_call_headers["Cache-Control"] == "no-cache"
+
+    async def test_resolve_measure_id_retries_on_exception(self):
+        """Verify that _resolve_measure_id retries when HAPI request fails."""
+        import asyncio
+
+        mock_resp_success = MagicMock()
+        mock_resp_success.raise_for_status = MagicMock()
+        mock_resp_success.json.return_value = {
+            "resourceType": "Bundle",
+            "entry": [{"resource": {"resourceType": "Measure", "id": "hapi-id-456"}}],
+        }
+
+        mock_client = AsyncMock()
+        # Side effect: one failure, then success
+        mock_client.get = AsyncMock(side_effect=[Exception("Network error"), mock_resp_success])
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
+            with patch("app.services.validation.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                result = await _resolve_measure_id("http://example.com/Measure/456")
+
+                assert result == "hapi-id-456"
+                assert mock_client.get.call_count == 2
+                assert mock_sleep.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # _fix_valueset_compose_for_hapi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - hapi.fhir.implementationguides.cql.version=1.0.0
       - hapi.fhir.server_address=http://hapi-fhir-cdr:8080/fhir
       - hapi.fhir.defer_indexing_for_codesystems_of_size=0
+      - hapi.fhir.reuse_cached_search_results_millis=0
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.enforce_referential_integrity_on_write=false
@@ -78,6 +79,7 @@ services:
       - hapi.fhir.implementationguides.cql.version=1.0.0
       - hapi.fhir.server_address=http://hapi-fhir-measure:8080/fhir
       - hapi.fhir.defer_indexing_for_codesystems_of_size=0
+      - hapi.fhir.reuse_cached_search_results_millis=0
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_multiple_delete=true
       - hapi.fhir.cr.enabled=true


### PR DESCRIPTION
## Summary
- Update `_resolve_measure_id` to use `Cache-Control: no-cache` and a 3-attempt retry loop to handle HAPI search caching and indexing lag.
- Set `hapi.fhir.reuse_cached_search_results_millis=0` in `docker-compose.yml` to disable search result caching at the engine level.
- Add regression tests in `backend/tests/test_services_validation.py`.

## Related issue
Closes #118

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI/CD

## Checklist
- [x] Tests added or updated
- [x] No new ADRs needed

## Test plan
1. Run backend unit tests: `cd backend && python3 -m pytest tests/test_services_validation.py -v`
2. Inspect `docker-compose.yml` for the new environment variable.
3. Observe production validation logs (once deployed) for retry attempts if indexing is slow.