### PR TITLE
fix: increase HAPI mem_limit to account for JVM overhead on t3.large

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     user: root
     ports: ["8081:8080"]
     volumes: ["cdrdata:/data/hapi"]
-    mem_limit: 1500m
+    mem_limit: 2g
     environment:
       # QI-Core STU6 IG packages
       - hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
@@ -74,7 +74,7 @@ services:
     user: root
     ports: ["8080:8080"]
     volumes: ["measuredata:/data/hapi"]
-    mem_limit: 2g
+    mem_limit: 3g
     environment:
       # QI-Core STU6 IG packages
       - hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore


### PR DESCRIPTION
## Summary

- Bumps `hapi-fhir-measure` `mem_limit` from `2g` → `3g`
- Bumps `hapi-fhir-cdr` `mem_limit` from `1500m` → `2g`

## Root cause

With `mem_limit: 2g` and `-Xmx1500m`, the measure engine was being OOM-killed by Docker during evaluation runs. The JVM heap cap is `1500m`, but JVM metaspace + native heap + thread stacks + other overhead adds ~400–600MB on top, pushing the total JVM footprint to ~2–2.1GB — right at the container limit under load. Docker kills the container the moment resident memory crosses `mem_limit`, with no warning in logs.

The CDR container had the same issue at `mem_limit: 1500m` with `-Xmx1g`.

## Why this fix now

We're on a t3.large (8GB RAM) as of today's EC2 resize. Memory budget on t3.large:

| Service | Before | After |
|---|---|---|
| hapi-fhir-measure | 2g | 3g |
| hapi-fhir-cdr | 1500m | 2g |
| Other services (DB, backend, frontend, Caddy) | ~1g | ~1g |
| **Total** | ~4.5g | ~6g of 8g |

## Test plan

- [ ] Deploy to prod: `git pull && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps --force-recreate hapi-fhir-measure hapi-fhir-cdr`
- [ ] Run a CMS122 job with Local CDR — confirm it reaches `complete` with processed patients > 0
- [ ] `docker stats --no-stream` to verify neither container exceeds its new limit under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)