### PR TITLE
[codex] isolate nightly source-of-truth suite

### DIFF
--- a/.github/workflows/connectathon-measures.yml
+++ b/.github/workflows/connectathon-measures.yml
@@ -1,11 +1,16 @@
 name: Connectathon Measures
 
 # Non-blocking: runs nightly and on manual trigger.
-# Per-patient $evaluate-measure calls (~548 test cases across 11 bundles)
-# take ~15-20 min, too long for the PR gate.
+# The source-of-truth integration suite is too slow for the PR gate, so it runs
+# once nightly here and can be triggered manually for large changes.
 #
-# When STRICT_STU6 flips to "1" this job will hard-fail on population
-# mismatches, giving a daily signal of connectathon readiness.
+# Job split:
+#   - source-of-truth: golden isolation plus full-bundle connectathon coverage.
+#   - full-workflow: orchestration end-to-end coverage in a clean runner so it
+#     does not inherit the connectathon-loaded CDR state.
+#
+# When STRICT_STU6 flips to "1" the source-of-truth job will hard-fail on
+# population mismatches, giving a daily signal of connectathon readiness.
 
 on:
   schedule:
@@ -21,8 +26,8 @@ env:
   PYTHON_VERSION: "3.10"
 
 jobs:
-  connectathon-measures:
-    name: Connectathon Measures (per-patient evaluation)
+  source-of-truth:
+    name: Source of Truth (golden + connectathon)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -41,5 +46,28 @@ jobs:
         working-directory: backend
         run: pip install -r requirements.txt -r requirements-test.txt
 
