### PR TITLE
fix: prevent measure engine OOM from hanging jobs and blocking settings page

### DIFF
--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -39,7 +39,7 @@ async def health_check(
 
     # Measure engine check
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{settings.MEASURE_ENGINE_URL}/metadata")
             if resp.status_code == 200:
                 status["measure_engine"] = {"status": "connected"}
@@ -55,7 +55,7 @@ async def health_check(
 
     # CDR check
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{cdr.cdr_url}/metadata")
             if resp.status_code == 200:
                 status["cdr"] = {"status": "connected", "name": cdr.name, "is_read_only": cdr.is_read_only}

--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -464,6 +464,9 @@ async def wipe_patient_data() -> None:
     Called at the START of a new job to clean up data from the prior run.
     This allows the previous job's evaluated resources to remain available
     for inspection until a new job begins.
+
+    Fails fast if the measure engine is unreachable: after 3 consecutive
+    timeouts we raise immediately rather than grinding for 20+ minutes.
     """
     resource_types = [
         "MeasureReport",
@@ -491,7 +494,9 @@ async def wipe_patient_data() -> None:
         "Practitioner",
         "Organization",
     ]
-    async with httpx.AsyncClient(timeout=60.0) as client:
+    _MAX_CONSECUTIVE_FAILURES = 3
+    consecutive_failures = 0
+    async with httpx.AsyncClient(timeout=10.0) as client:
         for rt in resource_types:
             try:
                 # Use conditional delete: DELETE ResourceType?_lastUpdated=gt1900-01-01
@@ -502,11 +507,18 @@ async def wipe_patient_data() -> None:
                 else:
                     # Fall back to individual delete via search-and-delete
                     await _delete_all_of_type(client, rt)
+                consecutive_failures = 0
             except httpx.HTTPError:
+                consecutive_failures += 1
                 logger.warning(
                     "Failed to wipe resource type (may not exist)",
                     extra={"resourceType": rt},
                 )
+                if consecutive_failures >= _MAX_CONSECUTIVE_FAILURES:
+                    raise RuntimeError(
+                        f"Measure engine unreachable: {consecutive_failures} consecutive "
+                        "timeouts during wipe. Job aborted."
+                    )
 
 
 async def _delete_all_of_type(client: httpx.AsyncClient, resource_type: str) -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     image: hapiproject/hapi:v8.8.0-1
     user: root
     volumes: ["cdrdata:/data/hapi"]
+    mem_limit: 1500m
     environment:
       # QI-Core STU6 IG packages
       - hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
@@ -64,11 +65,13 @@ services:
       - hapi.fhir.enforce_referential_integrity_on_write=false
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
+      - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
 
   hapi-fhir-measure:
     image: hapiproject/hapi:v8.8.0-1
     user: root
     volumes: ["measuredata:/data/hapi"]
+    mem_limit: 2g
     environment:
       # QI-Core STU6 IG packages
       - hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
@@ -90,6 +93,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
       - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+      - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m
 
   seed:
     build: ./seed

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -9,14 +9,18 @@ class ApiError extends Error {
   }
 }
 
-async function request(path, options = {}) {
+async function request(path, { _timeout = 20000, ...options } = {}) {
   const url = `${BASE_URL}${path}`;
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), _timeout);
+
   const config = {
     headers: {
       'Content-Type': 'application/json',
       ...options.headers,
     },
     ...options,
+    signal: controller.signal,
   };
 
   // Don't set Content-Type for FormData (let browser set multipart boundary)
@@ -24,7 +28,17 @@ async function request(path, options = {}) {
     delete config.headers['Content-Type'];
   }
 
-  const response = await fetch(url, config);
+  let response;
+  try {
+    response = await fetch(url, config);
+  } catch (err) {
+    clearTimeout(timerId);
+    if (err.name === 'AbortError') {
+      throw new ApiError(`Request timed out after ${_timeout}ms`, 0, null);
+    }
+    throw err;
+  }
+  clearTimeout(timerId);
 
   if (!response.ok) {
     let body = null;
@@ -61,7 +75,7 @@ async function request(path, options = {}) {
 
 // Health
 export function getHealth() {
-  return request('/health');
+  return request('/health', { _timeout: 5000 });
 }
 
 // Measures

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -64,7 +64,8 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
-    Promise.all([loadConnections(), loadHealth()]).finally(() => setLoading(false));
+    loadConnections().finally(() => setLoading(false));
+    loadHealth();
   }, [loadConnections, loadHealth]);
 
   const handleOpenAdd = () => {


### PR DESCRIPTION
## Summary

Root cause identified via live prod investigation: `hapi-fhir-measure` hit `java.lang.OutOfMemoryError: Java heap space` at 17:30:52 UTC during a CMS122 evaluation (confirmed via `docker logs`). No `-Xmx` was set, so the JVM consumed all available heap. H2 closed internally while the container stayed alive — leaving jobs and health checks hanging for up to 24 minutes.

- **docker-compose.yml**: Add `JAVA_TOOL_OPTIONS=-Xmx1500m/-Xmx1g` and `mem_limit` to both HAPI containers — OOM now fails cleanly and Docker auto-restarts the container instead of leaving a zombie
- **fhir_client.py**: `wipe_patient_data` timeout 60s→10s per request, bail after 3 consecutive failures (was grinding for up to 24 min on a dead engine)
- **health.py**: Measure engine + CDR probe timeouts 10s→3s (liveness probe should not block for 10s)
- **SettingsPage.js**: Decouple `/health` from page loading gate — connections render immediately, health card shows "Unknown" while probe resolves independently
- **client.js**: Add `AbortController` timeout (5s for `/health`, 20s default) — browser fetch calls no longer hang indefinitely

## Test plan

- [x] 263 unit tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Deploy to prod and verify `/health` returns `healthy` in <5s
- [ ] Load `/settings` — connections section should render immediately without waiting for health probe
- [ ] Start a new CMS122 job — if engine OOMs, job should fail fast (<60s) instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)