### PR TITLE
[codex] Add UI-backed deletion flows

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,6 +76,10 @@ async def _run_schema_migrations(conn) -> None:
 
         # AuthType enum: add 'smart' value if not present
         await conn.execute(text("ALTER TYPE authtype ADD VALUE IF NOT EXISTS 'smart'"))
+        result = await conn.execute(text("SELECT to_regtype('validationstatus')"))
+        validationstatus_exists = result.scalar() is not None
+        if validationstatus_exists:
+            await conn.execute(text("ALTER TYPE validationstatus ADD VALUE IF NOT EXISTS 'cancelled'"))
 
         # Add new columns to cdr_configs (idempotent)
         for stmt in [
@@ -94,6 +98,8 @@ async def _run_schema_migrations(conn) -> None:
             "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS cdr_read_only BOOLEAN NOT NULL DEFAULT FALSE",
             "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS cdr_auth_type VARCHAR(32)",
             "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS cdr_auth_credentials JSONB",
+            "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS delete_requested BOOLEAN NOT NULL DEFAULT FALSE",
+            "ALTER TABLE validation_runs ADD COLUMN IF NOT EXISTS delete_requested BOOLEAN NOT NULL DEFAULT FALSE",
         ]:
             await conn.execute(text(stmt))
 

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -49,6 +49,7 @@ class Job(Base):
     total_patients: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     processed_patients: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     failed_patients: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    delete_requested: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)

--- a/backend/app/models/validation.py
+++ b/backend/app/models/validation.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from sqlalchemy import (
     JSON,
+    Boolean,
     DateTime,
     Enum,
     ForeignKey,
@@ -23,6 +24,7 @@ from app.models.base import Base
 class ValidationStatus(str, enum.Enum):
     queued = "queued"
     running = "running"
+    cancelled = "cancelled"
     complete = "complete"
     failed = "failed"
 
@@ -72,6 +74,7 @@ class ValidationRun(Base):
     patients_tested: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     patients_passed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     patients_failed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    delete_requested: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -62,6 +63,7 @@ class JobResponse(BaseModel):
     total_patients: int
     processed_patients: int
     failed_patients: int
+    delete_requested: bool
     created_at: str
     completed_at: Optional[str]
     error_message: Optional[str]
@@ -106,6 +108,7 @@ def _job_to_response(job: Job) -> dict:
         "total_patients": job.total_patients,
         "processed_patients": job.processed_patients,
         "failed_patients": job.failed_patients,
+        "delete_requested": job.delete_requested,
         "created_at": job.created_at.isoformat() if job.created_at else None,
         "completed_at": job.completed_at.isoformat() if job.completed_at else None,
         "error_message": job.error_message,
@@ -269,6 +272,54 @@ async def cancel_job(
 
     logger.info("Job cancelled", extra={"job_id": job_id})
     return _job_to_response(job)
+
+
+@router.delete("/{job_id}")
+async def delete_job(
+    job_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    """Delete a job and its dependent batches/results."""
+    job = await session.get(Job, job_id)
+    if not job:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    {
+                        "severity": "error",
+                        "code": "not-found",
+                        "diagnostics": f"Job {job_id} not found",
+                    }
+                ],
+            },
+        )
+
+    if job.status == JobStatus.running:
+        job.delete_requested = True
+        await session.commit()
+        logger.info("Job delete requested", extra={"job_id": job_id})
+        return JSONResponse(
+            status_code=202,
+            content={"id": job_id, "status": "delete_requested", "delete_requested": True},
+        )
+
+    if job.status == JobStatus.queued:
+        job.status = JobStatus.cancelled
+        job.delete_requested = True
+        job.completed_at = datetime.now(timezone.utc)
+        await session.commit()
+        logger.info("Queued job delete requested", extra={"job_id": job_id})
+        return JSONResponse(
+            status_code=202,
+            content={"id": job_id, "status": "delete_requested", "delete_requested": True},
+        )
+
+    await session.delete(job)
+    await session.commit()
+    logger.info("Job deleted", extra={"job_id": job_id})
+    return Response(status_code=204)
 
 
 @router.get("/{job_id}/comparison")

--- a/backend/app/routes/measures.py
+++ b/backend/app/routes/measures.py
@@ -3,11 +3,12 @@
 import json
 import logging
 
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+import httpx
+from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile
 
 from app.config import MAX_UPLOAD_SIZE
 from app.limiter import limiter
-from app.services.fhir_client import list_measures, upload_measure_bundle
+from app.services.fhir_client import delete_measure, list_measures, upload_measure_bundle
 from app.services.validation import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -149,3 +150,57 @@ async def upload_measure(request: Request, file: UploadFile = File(...)) -> dict
                 ],
             },
         )
+
+
+@router.delete("/{measure_id}", status_code=204)
+async def delete_measure_route(measure_id: str) -> Response:
+    """Delete a Measure resource from the measure engine."""
+    try:
+        await delete_measure(measure_id)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "resourceType": "OperationOutcome",
+                    "issue": [
+                        {
+                            "severity": "error",
+                            "code": "not-found",
+                            "diagnostics": f"Measure {measure_id} not found",
+                        }
+                    ],
+                },
+            ) from exc
+        logger.exception("Measure engine rejected measure delete", extra={"measure_id": measure_id})
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    {
+                        "severity": "error",
+                        "code": "exception",
+                        "diagnostics": f"Measure engine rejected delete: {sanitize_error(exc)}",
+                    }
+                ],
+            },
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to delete measure", extra={"measure_id": measure_id})
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    {
+                        "severity": "error",
+                        "code": "exception",
+                        "diagnostics": f"Cannot reach measure engine: {sanitize_error(exc)}",
+                    }
+                ],
+            },
+        ) from exc
+
+    logger.info("Measure deleted", extra={"measure_id": measure_id})
+    return Response(status_code=204)