-      - name: Run connectathon measure evaluation tests
-        run: ./scripts/run-integration-tests.sh tests/integration/test_connectathon_measures.py tests/integration/test_full_workflow.py
+      - name: Run nightly source-of-truth integration suite
+        run: >-
+          ./scripts/run-integration-tests.sh
+          tests/integration/test_golden_measures.py
+          tests/integration/test_connectathon_measures.py
+
+  full-workflow:
+    name: Full Workflow (clean nightly run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt -r requirements-test.txt
+
+      - name: Run full workflow integration test in isolation
+        run: ./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,12 @@ jobs:
         run: pip install -r requirements.txt -r requirements-test.txt
 
       - name: Run integration tests
-        run: ./scripts/run-integration-tests.sh --ignore=tests/integration/test_connectathon_measures.py --ignore=tests/integration/test_full_workflow.py --durations=25
+        run: >-
+          ./scripts/run-integration-tests.sh
+          --ignore=tests/integration/test_golden_measures.py
+          --ignore=tests/integration/test_connectathon_measures.py
+          --ignore=tests/integration/test_full_workflow.py
+          --durations=25
 
   frontend-build:
     name: Frontend Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,13 +59,13 @@ New backend features require tests in `backend/tests/`. Match existing naming (`
 
 Frontend has no test suite yet.
 
-**Full workflow tests on large changes:** `tests/integration/test_full_workflow.py` runs nightly, not on PRs. For any change that touches the measure evaluation pipeline, FHIR data flow, or job orchestration, run these locally before merging:
+**Full workflow tests on large changes:** `tests/integration/test_full_workflow.py` runs nightly in its own clean job, not on PRs. For any change that touches the measure evaluation pipeline, FHIR data flow, or job orchestration, run these locally before merging:
 
 ```bash
 ./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py
 ```
 
-Or trigger the nightly workflow manually via GitHub Actions → Connectathon Measures → Run workflow.
+Or trigger the nightly workflow manually via GitHub Actions → Connectathon Measures → Run workflow. The workflow runs the source-of-truth suite (`test_golden_measures.py` + `test_connectathon_measures.py`) and the full workflow test in separate clean jobs.
 
 ## AWS
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,12 @@ docker compose -f docker-compose.test.yml up -d
 ```
 
 The script waits for HAPI health checks, runs the tests, and tears down containers automatically.
+If you pass explicit test files, directories, or node IDs, it runs only those targets; option-only invocations still default to the full integration suite.
+
+```bash
+# Run only the full workflow suite
+./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py
+```
 
 Integration tests are marked `@pytest.mark.integration` and live in `backend/tests/integration/`.
 
@@ -71,11 +77,15 @@ Integration tests are marked `@pytest.mark.integration` and live in `backend/tes
 
 | File | What it covers |
 |------|----------------|
-| `test_fhir_operations.py` | Core FHIR client operations against a live HAPI instance |
-| `test_smart_load.py` | `triage_test_bundle` + bundle loader against live HAPI |
-| `test_golden_measures.py` | End-to-end `$evaluate-measure` against golden bundles |
-| `test_connectathon_measures.py` | Parametrized per-test-case run across all connectathon bundles (skipped on the PR gate — runs nightly via `connectathon-measures.yml`) |
-| `test_full_workflow.py` | Full-stack pipeline covering job orchestration → measure eval → result storage (skipped on the PR gate — runs nightly) |
+| `test_fhir_operations.py` | Core FHIR client operations against a live HAPI instance; stays in the PR-gate integration smoke suite |
+| `test_smart_load.py` | `triage_test_bundle` + bundle loader against live HAPI; stays in the PR-gate integration smoke suite |
+| `test_golden_measures.py` | End-to-end `$evaluate-measure` against golden bundles; part of the nightly source-of-truth job |
+| `test_connectathon_measures.py` | Parametrized per-test-case run across all connectathon bundles; skipped on the PR gate and included in the nightly source-of-truth job |
+| `test_full_workflow.py` | Full-stack pipeline covering job orchestration → measure eval → result storage; skipped on the PR gate and run in its own clean nightly job |
+
+The nightly `connectathon-measures.yml` workflow still runs once per night, but it now uses two clean jobs:
+- `source-of-truth` runs `test_golden_measures.py` and `test_connectathon_measures.py`.
+- `full-workflow` runs `test_full_workflow.py` by itself so it does not inherit the connectathon-loaded CDR state.
 
 ---
 
@@ -188,12 +198,16 @@ Every PR to `main` triggers `.github/workflows/pr-checks.yml` with 4 jobs:
 |-----|-------------|----------|
 | **Unit Tests + Coverage** | Runs all unit tests with `--cov-fail-under=70` | Any test fails OR coverage < 70% |
 | **Lint** | `ruff check` + `ruff format --check` | Any lint or formatting violation |
-| **Integration Tests** | Spins up Docker containers, runs integration suite **minus** `test_connectathon_measures.py` and `test_full_workflow.py` (both run nightly). `STRICT_STU6=0` during rollout. | Any remaining integration test fails |
+| **Integration Tests** | Spins up Docker containers, runs integration smoke coverage while excluding `test_golden_measures.py`, `test_connectathon_measures.py`, and `test_full_workflow.py` (all moved out of the PR gate). `STRICT_STU6=0` during rollout. | Any remaining integration test fails |
 | **Frontend Build** | `npm ci && npm run build` | Build fails |
 
 All 4 jobs must pass before a PR can merge.
 
-The nightly `connectathon-measures.yml` workflow runs the excluded tests against the full connectathon bundle set. Trigger it manually from the Actions tab (`Run workflow`) before merging any change that touches the measure evaluation pipeline, FHIR data flow, or job orchestration.
+The nightly `connectathon-measures.yml` workflow adds a once-nightly source-of-truth run with clean runner isolation:
+- `source-of-truth` runs `test_golden_measures.py` and `test_connectathon_measures.py`.
+- `full-workflow` runs `test_full_workflow.py` in a separate clean runner.
+
+Trigger it manually from the Actions tab (`Run workflow`) before merging any change that touches the measure evaluation pipeline, FHIR data flow, or job orchestration.
 
 ---
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   ./scripts/run-integration-tests.sh
+#   ./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py
 #
 # This script:
 #   1. Starts docker-compose.test.yml in background
@@ -11,6 +12,12 @@
 #   3. Runs pytest -m integration
 #   4. Stops and removes test containers
 #   5. Exits with pytest's exit code
+#
+# Invocation modes:
+#   - No explicit test targets: run the default integration suite.
+#   - Explicit file/dir/nodeid targets: run only those targets.
+# This keeps option-only CI invocations (for example --ignore=...) on the
+# default suite while allowing nightly jobs to target isolated test files.
 
 set -euo pipefail
 
@@ -59,6 +66,18 @@ cleanup() {
 }
 
 trap cleanup EXIT
+
+has_explicit_pytest_target() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            *::*|*.py|tests/*|./tests/*|backend/tests/*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
 
 echo "==> Pulling HAPI FHIR image (avoids compose startup timeout on cold pull)..."
 docker pull hapiproject/hapi:v8.8.0-1
@@ -130,7 +149,13 @@ _phase_done "PostgreSQL ready"
 echo "==> Running integration tests..."
 cd "$PROJECT_ROOT/backend"
 pytest_exit=0
-python3 -m pytest tests/integration/ -m integration -v --tb=short "$@" || pytest_exit=$?
+pytest_args=(-m integration -v --tb=short)
+if has_explicit_pytest_target "$@"; then
+    pytest_args+=("$@")
+else
+    pytest_args+=(tests/integration/ "$@")
+fi
+python3 -m pytest "${pytest_args[@]}" || pytest_exit=$?
 
 echo ""
 if [ "$pytest_exit" -eq 0 ]; then


### PR DESCRIPTION
## What changed
- taught `scripts/run-integration-tests.sh` to honor explicit pytest targets while preserving option-only default-suite behavior
- split `connectathon-measures.yml` into two clean nightly jobs
  - `source-of-truth`: `test_golden_measures.py` + `test_connectathon_measures.py`
  - `full-workflow`: `test_full_workflow.py` in isolation
- removed `test_golden_measures.py`, `test_connectathon_measures.py`, and `test_full_workflow.py` from the PR-gate integration job
- updated `docs/testing.md` and `CLAUDE.md` to reflect the new nightly and PR-gate behavior

## Why
The nightly timeout was caused by two coupled issues:
- the integration wrapper always prepended `tests/integration/`, so explicit nightly targets still collected extra modules
- `test_full_workflow.py` shared runner state with the connectathon-loaded CDR and could end up processing the large manifest dataset instead of running in isolation

Keeping the source-of-truth suites on a once-nightly/manual cadence and isolating `test_full_workflow.py` removes that coupling without running the source-of-truth suite twice.

## Impact
- PR CI keeps the lighter integration smoke coverage
- source-of-truth measure validation stays out of the PR gate and runs once nightly
- `test_full_workflow.py` still runs nightly, but on a clean runner so it no longer inherits the connectathon dataset

## Validation
- `bash -n scripts/run-integration-tests.sh`
- YAML parse of `.github/workflows/connectathon-measures.yml`
- `./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py --collect-only` -> `4 tests collected`
- `./scripts/run-integration-tests.sh tests/integration/test_golden_measures.py tests/integration/test_connectathon_measures.py --collect-only` -> `571 tests collected`
- `./scripts/run-integration-tests.sh --ignore=tests/integration/test_golden_measures.py --ignore=tests/integration/test_connectathon_measures.py --ignore=tests/integration/test_full_workflow.py --collect-only` -> PR-gate collection limited to `test_fhir_operations.py` and `test_smart_load.py`
