### PR TITLE
[codex] Harden validation measure support resources

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -437,13 +437,31 @@ async def evaluate_measure(
         f"&subject=Patient/{patient_id}"
     )
     async with httpx.AsyncClient(timeout=120.0) as client:
-        logger.info(
-            "Evaluating measure",
-            extra={"measure_id": measure_id, "patient_id": patient_id},
-        )
-        resp = await client.get(url)
-        resp.raise_for_status()
-        return resp.json()
+        for attempt in range(3):
+            logger.info(
+                "Evaluating measure",
+                extra={"measure_id": measure_id, "patient_id": patient_id, "attempt": attempt + 1},
+            )
+            resp = await client.get(url)
+            try:
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code < 500 or attempt == 2:
+                    raise
+                logger.warning(
+                    "Transient measure evaluation failure — retrying",
+                    extra={
+                        "measure_id": measure_id,
+                        "patient_id": patient_id,
+                        "status_code": status_code,
+                        "attempt": attempt + 1,
+                    },
+                )
+                await asyncio.sleep(0.5 * (attempt + 1))
+
+    raise RuntimeError("Measure evaluation failed without a response")
 
 
 async def upload_measure_bundle(bundle_json: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -5,6 +5,7 @@ running validation against expected results, and comparing population counts.
 """
 
 import asyncio
+import base64
 import copy
 import json
 import logging
@@ -357,6 +358,118 @@ def _fix_valueset_compose_for_hapi(resources: list[dict[str, Any]]) -> list[dict
     return result
 
 
+def _get_missing_valueset_stubs(bundle_json: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return empty ValueSet stubs for ELM-declared ValueSets omitted by the bundle.
+
+    HAPI's CQL engine raises ``Unknown ValueSet`` when an ELM-declared ValueSet
+    is not present at all. An empty ValueSet makes membership checks evaluate
+    false instead, which preserves patient-level comparison and matches the
+    connectathon harness behavior for incomplete MADiE bundles.
+    """
+    elm_declared_urls: set[str] = set()
+    bundled_urls: set[str] = set()
+
+    for entry in bundle_json.get("entry", []):
+        resource = entry.get("resource") or {}
+        resource_type = resource.get("resourceType")
+
+        if resource_type == "ValueSet" and resource.get("url"):
+            bundled_urls.add(resource["url"])
+            continue
+
+        if resource_type != "Library":
+            continue
+
+        for content in resource.get("content", []):
+            if content.get("contentType") != "application/elm+json" or not content.get("data"):
+                continue
+            try:
+                elm = json.loads(base64.b64decode(content["data"]))
+            except Exception:
+                logger.warning(
+                    "Unable to parse ELM JSON while scanning missing ValueSets",
+                    extra={"library_id": resource.get("id")},
+                )
+                continue
+
+            for valueset in elm.get("library", {}).get("valueSets", {}).get("def", []):
+                if url := valueset.get("id"):
+                    elm_declared_urls.add(url)
+
+    stubs = []
+    for url in sorted(elm_declared_urls - bundled_urls):
+        stub_id = "stub-" + re.sub(r"[^A-Za-z0-9.-]", "-", url.removeprefix("http://").removeprefix("https://"))
+        stubs.append(
+            {
+                "resourceType": "ValueSet",
+                "id": stub_id[:64],
+                "url": url,
+                "status": "active",
+            }
+        )
+    return stubs
+
+
+async def _find_existing_valueset_id(
+    url: str,
+    client: httpx.AsyncClient,
+    *,
+    target_url: str | None = None,
+) -> str | None:
+    """Return the existing HAPI ValueSet resource ID for a canonical URL."""
+    resp = await client.get(
+        f"{target_url or settings.MEASURE_ENGINE_URL}/ValueSet",
+        params={"url": url, "_count": 1, "_elements": "id,url"},
+        headers={"Cache-Control": "no-cache", "Accept": "application/fhir+json"},
+    )
+    resp.raise_for_status()
+    entries = resp.json().get("entry", [])
+    if not entries:
+        return None
+    return entries[0].get("resource", {}).get("id")
+
+
+async def _prepare_measure_support_resources(
+    resources: list[dict[str, Any]],
+    bundle_json: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Prepare ValueSets/CodeSystems for HAPI upload.
+
+    Adds missing ELM ValueSet stubs only when HAPI does not already have that
+    URL, and remaps ValueSet IDs to existing HAPI resources to avoid HAPI-0902
+    URL+version uniqueness conflicts silently dropping updates inside a batch.
+    """
+    prepared = _fix_valueset_compose_for_hapi(resources)
+    stubs = _get_missing_valueset_stubs(bundle_json)
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        if stubs:
+            filtered_stubs = []
+            for stub in stubs:
+                url = stub.get("url")
+                if not url:
+                    continue
+                if await _find_existing_valueset_id(url, client):
+                    continue
+                filtered_stubs.append(stub)
+            if filtered_stubs:
+                prepared = [*prepared, *filtered_stubs]
+                logger.info("Prepared missing ValueSet stubs", extra={"count": len(filtered_stubs)})
+
+        aligned = []
+        for resource in prepared:
+            if resource.get("resourceType") != "ValueSet" or not resource.get("url"):
+                aligned.append(resource)
+                continue
+            existing_id = await _find_existing_valueset_id(resource["url"], client)
+            if existing_id and existing_id != resource.get("id"):
+                resource = copy.deepcopy(resource)
+                resource["id"] = existing_id
+            aligned.append(resource)
+
+    return aligned
+
+
 async def triage_test_bundle(
     bundle_json: dict[str, Any],
     filename: str,
@@ -379,9 +492,10 @@ async def triage_test_bundle(
         primary = [r for r in measure_defs if r.get("resourceType") in ("Measure", "Library")]
         secondary = [r for r in measure_defs if r.get("resourceType") not in ("Measure", "Library")]
         try:
-            if secondary:
-                # ValueSets/CodeSystems: patch compose before loading (HAPI-0902 is OK)
-                await push_resources(_fix_valueset_compose_for_hapi(secondary))
+            # ValueSets/CodeSystems plus ELM-declared missing ValueSet stubs.
+            support_resources = await _prepare_measure_support_resources(secondary, bundle_json)
+            if support_resources:
+                await push_resources(support_resources)
             if primary:
                 await push_resources(primary)  # Measure + Library always pushed
         except Exception as exc:
@@ -585,8 +699,9 @@ async def _reload_measures_from_seed_bundles() -> dict[str, int]:
             if measure_defs:
                 primary = [r for r in measure_defs if r.get("resourceType") in ("Measure", "Library")]
                 secondary = [r for r in measure_defs if r.get("resourceType") not in ("Measure", "Library")]
-                if secondary:
-                    await push_resources(_fix_valueset_compose_for_hapi(secondary))
+                support_resources = await _prepare_measure_support_resources(secondary, bundle_json)
+                if support_resources:
+                    await push_resources(support_resources)
                 if primary:
                     await push_resources(primary)
                     for r in primary:

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -295,6 +295,42 @@ async def test_evaluate_measure(mock_measure_report):
     assert "subject=Patient/patient-1" in url
 
 
+async def test_evaluate_measure_retries_transient_5xx(mock_measure_report):
+    """Transient HAPI 5xx responses are retried before returning the MeasureReport."""
+    responses = [
+        _make_response(500, {"resourceType": "OperationOutcome"}),
+        _make_response(502, {"resourceType": "OperationOutcome"}),
+        _make_response(200, mock_measure_report),
+    ]
+
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.get = AsyncMock(side_effect=responses)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+        with patch("app.services.fhir_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await evaluate_measure("measure-1", "patient-1", "2024-01-01", "2024-12-31")
+
+    assert result["resourceType"] == "MeasureReport"
+    assert mock_ctx.get.call_count == 3
+    assert mock_sleep.await_count == 2
+
+
+async def test_evaluate_measure_does_not_retry_4xx():
+    """Known HAPI/MADiE 4xx failures should surface without retrying."""
+    response = _make_response(400, {"resourceType": "OperationOutcome"})
+
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.get = AsyncMock(return_value=response)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+        with pytest.raises(httpx.HTTPStatusError):
+            await evaluate_measure("measure-1", "patient-1", "2024-01-01", "2024-12-31")
+
+    mock_ctx.get.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # wipe_patient_data
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -1,5 +1,7 @@
 """Tests for validation service — bundle triage, population extraction, comparison."""
 
+import base64
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,7 +14,9 @@ from app.services.validation import (
     _extract_population_counts,
     _extract_test_case_info,
     _fix_valueset_compose_for_hapi,
+    _get_missing_valueset_stubs,
     _is_test_case_measure_report,
+    _prepare_measure_support_resources,
     _resolve_measure_id,
     _warn_unknown_bundle_types,
     compare_populations,
@@ -624,6 +628,31 @@ class TestTriageTestBundle:
         assert result["patients_loaded"] == 0
         # push_resources called exactly once for measure defs
         mock_push.assert_called_once()
+
+    async def test_bundle_with_no_secondary_defs_still_loads_missing_valueset_stubs(self, test_session):
+        """Bundles like CMS1218 have Measure/Library resources but no bundled ValueSets."""
+        bundle = {
+            "resourceType": "Bundle",
+            "type": "transaction",
+            "entry": [
+                {"resource": {"resourceType": "Measure", "id": "m1", "url": "http://example.com/m1"}},
+                {"resource": {"resourceType": "Library", "id": "lib1", "url": "http://example.com/lib1"}},
+            ],
+        }
+        stub = {"resourceType": "ValueSet", "id": "stub-vs", "url": "http://example.com/vs"}
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
+            with patch(
+                "app.services.validation._prepare_measure_support_resources",
+                new_callable=AsyncMock,
+                return_value=[stub],
+            ) as mock_prepare:
+                result = await triage_test_bundle(bundle, "defs-only.json", test_session)
+
+        assert result["measures_loaded"] == 1
+        mock_prepare.assert_awaited_once_with([], bundle)
+        assert mock_push.call_count == 2
+        assert mock_push.call_args_list[0].args[0] == [stub]
 
     async def test_reupload_same_source_bundle_replaces_stale_expected_results(
         self, test_session, mock_test_bundle_with_expected
@@ -1291,3 +1320,108 @@ class TestFixValueSetComposeForHapi:
         result = _fix_valueset_compose_for_hapi([vs])
         assert id(result[0]) != original_id
         assert "compose" not in vs
+
+
+class TestMissingValueSetStubs:
+    def _bundle_with_elm(self, valueset_urls: list[str], bundled_valuesets: list[str] | None = None):
+        elm = {
+            "library": {
+                "valueSets": {"def": [{"id": url, "name": f"VS {idx}"} for idx, url in enumerate(valueset_urls)]}
+            }
+        }
+        entries = [
+            {
+                "resource": {
+                    "resourceType": "Library",
+                    "id": "lib",
+                    "content": [
+                        {
+                            "contentType": "application/elm+json",
+                            "data": base64.b64encode(json.dumps(elm).encode()).decode(),
+                        }
+                    ],
+                }
+            }
+        ]
+        for url in bundled_valuesets or []:
+            entries.append({"resource": {"resourceType": "ValueSet", "id": url.rsplit("/", 1)[-1], "url": url}})
+        return {"resourceType": "Bundle", "entry": entries}
+
+    def test_get_missing_valueset_stubs_skips_bundled_valuesets(self):
+        missing_url = "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3"
+        bundled_url = "http://cts.nlm.nih.gov/fhir/ValueSet/4.5.6"
+        bundle = self._bundle_with_elm([missing_url, bundled_url], bundled_valuesets=[bundled_url])
+
+        stubs = _get_missing_valueset_stubs(bundle)
+
+        assert [stub["url"] for stub in stubs] == [missing_url]
+        assert stubs[0]["resourceType"] == "ValueSet"
+        assert stubs[0]["status"] == "active"
+
+    async def test_prepare_measure_support_resources_adds_missing_stubs(self):
+        missing_url = "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3"
+        bundle = self._bundle_with_elm([missing_url])
+        resource = {"resourceType": "CodeSystem", "id": "cs"}
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"resourceType": "Bundle", "entry": []}
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
+            prepared = await _prepare_measure_support_resources([resource], bundle)
+
+        assert resource in prepared
+        assert any(r.get("resourceType") == "ValueSet" and r.get("url") == missing_url for r in prepared)
+
+    async def test_prepare_measure_support_resources_skips_stub_when_valueset_exists(self):
+        existing_url = "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3"
+        bundle = self._bundle_with_elm([existing_url])
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "resourceType": "Bundle",
+            "entry": [{"resource": {"resourceType": "ValueSet", "id": "existing-id", "url": existing_url}}],
+        }
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
+            prepared = await _prepare_measure_support_resources([], bundle)
+
+        assert prepared == []
+
+    async def test_prepare_measure_support_resources_remaps_existing_valueset_id(self):
+        valueset = {
+            "resourceType": "ValueSet",
+            "id": "bundle-id",
+            "url": "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3",
+            "expansion": {"contains": [{"system": "http://loinc.org", "code": "1234-5"}]},
+        }
+        bundle = {"resourceType": "Bundle", "entry": [{"resource": valueset}]}
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "resourceType": "Bundle",
+            "entry": [{"resource": {"resourceType": "ValueSet", "id": "existing-id", "url": valueset["url"]}}],
+        }
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
+            prepared = await _prepare_measure_support_resources([valueset], bundle)
+
+        assert prepared[0]["id"] == "existing-id"
+        assert valueset["id"] == "bundle-id"


### PR DESCRIPTION
## Summary

- load empty ValueSet stubs for ELM-declared ValueSets that MADiE bundles omit, including bundles with no ValueSet resources such as CMS1218
- remap uploaded ValueSet IDs to existing HAPI resources by canonical URL so real ValueSets can replace prior stubs instead of being dropped by HAPI uniqueness conflicts
- retry transient `$evaluate-measure` 5xx responses per patient while preserving 4xx failures such as the known CMS1017 HAPI issue

## Why

The post-merge parity sweep completed all 12 measures, but many local/prod diffs were per-patient HAPI 500s rather than actual population differences. Local logs showed CMS1218 failing with `Unknown ValueSet` for omitted MADiE ValueSets, and HAPI also returned intermittent 500 responses that succeeded on immediate retry.

## Validation

- `python3 -m ruff format --check app/ tests/`
- `python3 -m ruff check app/ tests/`
- `python3 -m pytest tests/test_services_fhir_client.py tests/test_services_validation.py tests/test_routes_validation.py -q` (`173 passed`)
- rebuilt local Docker backend with `docker compose up -d --build backend`
- `python3 scripts/compare_connectathon_local_vs_prod.py --measure-id CMS1218FHIRHHRF --local-api-base http://localhost:8000 --production-api-base http://localhost:8000 --output-dir artifacts/connectathon-local-local-cms1218-eval-retry --timeout-seconds 1800 --poll-seconds 5` produced zero patient-level diffs