--- a/backend/app/routes/validation.py
+++ b/backend/app/routes/validation.py
@@ -7,9 +7,11 @@ import os
 import re
 import time
 import uuid
+from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -223,6 +225,7 @@ async def list_validation_runs(session: AsyncSession = Depends(get_session)) -> 
                 "patients_tested": r.patients_tested,
                 "patients_passed": r.patients_passed,
                 "patients_failed": r.patients_failed,
+                "delete_requested": r.delete_requested,
                 "error_message": r.error_message,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
                 "completed_at": r.completed_at.isoformat() if r.completed_at else None,
@@ -295,8 +298,45 @@ async def get_validation_run(
         "patients_tested": run.patients_tested,
         "patients_passed": run.patients_passed,
         "patients_failed": run.patients_failed,
+        "delete_requested": run.delete_requested,
         "error_message": run.error_message,
         "created_at": run.created_at.isoformat() if run.created_at else None,
         "completed_at": run.completed_at.isoformat() if run.completed_at else None,
         "measures": list(measures.values()),
     }
+
+
+@router.delete("/runs/{run_id}")
+async def delete_validation_run(
+    run_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    """Delete a validation run and its stored results."""
+    run = await session.get(ValidationRun, run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Validation run not found")
+
+    if run.status == ValidationStatus.running:
+        run.delete_requested = True
+        await session.commit()
+        logger.info("Validation run delete requested", extra={"run_id": run_id})
+        return JSONResponse(
+            status_code=202,
+            content={"id": run_id, "status": "delete_requested", "delete_requested": True},
+        )
+
+    if run.status == ValidationStatus.queued:
+        run.status = ValidationStatus.cancelled
+        run.delete_requested = True
+        run.completed_at = run.completed_at or datetime.now(timezone.utc)
+        await session.commit()
+        logger.info("Queued validation run delete requested", extra={"run_id": run_id})
+        return JSONResponse(
+            status_code=202,
+            content={"id": run_id, "status": "delete_requested", "delete_requested": True},
+        )
+
+    await session.delete(run)
+    await session.commit()
+    logger.info("Validation run deleted", extra={"run_id": run_id})
+    return Response(status_code=204)

--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -458,6 +458,14 @@ async def upload_measure_bundle(bundle_json: dict[str, Any]) -> dict[str, Any]:
         return resp.json()
 
 
+async def delete_measure(measure_id: str) -> None:
+    """Delete a Measure resource from the measure engine."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.delete(f"{settings.MEASURE_ENGINE_URL}/Measure/{measure_id}")
+        if resp.status_code not in (200, 202, 204):
+            resp.raise_for_status()
+
+
 async def wipe_patient_data() -> None:
     """Delete patient-related data from the measure engine.
 

--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -67,12 +67,30 @@ def _extract_patient_name(patient_resource: dict[str, Any]) -> Optional[str]:
     return None
 
 
+async def _stop_or_delete_job(job_id: int) -> bool:
+    """Return True when work should stop because the job was cancelled or deleted."""
+    async with async_session() as session:
+        job = await session.get(Job, job_id)
+        if not job:
+            return True
+        if job.delete_requested:
+            await session.delete(job)
+            await session.commit()
+            return True
+        return job.status == JobStatus.cancelled
+
+
 async def run_job(job_id: int) -> None:
     """Execute the full $gather workflow for a job."""
     async with async_session() as session:
         job = await session.get(Job, job_id)
         if not job:
             logger.error("Job not found", extra={"job_id": job_id})
+            return
+        if job.delete_requested:
+            await session.delete(job)
+            await session.commit()
+            logger.info("Job deleted before start", extra={"job_id": job_id})
             return
         if job.status == JobStatus.cancelled:
             logger.info("Job already cancelled", extra={"job_id": job_id})
@@ -85,10 +103,14 @@ async def run_job(job_id: int) -> None:
         # Step 1: Wipe patient data from measure engine (cleanup from prior job)
         logger.info("Wiping prior patient data from measure engine", extra={"job_id": job_id})
         await wipe_patient_data()
+        if await _stop_or_delete_job(job_id):
+            return
 
         # Step 2: Resolve CDR connection settings
         auth_headers = await _get_cdr_auth_headers(job_id)
         cdr_url = await _get_cdr_url(job_id)
+        if await _stop_or_delete_job(job_id):
+            return
 
         # Step 3: Fetch patients from CDR (optionally filtered by Group)
         async with async_session() as session:
@@ -104,6 +126,8 @@ async def run_job(job_id: int) -> None:
             patients = await strategy.gather_patients(cdr_url, auth_headers)
 
         if not patients:
+            if await _stop_or_delete_job(job_id):
+                return
             async with async_session() as session:
                 job = await session.get(Job, job_id)
                 if job:
@@ -119,6 +143,8 @@ async def run_job(job_id: int) -> None:
         patient_ids = list(patient_map.keys())
         batch_size = settings.BATCH_SIZE
 
+        if await _stop_or_delete_job(job_id):
+            return
         async with async_session() as session:
             job = await session.get(Job, job_id)
             if not job:
@@ -152,14 +178,14 @@ async def run_job(job_id: int) -> None:
                 )
 
         # Check for cancellation before starting
-        async with async_session() as session:
-            job = await session.get(Job, job_id)
-            if job and job.status == JobStatus.cancelled:
-                return
+        if await _stop_or_delete_job(job_id):
+            return
 
         await asyncio.gather(*[process_batch(bid) for bid in batch_ids])
 
         # Step 6: Finalize job
+        if await _stop_or_delete_job(job_id):
+            return
         async with async_session() as session:
             job = await session.get(Job, job_id)
             if not job:
@@ -174,6 +200,8 @@ async def run_job(job_id: int) -> None:
 
     except Exception as exc:
         logger.exception("Job failed", extra={"job_id": job_id})
+        if await _stop_or_delete_job(job_id):
+            return
         async with async_session() as session:
             job = await session.get(Job, job_id)
             if job:
@@ -236,6 +264,8 @@ async def _process_single_batch(
         try:
             processed = 0
             failed = 0
+            if await _stop_or_delete_job(job_id):
+                return
 
             # Read job params once
             async with async_session() as session:
@@ -252,10 +282,8 @@ async def _process_single_batch(
             # Phase 1: Gather all patient data and push to measure engine
             # ----------------------------------------------------------
             for patient_id in patient_ids:
-                async with async_session() as session:
-                    job = await session.get(Job, job_id)
-                    if job and job.status == JobStatus.cancelled:
-                        return
+                if await _stop_or_delete_job(job_id):
+                    return
 
                 try:
                     resources = await strategy.gather_patient_data(cdr_url, patient_id, auth_headers)
@@ -284,15 +312,15 @@ async def _process_single_batch(
                 extra={"job_id": job_id, "batch_id": batch_id},
             )
             await asyncio.sleep(5.0)
+            if await _stop_or_delete_job(job_id):
+                return
 
             # ----------------------------------------------------------
             # Phase 2: Evaluate each patient
             # ----------------------------------------------------------
             for patient_id in patient_ids:
-                async with async_session() as session:
-                    job = await session.get(Job, job_id)
-                    if job and job.status == JobStatus.cancelled:
-                        return
+                if await _stop_or_delete_job(job_id):
+                    return
 
                 try:
                     measure_report = await evaluate_measure(measure_id, patient_id, period_start, period_end)
@@ -300,6 +328,8 @@ async def _process_single_batch(
                     populations = _extract_populations(measure_report)
                     patient_name = _extract_patient_name(patient_map.get(patient_id, {}))
 
+                    if await _stop_or_delete_job(job_id):
+                        return
                     async with async_session() as session:
                         result = MeasureResult(
                             job_id=job_id,
@@ -326,6 +356,8 @@ async def _process_single_batch(
                     failed += 1
 
             # Update batch and job counters
+            if await _stop_or_delete_job(job_id):
+                return
             async with async_session() as session:
                 batch = await session.get(Batch, batch_id)
                 if batch:

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -126,6 +126,19 @@ def compare_populations(expected: dict[str, int], actual: dict[str, int]) -> tup
     return (len(mismatches) == 0, mismatches)
 
 
+async def _stop_or_delete_validation_run(validation_run_id: int) -> bool:
+    """Return True when validation work should stop because the run was cancelled or deleted."""
+    async with async_session() as session:
+        run = await session.get(ValidationRun, validation_run_id)
+        if not run:
+            return True
+        if run.delete_requested:
+            await session.delete(run)
+            await session.commit()
+            return True
+        return run.status == ValidationStatus.cancelled
+
+
 # ---------------------------------------------------------------------------
 # Test bundle parsing and expected result extraction
 # ---------------------------------------------------------------------------
@@ -596,10 +609,20 @@ async def run_validation(validation_run_id: int) -> None:
         if not run:
             logger.error("ValidationRun not found", extra={"run_id": validation_run_id})
             return
+        if run.delete_requested:
+            await session.delete(run)
+            await session.commit()
+            logger.info("Validation run deleted before start", extra={"run_id": validation_run_id})
+            return
+        if run.status == ValidationStatus.cancelled:
+            logger.info("Validation run already cancelled", extra={"run_id": validation_run_id})
+            return
         run.status = ValidationStatus.running
         await session.commit()
 
     try:
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
         # Load expected results
         async with async_session() as session:
             run = await session.get(ValidationRun, validation_run_id)
@@ -613,6 +636,8 @@ async def run_validation(validation_run_id: int) -> None:
             expected_results = list(result.scalars().all())
 
         if not expected_results:
+            if await _stop_or_delete_validation_run(validation_run_id):
+                return
             async with async_session() as session:
                 run = await session.get(ValidationRun, validation_run_id)
                 if run:
@@ -641,6 +666,8 @@ async def run_validation(validation_run_id: int) -> None:
                     "period_start": ers[0].period_start,
                     "period_end": ers[0].period_end,
                 }
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
 
         # If measures are missing, try to reload from seed bundles (lazy loading)
         if missing_measures:
@@ -695,8 +722,12 @@ async def run_validation(validation_run_id: int) -> None:
                 cdr_url = settings.DEFAULT_CDR_URL
                 auth_headers = {}
 
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
         # Wipe measure engine patient data for clean evaluation
         await wipe_patient_data()
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
 
         # Phase 1: Gather from CDR and push to measure engine
         strategy = BatchQueryStrategy()
@@ -704,6 +735,8 @@ async def run_validation(validation_run_id: int) -> None:
 
         async def gather_and_push(patient_ref: str) -> None:
             async with semaphore:
+                if await _stop_or_delete_validation_run(validation_run_id):
+                    return
                 resources = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
                 if resources:
                     await push_resources(resources)
@@ -722,6 +755,8 @@ async def run_validation(validation_run_id: int) -> None:
 
         # Wait for HAPI indexing (configurable via HAPI_INDEX_WAIT_SECONDS env var)
         await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
 
         # Phase 2: Evaluate and compare (shared client avoids N connection pools)
         total_passed = 0
@@ -732,6 +767,8 @@ async def run_validation(validation_run_id: int) -> None:
         async def evaluate_and_compare(er: ExpectedResult, http_client: httpx.AsyncClient) -> ValidationResult:
             info = measure_info[er.measure_url]
             try:
+                if await _stop_or_delete_validation_run(validation_run_id):
+                    raise asyncio.CancelledError("Validation run deletion requested")
                 report = await evaluate_measure(
                     info["hapi_id"],
                     er.patient_ref,
@@ -786,6 +823,8 @@ async def run_validation(validation_run_id: int) -> None:
             result_coros = [eval_with_semaphore(er) for er in expected_results]
             all_results = list(await asyncio.gather(*result_coros))
 
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
         for vr in all_results:
             if vr.status == "pass":
                 total_passed += 1
@@ -795,6 +834,8 @@ async def run_validation(validation_run_id: int) -> None:
                 total_errors += 1
 
         # Store results
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
         async with async_session() as session:
             run = await session.get(ValidationRun, validation_run_id)
             if not run:
@@ -821,6 +862,8 @@ async def run_validation(validation_run_id: int) -> None:
 
     except Exception as exc:
         logger.exception("Validation run failed", extra={"run_id": validation_run_id})
+        if await _stop_or_delete_validation_run(validation_run_id):
+            return
         async with async_session() as session:
             run = await session.get(ValidationRun, validation_run_id)
             if run:

--- a/backend/app/services/worker.py
+++ b/backend/app/services/worker.py
@@ -23,6 +23,38 @@ logger = logging.getLogger(__name__)
 _shutdown_event = asyncio.Event()
 
 
+async def _cleanup_delete_requested_jobs(session) -> int:
+    """Delete queued/cancelled jobs that were marked for deletion before pickup."""
+    result = await session.execute(
+        select(Job).where(
+            Job.delete_requested.is_(True),
+            Job.status != JobStatus.running,
+        )
+    )
+    jobs = result.scalars().all()
+    for job in jobs:
+        await session.delete(job)
+    if jobs:
+        await session.commit()
+    return len(jobs)
+
+
+async def _cleanup_delete_requested_validation_runs(session) -> int:
+    """Delete queued/cancelled validation runs marked for deletion before pickup."""
+    result = await session.execute(
+        select(ValidationRun).where(
+            ValidationRun.delete_requested.is_(True),
+            ValidationRun.status != ValidationStatus.running,
+        )
+    )
+    runs = result.scalars().all()
+    for run in runs:
+        await session.delete(run)
+    if runs:
+        await session.commit()
+    return len(runs)
+
+
 async def worker_loop() -> None:
     """Poll for queued work and process sequentially.
 
@@ -34,21 +66,28 @@ async def worker_loop() -> None:
     while not _shutdown_event.is_set():
         found_work = False
         try:
+            async with async_session() as session:
+                deleted_jobs = await _cleanup_delete_requested_jobs(session)
+                deleted_runs = await _cleanup_delete_requested_validation_runs(session)
+            if deleted_jobs or deleted_runs:
+                found_work = True
+
             # --- Priority 1: Production Jobs ---
             job_id: int | None = None
-            async with async_session() as session:
-                result = await session.execute(
-                    select(Job.id)
-                    .where(Job.status == JobStatus.queued)
-                    .order_by(Job.created_at.asc())
-                    .limit(1)
-                    .with_for_update(skip_locked=True)
-                )
-                row = result.scalar_one_or_none()
-                if row is not None:
-                    job_id = row
-                    await session.execute(update(Job).where(Job.id == job_id).values(status=JobStatus.running))
-                    await session.commit()
+            if not found_work:
+                async with async_session() as session:
+                    result = await session.execute(
+                        select(Job.id)
+                        .where(Job.status == JobStatus.queued, Job.delete_requested.is_(False))
+                        .order_by(Job.created_at.asc())
+                        .limit(1)
+                        .with_for_update(skip_locked=True)
+                    )
+                    row = result.scalar_one_or_none()
+                    if row is not None:
+                        job_id = row
+                        await session.execute(update(Job).where(Job.id == job_id).values(status=JobStatus.running))
+                        await session.commit()
 
             if job_id is not None:
                 found_work = True
@@ -108,7 +147,10 @@ async def worker_loop() -> None:
                 async with async_session() as session:
                     result = await session.execute(
                         select(ValidationRun.id)
-                        .where(ValidationRun.status == ValidationStatus.queued)
+                        .where(
+                            ValidationRun.status == ValidationStatus.queued,
+                            ValidationRun.delete_requested.is_(False),
+                        )
                         .order_by(ValidationRun.created_at.asc())
                         .limit(1)
                         .with_for_update(skip_locked=True)

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -1,6 +1,7 @@
 """Tests for job endpoints (POST /jobs, GET /jobs, GET /jobs/{id}, POST /jobs/{id}/cancel)."""
 
 import pytest
+from sqlalchemy import select
 
 pytestmark = pytest.mark.asyncio
 
@@ -317,6 +318,108 @@ async def test_create_job_stamps_cdr_auth_type_as_string_value(client, test_sess
     result = await test_session.execute(select(Job).order_by(Job.id.desc()).limit(1))
     job = result.scalar_one()
     assert job.cdr_auth_type == "bearer"
+
+
+async def test_list_jobs_includes_delete_requested(client, test_session):
+    """GET /jobs includes delete_requested so the UI can reflect pending deletion."""
+    from app.models.job import Job
+
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="https://example.com/fhir",
+        delete_requested=True,
+    )
+    test_session.add(job)
+    await test_session.commit()
+
+    resp = await client.get("/jobs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["delete_requested"] is True
+
+
+async def test_delete_terminal_job_removes_results_and_batches(client, test_session):
+    """DELETE /jobs/{id} immediately removes terminal jobs and cascades dependents."""
+    from app.models.job import Batch, BatchStatus, Job, JobStatus, MeasureResult
+
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="https://example.com/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.flush()
+    batch = Batch(job_id=job.id, batch_number=1, patient_ids=["p1"], status=BatchStatus.complete)
+    result = MeasureResult(
+        job_id=job.id,
+        patient_id="p1",
+        patient_name="Patient One",
+        measure_report={"resourceType": "MeasureReport"},
+        populations={"initial_population": True},
+    )
+    test_session.add_all([batch, result])
+    await test_session.commit()
+    job_id = job.id
+    batch_id = batch.id
+    result_id = result.id
+
+    resp = await client.delete(f"/jobs/{job_id}")
+    assert resp.status_code == 204
+    test_session.expire_all()
+    assert await test_session.get(Job, job_id) is None
+    assert await test_session.get(Batch, batch_id) is None
+    assert await test_session.get(MeasureResult, result_id) is None
+
+
+async def test_delete_queued_job_marks_for_delete_and_cleanup_removes_it(client, test_session):
+    """DELETE /jobs/{id} on a queued job returns 202 and worker cleanup removes it."""
+    from app.models.job import Job
+    from app.services.worker import _cleanup_delete_requested_jobs
+
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="https://example.com/fhir",
+    )
+    test_session.add(job)
+    await test_session.commit()
+
+    resp = await client.delete(f"/jobs/{job.id}")
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["delete_requested"] is True
+
+    await test_session.refresh(job)
+    assert job.delete_requested is True
+
+    deleted = await _cleanup_delete_requested_jobs(test_session)
+    assert deleted == 1
+    assert await test_session.get(Job, job.id) is None
+
+
+async def test_delete_running_job_sets_delete_requested(client, test_session):
+    """DELETE /jobs/{id} on a running job returns 202 and leaves the row pending deletion."""
+    from app.models.job import Job, JobStatus
+
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="https://example.com/fhir",
+        status=JobStatus.running,
+    )
+    test_session.add(job)
+    await test_session.commit()
+
+    resp = await client.delete(f"/jobs/{job.id}")
+    assert resp.status_code == 202
+    await test_session.refresh(job)
+    assert job.delete_requested is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_routes_measures.py
+++ b/backend/tests/test_routes_measures.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 import app.routes.measures as measures_module
@@ -225,3 +226,46 @@ async def test_upload_measure_small_file_not_rejected_by_size_check(client, monk
         )
 
     assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+
+
+async def test_delete_measure_success(client):
+    """DELETE /measures/{id} proxies measure deletion to the engine."""
+    with patch(
+        "app.routes.measures.delete_measure",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as mock_delete:
+        resp = await client.delete("/measures/measure-1")
+
+    assert resp.status_code == 204
+    mock_delete.assert_awaited_once_with("measure-1")
+
+
+async def test_delete_measure_not_found(client):
+    """DELETE /measures/{id} returns 404 when the engine reports the measure is missing."""
+    request = httpx.Request("DELETE", "http://test/measures/measure-1")
+    response = httpx.Response(404, request=request)
+    with patch(
+        "app.routes.measures.delete_measure",
+        new_callable=AsyncMock,
+        side_effect=httpx.HTTPStatusError("not found", request=request, response=response),
+    ):
+        resp = await client.delete("/measures/measure-1")
+
+    assert resp.status_code == 404
+    data = resp.json()["detail"]
+    assert data["issue"][0]["code"] == "not-found"
+
+
+async def test_delete_measure_engine_error(client):
+    """DELETE /measures/{id} returns 502 for upstream delete failures."""
+    with patch(
+        "app.routes.measures.delete_measure",
+        new_callable=AsyncMock,
+        side_effect=ConnectionError("Connection refused"),
+    ):
+        resp = await client.delete("/measures/measure-1")
+
+    assert resp.status_code == 502
+    data = resp.json()["detail"]
+    assert "Cannot reach measure engine" in data["issue"][0]["diagnostics"]

--- a/backend/tests/test_routes_validation.py
+++ b/backend/tests/test_routes_validation.py
@@ -154,6 +154,7 @@ class TestListValidationRuns:
         runs = response.json()["runs"]
         assert len(runs) == 1
         assert runs[0]["patients_tested"] == 10
+        assert runs[0]["delete_requested"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +184,7 @@ class TestGetValidationRun:
         assert response.status_code == 200
         data = response.json()
         assert data["patients_tested"] == 2
+        assert data["delete_requested"] is False
         assert data["measures"] == []  # No results stored yet
 
 
@@ -258,6 +260,73 @@ class TestListUploads:
         uploads = response.json()["uploads"]
         assert len(uploads) == 1
         assert uploads[0]["warning_message"] == "2 resources could not be loaded"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /validation/runs/{run_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteValidationRun:
+    @pytest.mark.asyncio
+    async def test_delete_terminal_run_removes_results(self, client, test_session):
+        from app.models.validation import ValidationResult
+
+        run = ValidationRun(status=ValidationStatus.complete)
+        test_session.add(run)
+        await test_session.flush()
+        result = ValidationResult(
+            validation_run_id=run.id,
+            measure_url="https://example.com/Measure/CMS124",
+            patient_ref="Patient/test-patient-1",
+            expected_populations={"numerator": 1},
+            actual_populations={"numerator": 1},
+            status="pass",
+            mismatches=[],
+        )
+        test_session.add(result)
+        await test_session.commit()
+        run_id = run.id
+        result_id = result.id
+
+        response = await client.delete(f"/validation/runs/{run_id}")
+        assert response.status_code == 204
+        test_session.expire_all()
+        assert await test_session.get(ValidationRun, run_id) is None
+        assert await test_session.get(ValidationResult, result_id) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_queued_run_marks_for_delete_and_cleanup_removes_it(self, client, test_session):
+        from app.services.worker import _cleanup_delete_requested_validation_runs
+
+        run = ValidationRun(status=ValidationStatus.queued)
+        test_session.add(run)
+        await test_session.commit()
+
+        response = await client.delete(f"/validation/runs/{run.id}")
+        assert response.status_code == 202
+        assert response.json()["delete_requested"] is True
+
+        await test_session.refresh(run)
+        assert run.delete_requested is True
+        assert run.status == ValidationStatus.cancelled
+
+        deleted = await _cleanup_delete_requested_validation_runs(test_session)
+        assert deleted == 1
+        assert await test_session.get(ValidationRun, run.id) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_running_run_sets_delete_requested(self, client, test_session):
+        run = ValidationRun(status=ValidationStatus.running)
+        test_session.add(run)
+        await test_session.commit()
+
+        response = await client.delete(f"/validation/runs/{run.id}")
+        assert response.status_code == 202
+
+        await test_session.refresh(run)
+        assert run.delete_requested is True
+        assert run.status == ValidationStatus.running
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -92,6 +92,12 @@ export function uploadMeasure(file) {
   });
 }
 
+export function deleteMeasure(id) {
+  return request(`/measures/${id}`, {
+    method: 'DELETE',
+  });
+}
+
 // Groups
 export function getGroups() {
   return request('/jobs/groups');
@@ -116,6 +122,12 @@ export function createJob(data) {
 export function cancelJob(id) {
   return request(`/jobs/${id}/cancel`, {
     method: 'POST',
+  });
+}
+
+export function deleteJob(id) {
+  return request(`/jobs/${id}`, {
+    method: 'DELETE',
   });
 }
 
@@ -202,6 +214,12 @@ export function getValidationRuns() {
 
 export function getValidationRun(runId) {
   return request(`/validation/runs/${runId}`);
+}
+
+export function deleteValidationRun(runId) {
+  return request(`/validation/runs/${runId}`, {
+    method: 'DELETE',
+  });
 }
 
 // Comparison

--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -74,7 +74,7 @@ export function ToastProvider({ children }) {
               onClick={() => removeToast(toast.id)}
               aria-label="Dismiss notification"
             >
-              \u00D7
+              {'\u00D7'}
             </button>
           </div>
         ))}

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import styles from './JobsPage.module.css';
-import { getJobs, getMeasures, getGroups, createJob, cancelJob } from '../api/client';
+import { getJobs, getMeasures, getGroups, createJob, cancelJob, deleteJob } from '../api/client';
 import { useToast } from '../components/Toast';
 import ProgressBar from '../components/ProgressBar';
 
@@ -61,6 +61,7 @@ export default function JobsPage() {
   const [showModal, setShowModal] = useState(false);
   const [formData, setFormData] = useState({ measure_id: '', group_id: '', period_start: '', period_end: '' });
   const [creating, setCreating] = useState(false);
+  const [deletingJobIds, setDeletingJobIds] = useState([]);
   const pollRef = useRef(null);
   const toast = useToast();
 
@@ -109,8 +110,8 @@ export default function JobsPage() {
 
   // Polling for in-progress jobs
   useEffect(() => {
-    const hasRunning = jobs.some(j => isRunning(j.status));
-    if (hasRunning) {
+    const hasActiveOrDeleting = jobs.some(j => isRunning(j.status) || j.delete_requested);
+    if (hasActiveOrDeleting) {
       pollRef.current = setInterval(loadJobs, 3000);
     } else {
       if (pollRef.current) clearInterval(pollRef.current);
@@ -152,6 +153,25 @@ export default function JobsPage() {
       loadJobs();
     } catch (err) {
       toast.error(`Failed to cancel job: ${err.message}`);
+    }
+  };
+
+  const handleDelete = async (job) => {
+    if (!window.confirm(`Delete job "${getMeasureName(job)}"? This also deletes its stored results.`)) return;
+
+    setDeletingJobIds(prev => [...prev, job.id]);
+    try {
+      const result = await deleteJob(job.id);
+      if (result?.delete_requested) {
+        toast.warning('Deletion requested. The job will disappear once background work stops.');
+      } else {
+        toast.success('Job deleted');
+      }
+      await loadJobs();
+    } catch (err) {
+      toast.error(`Failed to delete job: ${err.message}`);
+    } finally {
+      setDeletingJobIds(prev => prev.filter(id => id !== job.id));
     }
   };
 
@@ -242,6 +262,7 @@ export default function JobsPage() {
                   const running = isRunning(job.status);
                   const progress = getProgress(job);
                   const completed = (job.status || '').toLowerCase() === 'completed' || (job.status || '').toLowerCase() === 'complete';
+                  const deleting = job.delete_requested || deletingJobIds.includes(job.id);
 
                   return (
                     <tr key={job.id}>
@@ -281,19 +302,30 @@ export default function JobsPage() {
                       </td>
                       <td className={styles.dateCell}>{formatDateTime(job.started_at || job.created_at)}</td>
                       <td>
-                        {running && (
+                        <div className={styles.actionGroup}>
+                          {running && (
+                            <button
+                              className={styles.cancelBtn}
+                              onClick={() => handleCancel(job.id)}
+                              disabled={deleting}
+                            >
+                              Cancel
+                            </button>
+                          )}
+                          {completed && !deleting && (
+                            <Link to={`/results/${job.id}`} className={styles.viewLink}>
+                              View Results
+                            </Link>
+                          )}
                           <button
-                            className={styles.cancelBtn}
-                            onClick={() => handleCancel(job.id)}
+                            type="button"
+                            className={styles.deleteBtn}
+                            onClick={() => handleDelete(job)}
+                            disabled={deleting}
                           >
-                            Cancel
+                            {deleting ? 'Deleting...' : 'Delete'}
                           </button>
-                        )}
-                        {completed && (
-                          <Link to={`/results/${job.id}`} className={styles.viewLink}>
-                            View Results
-                          </Link>
-                        )}
+                        </div>
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/JobsPage.module.css
+++ b/frontend/src/pages/JobsPage.module.css
@@ -135,6 +135,32 @@
   font-weight: var(--font-weight-semibold);
 }
 
+.actionGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.deleteBtn {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.deleteBtn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.deleteBtn:disabled,
+.cancelBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .emptyRow {
   text-align: center;
   color: var(--color-text-tertiary);

--- a/frontend/src/pages/MeasuresPage.js
+++ b/frontend/src/pages/MeasuresPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import styles from './MeasuresPage.module.css';
-import { getMeasures, uploadMeasure } from '../api/client';
+import { deleteMeasure, getMeasures, uploadMeasure } from '../api/client';
 import { useToast } from '../components/Toast';
 
 function getMeasureDisplayName(measure) {
@@ -52,6 +52,7 @@ export default function MeasuresPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [uploading, setUploading] = useState(false);
+  const [deletingMeasureId, setDeletingMeasureId] = useState(null);
   const fileInputRef = useRef(null);
   const toast = useToast();
 
@@ -93,6 +94,23 @@ export default function MeasuresPage() {
       toast.error(`Upload failed: ${message}`);
     } finally {
       setUploading(false);
+    }
+  };
+
+  const handleDeleteMeasure = async (measure) => {
+    if (!measure.id) return;
+    const measureName = getMeasureDisplayName(measure);
+    if (!window.confirm(`Delete measure "${measureName}"?`)) return;
+
+    setDeletingMeasureId(measure.id);
+    try {
+      await deleteMeasure(measure.id);
+      toast.success(`Deleted ${measureName}`);
+      await loadMeasures();
+    } catch (err) {
+      toast.error(`Delete failed: ${err.message || 'Failed to delete measure'}`);
+    } finally {
+      setDeletingMeasureId(null);
     }
   };
 
@@ -183,7 +201,17 @@ export default function MeasuresPage() {
                     <td className={styles.version}>{getMeasureVersion(measure)}</td>
                     <td><StatusBadge status={getMeasureStatus(measure)} /></td>
                     <td>
-                      <a href="/jobs" className={styles.actionLink}>Calculate</a>
+                      <div className={styles.actionGroup}>
+                        <a href="/jobs" className={styles.actionLink}>Calculate</a>
+                        <button
+                          type="button"
+                          className={styles.deleteBtn}
+                          onClick={() => handleDeleteMeasure(measure)}
+                          disabled={deletingMeasureId === measure.id || !measure.id}
+                        >
+                          {deletingMeasureId === measure.id ? 'Deleting...' : 'Delete'}
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 ))

--- a/frontend/src/pages/MeasuresPage.module.css
+++ b/frontend/src/pages/MeasuresPage.module.css
@@ -120,6 +120,31 @@
   font-weight: var(--font-weight-semibold);
 }
 
+.actionGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.deleteBtn {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.deleteBtn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.deleteBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .emptyRow {
   text-align: center;
   color: var(--color-text-tertiary);

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -46,20 +46,34 @@ export default function ResultsPage() {
           return s === 'completed' || s === 'complete';
         });
         setJobs(completed);
-        if (!selectedJobId && completed.length > 0) {
-          const id = routeJobId || completed[0].id;
-          setSelectedJobId(id);
+        const preferredId = routeJobId || selectedJobId;
+        const preferredExists = preferredId && completed.some(j => String(j.id) === String(preferredId));
+
+        if (preferredExists) {
+          if (String(selectedJobId) !== String(preferredId)) {
+            setSelectedJobId(String(preferredId));
+          }
+          return;
+        }
+
+        const fallbackId = completed[0] ? String(completed[0].id) : '';
+        if (String(selectedJobId) !== fallbackId) {
+          setSelectedJobId(fallbackId);
+        }
+        if (routeJobId && String(routeJobId) !== fallbackId) {
+          navigate(fallbackId ? `/results/${fallbackId}` : '/results', { replace: true });
         }
       } catch {
         // Non-blocking
       }
     }
     loadJobs();
-  }, [routeJobId, selectedJobId]);
+  }, [navigate, routeJobId, selectedJobId]);
 
   // Load results when job is selected
   const loadResults = useCallback(async () => {
     if (!selectedJobId) {
+      setResults(null);
       setLoading(false);
       return;
     }

--- a/frontend/src/pages/ValidationPage.js
+++ b/frontend/src/pages/ValidationPage.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import styles from './ValidationPage.module.css';
 import {
+  deleteValidationRun,
   uploadTestBundle,
   getUploads,
   getExpectedResults,
@@ -8,6 +9,7 @@ import {
   getValidationRuns,
   getValidationRun,
 } from '../api/client';
+import { useToast } from '../components/Toast';
 
 function SummaryCard({ label, value, variant = 'default' }) {
   return (
@@ -30,9 +32,11 @@ export default function ValidationPage() {
   const [runDetail, setRunDetail] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [runStarting, setRunStarting] = useState(false);
+  const [deletingRunIds, setDeletingRunIds] = useState([]);
   const [error, setError] = useState(null);
   const fileInputRef = useRef(null);
   const pollRef = useRef(null);
+  const toast = useToast();
 
   // Load initial data
   const loadData = useCallback(async () => {
@@ -57,7 +61,7 @@ export default function ValidationPage() {
   // Poll for status updates when uploads or runs are in progress
   useEffect(() => {
     const hasActive = uploads.some(u => u.status === 'queued' || u.status === 'running')
-      || runs.some(r => r.status === 'queued' || r.status === 'running');
+      || runs.some(r => r.status === 'queued' || r.status === 'running' || r.delete_requested);
 
     if (hasActive) {
       pollRef.current = setInterval(loadData, 3000);
@@ -78,6 +82,11 @@ export default function ValidationPage() {
         const detail = await getValidationRun(selectedRunId);
         setRunDetail(detail);
       } catch (err) {
+        if (err.status === 404) {
+          setSelectedRunId('');
+          setRunDetail(null);
+          return;
+        }
         setError(err.message);
       }
     }
@@ -122,7 +131,35 @@ export default function ValidationPage() {
     }
   };
 
+  const handleDeleteRun = async () => {
+    if (!selectedRunId) return;
+    const runId = String(selectedRunId);
+    const selectedRun = runs.find(run => String(run.id) === runId);
+    const label = selectedRun ? `Run #${selectedRun.id}` : `run ${runId}`;
+    if (!window.confirm(`Delete ${label}?`)) return;
+
+    setDeletingRunIds(prev => [...prev, runId]);
+    setSelectedRunId('');
+    setRunDetail(null);
+
+    try {
+      const result = await deleteValidationRun(runId);
+      if (result?.delete_requested) {
+        toast.warning('Deletion requested. The run will disappear once background work stops.');
+      } else {
+        toast.success('Validation run deleted');
+      }
+      await loadData();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setDeletingRunIds(prev => prev.filter(id => id !== runId));
+    }
+  };
+
   const hasExpected = expected && expected.total_measures > 0;
+  const selectedRun = runs.find(run => String(run.id) === String(selectedRunId));
+  const selectedRunDeleting = selectedRun && (selectedRun.delete_requested || deletingRunIds.includes(String(selectedRun.id)));
 
   return (
     <div className={styles.page}>
@@ -219,14 +256,24 @@ export default function ValidationPage() {
       <section className={styles.section}>
         <div className={styles.runHeader}>
           <h2 className={styles.sectionTitle}>Validation Runs</h2>
-          <button
-            onClick={handleRunValidation}
-            disabled={!hasExpected || runStarting}
-            className={styles.primaryBtn}
-            title={!hasExpected ? 'Upload a test bundle first' : ''}
-          >
-            {runStarting ? 'Starting...' : 'Run Validation'}
-          </button>
+          <div className={styles.runActions}>
+            <button
+              onClick={handleRunValidation}
+              disabled={!hasExpected || runStarting}
+              className={styles.primaryBtn}
+              title={!hasExpected ? 'Upload a test bundle first' : ''}
+            >
+              {runStarting ? 'Starting...' : 'Run Validation'}
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteRun}
+              disabled={!selectedRunId || selectedRunDeleting}
+              className={styles.dangerBtn}
+            >
+              {selectedRunDeleting ? 'Deleting...' : 'Delete Run'}
+            </button>
+          </div>
         </div>
 
         {runs.length > 0 && (
@@ -240,7 +287,7 @@ export default function ValidationPage() {
               <option value="">Select a run...</option>
               {runs.map(r => (
                 <option key={r.id} value={r.id}>
-                  Run #{r.id} — {r.status} — {r.created_at ? new Date(r.created_at).toLocaleString() : ''}
+                  Run #{r.id} — {r.delete_requested ? 'deleting' : r.status} — {r.created_at ? new Date(r.created_at).toLocaleString() : ''}
                 </option>
               ))}
             </select>

--- a/frontend/src/pages/ValidationPage.module.css
+++ b/frontend/src/pages/ValidationPage.module.css
@@ -58,6 +58,27 @@
   filter: brightness(0.9);
 }
 
+.dangerBtn {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-body);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.dangerBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dangerBtn:hover:not(:disabled) {
+  background: var(--color-error-light);
+}
+
 /* Tables */
 .table {
   width: 100%;
@@ -98,6 +119,7 @@
 
 .badge_queued { color: #666; border: 1px solid #ccc; }
 .badge_running { color: #1a73e8; border: 1px solid #1a73e8; }
+.badge_cancelled { color: #cf222e; border: 1px solid #cf222e; }
 .badge_complete { color: #2d8a4e; border: 1px solid #2d8a4e; }
 .badge_failed { color: #cf222e; border: 1px solid #cf222e; }
 
@@ -115,6 +137,13 @@
   align-items: center;
   gap: var(--space-2);
   margin-top: var(--space-3);
+}
+
+.runActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
 }
 
 .runLabel {


### PR DESCRIPTION
## Summary

Adds delete flows for measures, calculation jobs, job results, and validation runs from the UI. Deletes are confirmed before execution and are backed by real API endpoints.

## Changes

- Add backend delete endpoints for measures, jobs, and validation runs.
- Add cooperative `delete_requested` handling so queued/running jobs and validation runs stop safely before being removed.
- Add schema migration support for delete tracking and validation cancellation.
- Add UI delete actions with confirmation, pending states, refresh/poll behavior, and stale Results route recovery.
- Fix toast dismiss rendering so the close button displays `×` instead of a literal Unicode escape.
- Add backend route tests covering delete behavior and response fields.

## Validation

- `pytest backend/tests/test_routes_measures.py backend/tests/test_routes_jobs.py backend/tests/test_routes_validation.py` passed: 72 passed.
- `npm run build` passed for the frontend.
- `docker compose up -d --build` completed and the app served on `http://localhost:3001`; backend health reported connected DB, measure engine, and CDR.
