### PR TITLE
[codex] Let validation continue after HAPI wipe timeouts

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -466,15 +466,17 @@ async def delete_measure(measure_id: str) -> None:
             resp.raise_for_status()
 
 
-async def wipe_patient_data() -> None:
+async def wipe_patient_data(*, strict: bool = True) -> None:
     """Delete patient-related data from the measure engine.
 
     Called at the START of a new job to clean up data from the prior run.
     This allows the previous job's evaluated resources to remain available
     for inspection until a new job begins.
 
-    Fails fast if the measure engine is unreachable: after 3 consecutive
-    timeouts we raise immediately rather than grinding for 20+ minutes.
+    In strict mode, fail fast if the measure engine is unreachable: after 3
+    consecutive timeouts we raise immediately rather than grinding for 20+ minutes.
+    Validation runs use non-strict mode so a slow conditional delete does not abort
+    patient-level comparison when the engine is otherwise up.
     """
     resource_types = [
         "MeasureReport",
@@ -523,10 +525,16 @@ async def wipe_patient_data() -> None:
                     extra={"resourceType": rt},
                 )
                 if consecutive_failures >= _MAX_CONSECUTIVE_FAILURES:
-                    raise RuntimeError(
-                        f"Measure engine unreachable: {consecutive_failures} consecutive "
-                        "timeouts during wipe. Job aborted."
+                    if strict:
+                        raise RuntimeError(
+                            f"Measure engine unreachable: {consecutive_failures} consecutive "
+                            "timeouts during wipe. Job aborted."
+                        )
+                    logger.warning(
+                        "Stopping best-effort wipe after consecutive failures",
+                        extra={"failures": consecutive_failures},
                     )
+                    return
 
 
 async def _delete_all_of_type(client: httpx.AsyncClient, resource_type: str) -> None:

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -762,8 +762,9 @@ async def run_validation(validation_run_id: int) -> None:
             if await _stop_or_delete_validation_run(validation_run_id):
                 return
 
-            # Wipe measure engine patient data for clean evaluation
-            await wipe_patient_data()
+            # Best-effort for validation: stale resources are worse than ideal, but
+            # aborting prevents patient-level comparison entirely on slow HAPI deletes.
+            await wipe_patient_data(strict=False)
             if await _stop_or_delete_validation_run(validation_run_id):
                 return
 

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -348,6 +348,31 @@ async def test_wipe_patient_data_includes_qi_core_types():
         assert expected_type in wiped_types, f"{expected_type} missing from wipe list"
 
 
+async def test_wipe_patient_data_strict_raises_after_consecutive_failures():
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.delete = AsyncMock(side_effect=httpx.TimeoutException("slow delete"))
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(RuntimeError, match="Measure engine unreachable"):
+            await wipe_patient_data()
+
+    assert mock_ctx.delete.call_count == 3
+
+
+async def test_wipe_patient_data_non_strict_stops_after_consecutive_failures():
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.delete = AsyncMock(side_effect=httpx.TimeoutException("slow delete"))
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await wipe_patient_data(strict=False)
+
+    assert mock_ctx.delete.call_count == 3
+
+
 # ---------------------------------------------------------------------------
 # test_connection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- keep `wipe_patient_data()` strict by default for production calculation jobs
- add non-strict wipe mode for validation runs so parity checks can continue after repeated HAPI conditional-delete timeouts
- update validation to call `wipe_patient_data(strict=False)`
- add tests for strict failure and non-strict best-effort wipe behavior

## Why
After production came back, the CMS816 canary confirmed the stale expected-result fix worked: production `CMS816` expected rows dropped from 28 to 9 after re-upload. The validation run then failed before evaluation with:

`Measure engine unreachable: 3 consecutive timeouts during wipe. Job aborted.`

The API health and measure list were still healthy, so this is a slow HAPI delete path rather than a dead measure engine. For validation/parity runs, aborting before patient-level comparison is worse than proceeding after best-effort cleanup.

## Validation
- `cd backend && python3 -m ruff format --check app/ tests/`
- `cd backend && python3 -m ruff check app/ tests/`
- `cd backend && python3 -m pytest tests/test_services_fhir_client.py tests/test_services_validation.py tests/test_routes_validation.py -q`

## Production canary state before this PR
- prod health: healthy
- prod CMS816 expected rows after re-upload: 9
- prod CMS816 validation failed during wipe before evaluating patients
