### PR TITLE
fix(ci): stop forwarding POSTGRES_PASSWORD to prod deploy shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,13 +35,10 @@ jobs:
       - name: Deploy to EC2
         if: success()
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1
-        env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: POSTGRES_PASSWORD
           script: |
             cd /opt/leonard
             git fetch origin main


### PR DESCRIPTION
## Summary

- Remove `env.POSTGRES_PASSWORD` and `envs: POSTGRES_PASSWORD` from the `Deploy to EC2` step in `.github/workflows/deploy.yml` so the SSH session on the prod box no longer injects a shell value that overrides `.env` at `docker compose up` time.
- Compose now interpolates `${POSTGRES_PASSWORD}` solely from `/opt/leonard/.env`, which matches the password the `leonard_pgdata` volume was initialized with — eliminating the drift that crash-looped the backend on `asyncpg.exceptions.InvalidPasswordError` and took prod down twice in 12 hours (2026-04-22 ~22:55 UTC, 2026-04-23 ~11:15 UTC).

## Related issue

Partial mitigation for #125 (does not replace it — #125 Part A/B still required for volume drift, rotation, and removing SSH-based deploy).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Infrastructure / CI/CD
- [ ] Chore (deps, tooling, lockfile)

## Checklist

- [x] Tests added or updated (N/A — CI/CD workflow only)
- [x] docs/ updated (N/A — behavior is unchanged for correctly-configured `.env`)
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md` (this is an interim fix; #125 is the tracked decision point)
- [x] Security implications considered — see below

### Security note

After this change, `POSTGRES_PASSWORD` is no longer transmitted from GitHub Actions to the EC2 host on each deploy. The GitHub secret becomes unused; leaving it in place until #125 Part A lands is intentional (avoid mid-incident secret deletion). `/opt/leonard/.env` on the host remains the source of truth for the DB password until SSM reconciliation ships.

## Test plan

- [ ] CI green (unit tests + frontend build unaffected by this diff).
- [ ] On merge, the auto-deploy step runs against prod. Verify:
  - [ ] `docker inspect leonard-backend-1 --format '{{range .Config.Env}}{{println .}}{{end}}' | grep DATABASE_URL` shows the short `mct2` password (length ~45, not ~71).
  - [ ] `curl -sS https://api.98-89-219-217.nip.io/health` returns 200 with all deps `connected`.
  - [ ] `curl -sS https://98-89-219-217.nip.io/` returns 200.
- [ ] Rollback plan: `git revert` this commit and merge; previous forwarding behavior returns. DB volume is untouched so no data migration needed either way.