### PR TITLE
[codex] Fix connectathon validation parity sweep

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -14,8 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import httpx
-from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import delete, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -349,7 +348,7 @@ async def triage_test_bundle(
     bundle_json: dict[str, Any],
     filename: str,
     session: AsyncSession,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Triage a test bundle: send resources to their correct destinations.
 
     - Measure/Library/ValueSet → measure engine
@@ -379,31 +378,43 @@ async def triage_test_bundle(
                 f"Details: {str(exc)}"
             ) from exc
 
-    # Upsert expected results atomically (avoids TOCTOU on concurrent uploads)
-    for tc in test_cases:
-        stmt = (
-            pg_insert(ExpectedResult)
-            .values(
-                measure_url=tc["measure_url"],
-                patient_ref=tc["patient_ref"],
-                test_description=tc["test_description"],
-                expected_populations=tc["expected_populations"],
-                period_start=tc["period_start"],
-                period_end=tc["period_end"],
-                source_bundle=filename,
-            )
-            .on_conflict_do_update(
-                constraint="uq_measure_patient",
-                set_={
-                    "test_description": tc["test_description"],
-                    "expected_populations": tc["expected_populations"],
-                    "period_start": tc["period_start"],
-                    "period_end": tc["period_end"],
-                    "source_bundle": filename,
-                },
-            )
+    # Fully replace expected results owned by this source bundle before loading the
+    # current bundle contents. This removes stale rows when a bundle shrinks or when
+    # MADiE changes the canonical URL for the same filename.
+    await session.execute(delete(ExpectedResult).where(ExpectedResult.source_bundle == filename))
+
+    existing_by_key: dict[tuple[str, str], ExpectedResult] = {}
+    if test_cases:
+        key_tuples = [(tc["measure_url"], tc["patient_ref"]) for tc in test_cases]
+        existing_result = await session.execute(
+            select(ExpectedResult).where(tuple_(ExpectedResult.measure_url, ExpectedResult.patient_ref).in_(key_tuples))
         )
-        await session.execute(stmt)
+        existing_by_key = {
+            (er.measure_url, er.patient_ref): er
+            for er in existing_result.scalars().all()
+        }
+
+    for tc in test_cases:
+        key = (tc["measure_url"], tc["patient_ref"])
+        existing = existing_by_key.get(key)
+        if existing:
+            existing.test_description = tc["test_description"]
+            existing.expected_populations = tc["expected_populations"]
+            existing.period_start = tc["period_start"]
+            existing.period_end = tc["period_end"]
+            existing.source_bundle = filename
+        else:
+            session.add(
+                ExpectedResult(
+                    measure_url=tc["measure_url"],
+                    patient_ref=tc["patient_ref"],
+                    test_description=tc["test_description"],
+                    expected_populations=tc["expected_populations"],
+                    period_start=tc["period_start"],
+                    period_end=tc["period_end"],
+                    source_bundle=filename,
+                )
+            )
     await session.commit()
 
     # Push clinical data to active CDR (default or external)
@@ -565,7 +576,7 @@ async def _reload_measures_from_seed_bundles() -> dict[str, int]:
                 primary = [r for r in measure_defs if r.get("resourceType") in ("Measure", "Library")]
                 secondary = [r for r in measure_defs if r.get("resourceType") not in ("Measure", "Library")]
                 if secondary:
-                    await push_resources(secondary)
+                    await push_resources(_fix_valueset_compose_for_hapi(secondary))
                 if primary:
                     await push_resources(primary)
                     for r in primary:
@@ -630,17 +641,23 @@ async def run_validation(validation_run_id: int) -> None:
         # Resolve measure IDs and get periods
         measure_info: dict[str, dict[str, str]] = {}
         missing_measures: list[str] = []
+        unresolved_errors: dict[str, str] = {}
+        all_results: list[ValidationResult] = []
 
         for measure_url, ers in measures.items():
-            hapi_id = await _resolve_measure_id(measure_url)
+            try:
+                hapi_id = await _resolve_measure_id(measure_url)
+            except Exception as exc:
+                unresolved_errors[measure_url] = f"Measure resolution failed: {sanitize_error(exc)}"
+                continue
             if not hapi_id:
                 missing_measures.append(measure_url)
-            else:
-                measure_info[measure_url] = {
-                    "hapi_id": hapi_id,
-                    "period_start": ers[0].period_start,
-                    "period_end": ers[0].period_end,
-                }
+                continue
+            measure_info[measure_url] = {
+                "hapi_id": hapi_id,
+                "period_start": ers[0].period_start,
+                "period_end": ers[0].period_end,
+            }
 
         # If measures are missing, try to reload from seed bundles (lazy loading)
         if missing_measures:
@@ -653,9 +670,15 @@ async def run_validation(validation_run_id: int) -> None:
                 logger.info("Seed bundle reload complete", extra=reload_result)
 
                 # Retry resolving measures after reload
-                still_missing: list[str] = []
                 for measure_url in missing_measures:
-                    hapi_id = await _resolve_measure_id(measure_url)
+                    try:
+                        hapi_id = await _resolve_measure_id(measure_url)
+                    except Exception as exc:
+                        unresolved_errors[measure_url] = (
+                            f"Measure resolution failed after reload attempt: {sanitize_error(exc)}"
+                        )
+                        continue
+
                     if hapi_id:
                         ers = measures[measure_url]
                         measure_info[measure_url] = {
@@ -664,127 +687,140 @@ async def run_validation(validation_run_id: int) -> None:
                             "period_end": ers[0].period_end,
                         }
                     else:
-                        still_missing.append(measure_url)
-
-                if still_missing:
-                    error_msg = (
-                        f"Measures not found on engine after reload attempt. "
-                        f"This may indicate the HAPI measure engine is unavailable or the seed bundles are missing. "
-                        f"Please ensure the backend is properly connected to the measure engine, "
-                        f"or manually upload test bundles using the Validation page. "
-                        f"Missing measures: {', '.join(still_missing[:3])}{'...' if len(still_missing) > 3 else ''}"
-                    )
-                    raise ValueError(error_msg)
-            except ValueError:
-                raise
+                        unresolved_errors[measure_url] = (
+                            "Measure not found on engine after reload attempt. "
+                            "Upload the current bundle or verify the measure engine seed state."
+                        )
             except Exception as exc:
-                error_msg = (
-                    f"Failed to reload measures from seed bundles: {str(exc)}. "
-                    f"Please manually upload test bundles using the Validation page."
+                reload_error = sanitize_error(exc)
+                logger.warning(
+                    "Seed bundle reload failed; unresolved measures will be reported per patient",
+                    extra={"run_id": validation_run_id, "error": reload_error},
                 )
-                raise ValueError(error_msg) from exc
+                for measure_url in missing_measures:
+                    unresolved_errors.setdefault(
+                        measure_url,
+                        f"Failed to reload measures from seed bundles: {reload_error}",
+                    )
+
+        for measure_url, error_message in unresolved_errors.items():
+            for er in measures[measure_url]:
+                all_results.append(
+                    ValidationResult(
+                        validation_run_id=validation_run_id,
+                        measure_url=er.measure_url,
+                        patient_ref=er.patient_ref,
+                        patient_name=None,
+                        expected_populations=er.expected_populations,
+                        actual_populations=None,
+                        status="error",
+                        error_message=error_message,
+                        mismatches=[],
+                    )
+                )
 
         # Resolve CDR connection
-        async with async_session() as session:
-            cdr_result = await session.execute(select(CDRConfig).where(CDRConfig.is_active.is_(True)).limit(1))
-            active_cdr = cdr_result.scalar_one_or_none()
-            if active_cdr:
-                cdr_url = active_cdr.cdr_url
-                auth_headers = await _build_auth_headers(active_cdr.auth_type, active_cdr.auth_credentials)
-            else:
-                cdr_url = settings.DEFAULT_CDR_URL
-                auth_headers = {}
-
-        # Wipe measure engine patient data for clean evaluation
-        await wipe_patient_data()
-
-        # Phase 1: Gather from CDR and push to measure engine
-        strategy = BatchQueryStrategy()
-        semaphore = asyncio.Semaphore(settings.MAX_WORKERS)
-
-        async def gather_and_push(patient_ref: str) -> None:
-            async with semaphore:
-                resources = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
-                if resources:
-                    await push_resources(resources)
-
-        all_patient_refs = [er.patient_ref for er in expected_results]
-        gather_results = await asyncio.gather(
-            *[gather_and_push(pr) for pr in all_patient_refs],
-            return_exceptions=True,
-        )
-        failed_gathers = sum(1 for r in gather_results if isinstance(r, BaseException))
-        if failed_gathers:
-            logger.warning(
-                "Patient data gather partial failure — validation may reflect incomplete data",
-                extra={"failed": failed_gathers, "total": len(all_patient_refs), "run_id": validation_run_id},
-            )
-
-        # Wait for HAPI indexing (configurable via HAPI_INDEX_WAIT_SECONDS env var)
-        await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
-
-        # Phase 2: Evaluate and compare (shared client avoids N connection pools)
+        resolved_expected_results = [er for er in expected_results if er.measure_url in measure_info]
         total_passed = 0
         total_failed = 0
         total_errors = 0
-        all_results: list[ValidationResult] = []
 
-        async def evaluate_and_compare(er: ExpectedResult, http_client: httpx.AsyncClient) -> ValidationResult:
-            info = measure_info[er.measure_url]
-            try:
-                report = await evaluate_measure(
-                    info["hapi_id"],
-                    er.patient_ref,
-                    info["period_start"],
-                    info["period_end"],
-                )
-                actual = _extract_population_counts(report)
+        if resolved_expected_results:
+            async with async_session() as session:
+                cdr_result = await session.execute(select(CDRConfig).where(CDRConfig.is_active.is_(True)).limit(1))
+                active_cdr = cdr_result.scalar_one_or_none()
+                if active_cdr:
+                    cdr_url = active_cdr.cdr_url
+                    auth_headers = await _build_auth_headers(active_cdr.auth_type, active_cdr.auth_credentials)
+                else:
+                    cdr_url = settings.DEFAULT_CDR_URL
+                    auth_headers = {}
 
-                # Try to get patient name from the report's evaluated resources
-                patient_name = None
-                for eval_ref in report.get("evaluatedResource", []):
-                    ref_str = eval_ref.get("reference", "")
-                    if ref_str.startswith("Patient/"):
-                        try:
-                            resp = await http_client.get(f"{settings.MEASURE_ENGINE_URL}/{ref_str}")
-                            if resp.status_code == 200:
-                                patient_name = _extract_patient_name(resp.json())
-                        except Exception:
-                            pass
-                        break
+            # Wipe measure engine patient data for clean evaluation
+            await wipe_patient_data()
 
-                passed, mismatches = compare_populations(er.expected_populations, actual)
-                return ValidationResult(
-                    validation_run_id=validation_run_id,
-                    measure_url=er.measure_url,
-                    patient_ref=er.patient_ref,
-                    patient_name=patient_name,
-                    expected_populations=er.expected_populations,
-                    actual_populations=actual,
-                    status="pass" if passed else "fail",
-                    mismatches=mismatches if mismatches else [],
-                )
-            except Exception as exc:
-                return ValidationResult(
-                    validation_run_id=validation_run_id,
-                    measure_url=er.measure_url,
-                    patient_ref=er.patient_ref,
-                    patient_name=None,
-                    expected_populations=er.expected_populations,
-                    actual_populations=None,
-                    status="error",
-                    error_message=sanitize_error(exc),
-                    mismatches=[],
-                )
+            # Phase 1: Gather from CDR and push to measure engine
+            strategy = BatchQueryStrategy()
+            semaphore = asyncio.Semaphore(settings.MAX_WORKERS)
 
-        async with httpx.AsyncClient(timeout=10.0) as http_client:
-
-            async def eval_with_semaphore(er: ExpectedResult) -> ValidationResult:
+            async def gather_and_push(patient_ref: str) -> None:
                 async with semaphore:
-                    return await evaluate_and_compare(er, http_client)
+                    resources = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
+                    if resources:
+                        await push_resources(resources)
 
-            result_coros = [eval_with_semaphore(er) for er in expected_results]
-            all_results = list(await asyncio.gather(*result_coros))
+            all_patient_refs = [er.patient_ref for er in resolved_expected_results]
+            gather_results = await asyncio.gather(
+                *[gather_and_push(pr) for pr in all_patient_refs],
+                return_exceptions=True,
+            )
+            failed_gathers = sum(1 for r in gather_results if isinstance(r, BaseException))
+            if failed_gathers:
+                logger.warning(
+                    "Patient data gather partial failure — validation may reflect incomplete data",
+                    extra={"failed": failed_gathers, "total": len(all_patient_refs), "run_id": validation_run_id},
+                )
+
+            # Wait for HAPI indexing (configurable via HAPI_INDEX_WAIT_SECONDS env var)
+            await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
+
+            # Phase 2: Evaluate and compare (shared client avoids N connection pools)
+            async def evaluate_and_compare(er: ExpectedResult, http_client: httpx.AsyncClient) -> ValidationResult:
+                info = measure_info[er.measure_url]
+                try:
+                    report = await evaluate_measure(
+                        info["hapi_id"],
+                        er.patient_ref,
+                        info["period_start"],
+                        info["period_end"],
+                    )
+                    actual = _extract_population_counts(report)
+
+                    # Try to get patient name from the report's evaluated resources
+                    patient_name = None
+                    for eval_ref in report.get("evaluatedResource", []):
+                        ref_str = eval_ref.get("reference", "")
+                        if ref_str.startswith("Patient/"):
+                            try:
+                                resp = await http_client.get(f"{settings.MEASURE_ENGINE_URL}/{ref_str}")
+                                if resp.status_code == 200:
+                                    patient_name = _extract_patient_name(resp.json())
+                            except Exception:
+                                pass
+                            break
+
+                    passed, mismatches = compare_populations(er.expected_populations, actual)
+                    return ValidationResult(
+                        validation_run_id=validation_run_id,
+                        measure_url=er.measure_url,
+                        patient_ref=er.patient_ref,
+                        patient_name=patient_name,
+                        expected_populations=er.expected_populations,
+                        actual_populations=actual,
+                        status="pass" if passed else "fail",
+                        mismatches=mismatches if mismatches else [],
+                    )
+                except Exception as exc:
+                    return ValidationResult(
+                        validation_run_id=validation_run_id,
+                        measure_url=er.measure_url,
+                        patient_ref=er.patient_ref,
+                        patient_name=None,
+                        expected_populations=er.expected_populations,
+                        actual_populations=None,
+                        status="error",
+                        error_message=sanitize_error(exc),
+                        mismatches=[],
+                    )
+
+            async with httpx.AsyncClient(timeout=10.0) as http_client:
+
+                async def eval_with_semaphore(er: ExpectedResult) -> ValidationResult:
+                    async with semaphore:
+                        return await evaluate_and_compare(er, http_client)
+
+                result_coros = [eval_with_semaphore(er) for er in resolved_expected_results]
+                all_results.extend(await asyncio.gather(*result_coros))
 
         for vr in all_results:
             if vr.status == "pass":

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -389,10 +389,7 @@ async def triage_test_bundle(
         existing_result = await session.execute(
             select(ExpectedResult).where(tuple_(ExpectedResult.measure_url, ExpectedResult.patient_ref).in_(key_tuples))
         )
-        existing_by_key = {
-            (er.measure_url, er.patient_ref): er
-            for er in existing_result.scalars().all()
-        }
+        existing_by_key = {(er.measure_url, er.patient_ref): er for er in existing_result.scalars().all()}
 
     for tc in test_cases:
         key = (tc["measure_url"], tc["patient_ref"])

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -657,12 +657,16 @@ class TestTriageTestBundle:
             await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         rows = (
-            await test_session.execute(
-                select(ExpectedResult)
-                .where(ExpectedResult.source_bundle == "test.json")
-                .order_by(ExpectedResult.patient_ref)
+            (
+                await test_session.execute(
+                    select(ExpectedResult)
+                    .where(ExpectedResult.source_bundle == "test.json")
+                    .order_by(ExpectedResult.patient_ref)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         assert len(rows) == 1
         assert rows[0].measure_url == "https://example.com/Measure/CMS124"
@@ -873,9 +877,7 @@ class TestRunValidation:
         await test_session.refresh(run)
 
         strategy = MagicMock()
-        strategy.gather_patient_data = AsyncMock(
-            return_value=[{"resourceType": "Patient", "id": "patient-1"}]
-        )
+        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
 
         def make_ctx():
             return self._make_session_ctx(test_session)
@@ -920,12 +922,16 @@ class TestRunValidation:
 
         await test_session.refresh(run)
         rows = (
-            await test_session.execute(
-                select(ValidationResult).where(ValidationResult.validation_run_id == run.id).order_by(
-                    ValidationResult.patient_ref
+            (
+                await test_session.execute(
+                    select(ValidationResult)
+                    .where(ValidationResult.validation_run_id == run.id)
+                    .order_by(ValidationResult.patient_ref)
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         assert run.status == ValidationStatus.complete
         assert run.measures_tested == 2

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -3,6 +3,9 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import func, select
+
+from app.models.validation import ExpectedResult, ValidationResult, ValidationRun, ValidationStatus
 
 from app.services.validation import (
     _classify_bundle_entries,
@@ -15,6 +18,7 @@ from app.services.validation import (
     _warn_unknown_bundle_types,
     compare_populations,
     process_bundle_upload,
+    run_validation,
     sanitize_error,
     triage_test_bundle,
 )
@@ -500,18 +504,6 @@ class TestTriageTestBundle:
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
             with patch("app.services.validation.settings") as mock_settings:
                 mock_settings.DEFAULT_CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
-                # session.execute needs to handle the pg_insert statement —
-                # mock it to avoid PostgreSQL dialect errors with SQLite.
-                orig_execute = test_session.execute
-
-                async def _execute_interceptor(stmt, *args, **kwargs):
-                    # Intercept pg_insert statements (they have on_conflict_do_update attr)
-                    if hasattr(stmt, "excluded"):
-                        return MagicMock()
-                    return await orig_execute(stmt, *args, **kwargs)
-
-                test_session.execute = _execute_interceptor
-
                 result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         # Measure + Library = 2 measure defs → push_resources called once for defs
@@ -539,15 +531,6 @@ class TestTriageTestBundle:
         await test_session.commit()
 
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
-            orig_execute = test_session.execute
-
-            async def _execute_interceptor(stmt, *args, **kwargs):
-                if hasattr(stmt, "excluded"):
-                    return MagicMock()
-                return await orig_execute(stmt, *args, **kwargs)
-
-            test_session.execute = _execute_interceptor
-
             result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         # clinical data IS pushed to the external CDR
@@ -585,15 +568,6 @@ class TestTriageTestBundle:
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
             with patch("app.services.validation.settings") as mock_settings:
                 mock_settings.DEFAULT_CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
-                orig_execute = test_session.execute
-
-                async def _execute_interceptor(stmt, *args, **kwargs):
-                    if hasattr(stmt, "excluded"):
-                        return MagicMock()
-                    return await orig_execute(stmt, *args, **kwargs)
-
-                test_session.execute = _execute_interceptor
-
                 result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         # clinical data pushed with auth headers
@@ -651,6 +625,76 @@ class TestTriageTestBundle:
         assert result["patients_loaded"] == 0
         # push_resources called exactly once for measure defs
         mock_push.assert_called_once()
+
+    async def test_reupload_same_source_bundle_replaces_stale_expected_results(
+        self, test_session, mock_test_bundle_with_expected
+    ):
+        """Refreshing a bundle drops stale rows previously owned by the same source_bundle."""
+        test_session.add_all(
+            [
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/old-canonical",
+                    patient_ref="legacy-patient",
+                    test_description="stale row",
+                    expected_populations={"numerator": 0},
+                    period_start="2025-01-01",
+                    period_end="2025-12-31",
+                    source_bundle="test.json",
+                ),
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/CMS124",
+                    patient_ref="extra-stale-patient",
+                    test_description="stale extra patient",
+                    expected_populations={"numerator": 0},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="test.json",
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock):
+            await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        rows = (
+            await test_session.execute(
+                select(ExpectedResult).where(ExpectedResult.source_bundle == "test.json").order_by(ExpectedResult.patient_ref)
+            )
+        ).scalars().all()
+
+        assert len(rows) == 1
+        assert rows[0].measure_url == "https://example.com/Measure/CMS124"
+        assert rows[0].patient_ref == "test-patient-1"
+
+    async def test_reupload_same_source_bundle_updates_count_to_current_bundle(
+        self, test_session, mock_test_bundle_with_expected
+    ):
+        """Bundle refresh removes count drift when the new bundle has fewer patients."""
+        stale_rows = [
+            ExpectedResult(
+                measure_url="https://example.com/Measure/CMS124",
+                patient_ref=f"stale-{idx}",
+                test_description="stale",
+                expected_populations={"numerator": 0},
+                period_start="2026-01-01",
+                period_end="2026-12-31",
+                source_bundle="test.json",
+            )
+            for idx in range(3)
+        ]
+        test_session.add_all(stale_rows)
+        await test_session.commit()
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock):
+            result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        refreshed_count = await test_session.scalar(
+            select(func.count()).select_from(ExpectedResult).where(ExpectedResult.source_bundle == "test.json")
+        )
+
+        assert result["expected_results_loaded"] == 1
+        assert refreshed_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -784,6 +828,115 @@ class TestProcessBundleUpload:
             assert upload.warning_message == "Clinical test data was not loaded because the active CDR is read-only."
         finally:
             os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# run_validation (async, mocked async_session + FHIR services)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRunValidation:
+    def _make_session_ctx(self, session):
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    async def test_missing_measure_creates_error_results_and_resolved_measure_still_runs(self, test_session):
+        run = ValidationRun(status=ValidationStatus.queued)
+        test_session.add(run)
+        test_session.add_all(
+            [
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/resolved",
+                    patient_ref="patient-1",
+                    test_description="resolved",
+                    expected_populations={"numerator": 1},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="resolved.json",
+                ),
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/missing",
+                    patient_ref="patient-2",
+                    test_description="missing",
+                    expected_populations={"numerator": 0},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="missing.json",
+                ),
+            ]
+        )
+        await test_session.commit()
+        await test_session.refresh(run)
+
+        strategy = MagicMock()
+        strategy.gather_patient_data = AsyncMock(
+            return_value=[{"resourceType": "Patient", "id": "patient-1"}]
+        )
+
+        def make_ctx():
+            return self._make_session_ctx(test_session)
+
+        async def resolve_measure_side_effect(measure_url):
+            if measure_url.endswith("/resolved"):
+                return "measure-1"
+            return None
+
+        with patch("app.services.validation.async_session", side_effect=lambda: make_ctx()):
+            with patch("app.services.validation._resolve_measure_id", side_effect=resolve_measure_side_effect):
+                with patch(
+                    "app.services.validation._reload_measures_from_seed_bundles",
+                    new_callable=AsyncMock,
+                    return_value={"measures_loaded": 0, "libraries_loaded": 0, "failed": 0},
+                ):
+                    with patch("app.services.validation.BatchQueryStrategy", return_value=strategy):
+                        with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
+                            with patch("app.services.validation.wipe_patient_data", new_callable=AsyncMock) as mock_wipe:
+                                with patch(
+                                    "app.services.validation.evaluate_measure",
+                                    new_callable=AsyncMock,
+                                    return_value={
+                                        "group": [
+                                            {
+                                                "population": [
+                                                    {
+                                                        "code": {"coding": [{"code": "numerator"}]},
+                                                        "count": 1,
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "evaluatedResource": [],
+                                    },
+                                ) as mock_evaluate:
+                                    with patch("app.services.validation.settings.HAPI_INDEX_WAIT_SECONDS", 0):
+                                        await run_validation(run.id)
+
+        await test_session.refresh(run)
+        rows = (
+            await test_session.execute(
+                select(ValidationResult).where(ValidationResult.validation_run_id == run.id).order_by(
+                    ValidationResult.patient_ref
+                )
+            )
+        ).scalars().all()
+
+        assert run.status == ValidationStatus.complete
+        assert run.measures_tested == 2
+        assert run.patients_tested == 2
+        assert run.patients_passed == 1
+        assert run.patients_failed == 1
+        assert len(rows) == 2
+        assert rows[0].patient_ref == "patient-1"
+        assert rows[0].status == "pass"
+        assert rows[1].patient_ref == "patient-2"
+        assert rows[1].status == "error"
+        assert "Measure not found on engine after reload attempt" in rows[1].error_message
+        mock_wipe.assert_awaited_once()
+        mock_push.assert_awaited_once()
+        mock_evaluate.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -6,7 +6,6 @@ import pytest
 from sqlalchemy import func, select
 
 from app.models.validation import ExpectedResult, ValidationResult, ValidationRun, ValidationStatus
-
 from app.services.validation import (
     _classify_bundle_entries,
     _extract_patient_name,
@@ -659,7 +658,9 @@ class TestTriageTestBundle:
 
         rows = (
             await test_session.execute(
-                select(ExpectedResult).where(ExpectedResult.source_bundle == "test.json").order_by(ExpectedResult.patient_ref)
+                select(ExpectedResult)
+                .where(ExpectedResult.source_bundle == "test.json")
+                .order_by(ExpectedResult.patient_ref)
             )
         ).scalars().all()
 
@@ -893,7 +894,10 @@ class TestRunValidation:
                 ):
                     with patch("app.services.validation.BatchQueryStrategy", return_value=strategy):
                         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
-                            with patch("app.services.validation.wipe_patient_data", new_callable=AsyncMock) as mock_wipe:
+                            with patch(
+                                "app.services.validation.wipe_patient_data",
+                                new_callable=AsyncMock,
+                            ) as mock_wipe:
                                 with patch(
                                     "app.services.validation.evaluate_measure",
                                     new_callable=AsyncMock,

--- a/scripts/compare_connectathon_local_vs_prod.py
+++ b/scripts/compare_connectathon_local_vs_prod.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Compare connectathon validation results between local and production MCT2 APIs.
+
+For each manifest measure, this script:
+  1. Uploads the current bundle to both environments.
+  2. Waits for bundle processing to finish.
+  3. Starts a measure-filtered validation run in both environments.
+  4. Polls each run to completion.
+  5. Writes per-measure JSON + Markdown diff artifacts plus an overall summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "seed" / "connectathon-bundles" / "manifest.json"
+
+
+def _normalize_base_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _http_json(
+    method: str,
+    url: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> Any:
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code} {body[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc.reason}") from exc
+
+
+def _multipart_body(field_name: str, filename: str, content: bytes) -> tuple[bytes, str]:
+    boundary = f"codex-{uuid.uuid4().hex}"
+    parts = [
+        f"--{boundary}\r\n".encode("utf-8"),
+        (
+            f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+            "Content-Type: application/json\r\n\r\n"
+        ).encode("utf-8"),
+        content,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode("utf-8"),
+    ]
+    return b"".join(parts), boundary
+
+
+def upload_bundle(api_base: str, bundle_path: Path) -> int:
+    content = bundle_path.read_bytes()
+    body, boundary = _multipart_body("file", bundle_path.name, content)
+    response = _http_json(
+        "POST",
+        f"{api_base}/validation/upload-bundle",
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    return int(response["id"])
+
+
+def wait_for_upload(api_base: str, upload_id: int, timeout_seconds: int, poll_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        response = _http_json("GET", f"{api_base}/validation/uploads")
+        for upload in response.get("uploads", []):
+            if upload.get("id") != upload_id:
+                continue
+            status = upload.get("status")
+            if status in {"complete", "failed"}:
+                return upload
+            break
+        time.sleep(poll_seconds)
+    raise TimeoutError(f"Upload {upload_id} did not finish within {timeout_seconds}s on {api_base}")
+
+
+def start_validation_run(api_base: str, measure_url: str) -> int:
+    response = _http_json("POST", f"{api_base}/validation/run", json_body={"measure_urls": [measure_url]})
+    return int(response["id"])
+
+
+def wait_for_run(api_base: str, run_id: int, timeout_seconds: int, poll_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        run = _http_json("GET", f"{api_base}/validation/runs/{run_id}")
+        if run.get("status") in {"complete", "failed"}:
+            return run
+        time.sleep(poll_seconds)
+    raise TimeoutError(f"Validation run {run_id} did not finish within {timeout_seconds}s on {api_base}")
+
+
+def normalize_run(run: dict[str, Any], measure_url: str) -> dict[str, Any]:
+    measure_block = next((m for m in run.get("measures", []) if m.get("measure_url") == measure_url), None)
+    patients = {}
+    if measure_block:
+        for patient in measure_block.get("patients", []):
+            patient_ref = patient.get("patient_ref", "")
+            patients[patient_ref] = {
+                "patient_name": patient.get("patient_name"),
+                "status": patient.get("status"),
+                "expected_populations": patient.get("expected_populations"),
+                "actual_populations": patient.get("actual_populations"),
+                "mismatches": patient.get("mismatches") or [],
+                "error_message": patient.get("error_message"),
+            }
+
+    return {
+        "status": run.get("status"),
+        "error_message": run.get("error_message"),
+        "measures_tested": run.get("measures_tested"),
+        "patients_tested": run.get("patients_tested"),
+        "patients_passed": run.get("patients_passed"),
+        "patients_failed": run.get("patients_failed"),
+        "measure": {
+            "measure_url": measure_url,
+            "passed": measure_block.get("passed", 0) if measure_block else 0,
+            "failed": measure_block.get("failed", 0) if measure_block else 0,
+            "errors": measure_block.get("errors", 0) if measure_block else 0,
+            "patients": patients,
+        },
+    }
+
+
+def compare_normalized_runs(local_run: dict[str, Any], prod_run: dict[str, Any]) -> dict[str, Any]:
+    local_patients = local_run["measure"]["patients"]
+    prod_patients = prod_run["measure"]["patients"]
+    patient_refs = sorted(set(local_patients) | set(prod_patients))
+
+    patient_diffs = []
+    for patient_ref in patient_refs:
+        local_patient = local_patients.get(patient_ref)
+        prod_patient = prod_patients.get(patient_ref)
+        if local_patient == prod_patient:
+            continue
+        patient_diffs.append(
+            {
+                "patient_ref": patient_ref,
+                "local": local_patient,
+                "production": prod_patient,
+            }
+        )
+
+    summary = {
+        "local_status": local_run["status"],
+        "production_status": prod_run["status"],
+        "local_error_message": local_run["error_message"],
+        "production_error_message": prod_run["error_message"],
+        "local_counts": {
+            "patients_tested": local_run["patients_tested"],
+            "patients_passed": local_run["patients_passed"],
+            "patients_failed": local_run["patients_failed"],
+        },
+        "production_counts": {
+            "patients_tested": prod_run["patients_tested"],
+            "patients_passed": prod_run["patients_passed"],
+            "patients_failed": prod_run["patients_failed"],
+        },
+        "patient_diff_count": len(patient_diffs),
+        "matches": len(patient_diffs) == 0 and local_run["status"] == prod_run["status"],
+        "patient_diffs": patient_diffs,
+    }
+    return summary
+
+
+def markdown_for_measure(measure_id: str, measure_url: str, comparison: dict[str, Any]) -> str:
+    lines = [
+        f"# {measure_id}",
+        "",
+        f"- Measure URL: `{measure_url}`",
+        f"- Local run status: `{comparison['local_status']}`",
+        f"- Production run status: `{comparison['production_status']}`",
+        f"- Patient diffs: `{comparison['patient_diff_count']}`",
+        "",
+        "## Counts",
+        "",
+        "| Environment | Tested | Passed | Failed |",
+        "|---|---:|---:|---:|",
+        (
+            f"| Local | {comparison['local_counts']['patients_tested']} | "
+            f"{comparison['local_counts']['patients_passed']} | {comparison['local_counts']['patients_failed']} |"
+        ),
+        (
+            f"| Production | {comparison['production_counts']['patients_tested']} | "
+            f"{comparison['production_counts']['patients_passed']} | "
+            f"{comparison['production_counts']['patients_failed']} |"
+        ),
+        "",
+    ]
+
+    if comparison["local_error_message"] or comparison["production_error_message"]:
+        lines.extend(
+            [
+                "## Run Errors",
+                "",
+                f"- Local: {comparison['local_error_message'] or 'none'}",
+                f"- Production: {comparison['production_error_message'] or 'none'}",
+                "",
+            ]
+        )
+
+    if comparison["patient_diffs"]:
+        lines.extend(["## Patient Diffs", ""])
+        for diff in comparison["patient_diffs"]:
+            lines.append(f"### `{diff['patient_ref']}`")
+            lines.append("")
+            lines.append(f"- Local: `{json.dumps(diff['local'], sort_keys=True)}`")
+            lines.append(f"- Production: `{json.dumps(diff['production'], sort_keys=True)}`")
+            lines.append("")
+    else:
+        lines.extend(["## Patient Diffs", "", "No patient-level differences detected.", ""])
+
+    return "\n".join(lines)
+
+
+def summary_markdown(results: list[dict[str, Any]]) -> str:
+    lines = [
+        "# Connectathon Local vs Production Summary",
+        "",
+        "| Measure | Match | Local | Production | Patient diffs |",
+        "|---|---|---|---|---:|",
+    ]
+    for result in results:
+        comparison = result["comparison"]
+        lines.append(
+            f"| {result['measure_id']} | "
+            f"{'yes' if comparison['matches'] else 'no'} | "
+            f"{comparison['local_status']} | "
+            f"{comparison['production_status']} | "
+            f"{comparison['patient_diff_count']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--local-api-base",
+        default="http://localhost:8000",
+        help="Local MCT2 API base URL (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--production-api-base",
+        default="https://api.98-89-219-217.nip.io",
+        help="Production MCT2 API base URL",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(MANIFEST_PATH),
+        help="Path to manifest.json",
+    )
+    parser.add_argument(
+        "--measure-id",
+        help="Optional single measure id to run",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(REPO_ROOT / "artifacts" / "connectathon-local-vs-prod"),
+        help="Directory for JSON/Markdown output",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=1800,
+        help="Per-upload and per-run timeout",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=5,
+        help="Polling interval",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = Path(args.manifest)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    measures = manifest.get("measures", [])
+    if args.measure_id:
+        measures = [m for m in measures if m.get("id") == args.measure_id]
+        if not measures:
+            raise SystemExit(f"Measure id not found in manifest: {args.measure_id}")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    local_api = _normalize_base_url(args.local_api_base)
+    prod_api = _normalize_base_url(args.production_api_base)
+
+    results = []
+    for measure in measures:
+        measure_id = measure["id"]
+        measure_url = measure["canonical_url"]
+        bundle_path = manifest_path.parent / measure["bundle_file"]
+
+        print(f"[measure] {measure_id}", flush=True)
+
+        local_upload_id = upload_bundle(local_api, bundle_path)
+        prod_upload_id = upload_bundle(prod_api, bundle_path)
+
+        local_upload = wait_for_upload(local_api, local_upload_id, args.timeout_seconds, args.poll_seconds)
+        prod_upload = wait_for_upload(prod_api, prod_upload_id, args.timeout_seconds, args.poll_seconds)
+
+        local_run_id = start_validation_run(local_api, measure_url)
+        prod_run_id = start_validation_run(prod_api, measure_url)
+
+        local_run = wait_for_run(local_api, local_run_id, args.timeout_seconds, args.poll_seconds)
+        prod_run = wait_for_run(prod_api, prod_run_id, args.timeout_seconds, args.poll_seconds)
+
+        normalized_local = normalize_run(local_run, measure_url)
+        normalized_prod = normalize_run(prod_run, measure_url)
+        comparison = compare_normalized_runs(normalized_local, normalized_prod)
+
+        measure_payload = {
+            "measure_id": measure_id,
+            "measure_url": measure_url,
+            "bundle_file": measure["bundle_file"],
+            "local_upload": local_upload,
+            "production_upload": prod_upload,
+            "local_run": normalized_local,
+            "production_run": normalized_prod,
+            "comparison": comparison,
+        }
+        results.append(measure_payload)
+
+        json_path = output_dir / f"{measure_id}.json"
+        md_path = output_dir / f"{measure_id}.md"
+        json_path.write_text(json.dumps(measure_payload, indent=2, sort_keys=True), encoding="utf-8")
+        md_path.write_text(markdown_for_measure(measure_id, measure_url, comparison), encoding="utf-8")
+
+    summary_payload = {"generated_at_epoch": int(time.time()), "results": results}
+    (output_dir / "summary.json").write_text(json.dumps(summary_payload, indent=2, sort_keys=True), encoding="utf-8")
+    (output_dir / "summary.md").write_text(summary_markdown(results), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        raise SystemExit(130)


### PR DESCRIPTION
## What changed
- replace validation expected results by `source_bundle` instead of accumulating stale rows across bundle refreshes
- keep validation runs going when one measure canonical cannot be resolved by emitting scoped per-patient `error` results instead of aborting the whole run
- add a local-vs-production connectathon comparison script that refreshes each bundle, runs filtered validation on both environments, and writes JSON/Markdown diffs
- apply the existing ValueSet compose patch during seed-measure reloads so lazy reload follows the same HAPI compatibility path as normal bundle ingest

## Why
Production parity checks showed stale validation state was contaminating comparisons. A CMS816 canary upload loaded 9 expected results, but production still executed 28 patients for that canonical because older rows were never removed. The previous validation flow could also fail the entire run before any patient work if one measure URL no longer resolved on the engine.

## Impact
- re-uploading a connectathon bundle now fully refreshes that bundle's validation corpus
- production/local parity runs are stable enough to compare one measure at a time without one bad canonical killing the whole run
- operators have a repeatable script for parity sweeps and diff artifacts before merging/deploying

## Validation
- `python3 -m pytest backend/tests/test_services_validation.py backend/tests/test_routes_validation.py backend/tests/test_routes_measures.py -q`
- `python3 -m py_compile scripts/compare_connectathon_local_vs_prod.py`
- canary parity run: `CMS816FHIRHHHypo`
  - local completed with 9 patients
  - production completed with 28 patients, confirming stale prod validation state that this PR fixes on deploy
