### PR TITLE
[codex] Add Jobs-based Connectathon parity runner

### DIFF
--- a/.github/workflows/connectathon-measures.yml
+++ b/.github/workflows/connectathon-measures.yml
@@ -8,6 +8,8 @@ name: Connectathon Measures
 #   - source-of-truth: golden isolation plus full-bundle connectathon coverage.
 #   - full-workflow: orchestration end-to-end coverage in a clean runner so it
 #     does not inherit the connectathon-loaded CDR state.
+#   - jobs-workflow: real MCT2 /jobs calculations for known passing
+#     Connectathon measures, compared against loaded expected patient outcomes.
 #
 # When STRICT_STU6 flips to "1" the source-of-truth job will hard-fail on
 # population mismatches, giving a daily signal of connectathon readiness.
@@ -71,3 +73,57 @@ jobs:
 
       - name: Run full workflow integration test in isolation
         run: ./scripts/run-integration-tests.sh tests/integration/test_full_workflow.py
+
+  jobs-workflow:
+    name: Jobs Workflow (connectathon expected parity)
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Pull HAPI FHIR image
+        run: docker pull hapiproject/hapi:v8.8.0-1
+
+      - name: Start product API stack
+        run: docker compose up -d --build backend
+
+      - name: Wait for product API
+        run: |
+          for attempt in {1..60}; do
+            if curl -sf http://localhost:8000/health > /dev/null; then
+              exit 0
+            fi
+            echo "Waiting for backend health (${attempt}/60)..."
+            sleep 10
+          done
+          docker compose ps
+          docker compose logs --no-color --tail=200 backend hapi-fhir-cdr hapi-fhir-measure
+          exit 1
+
+      - name: Run real jobs-path connectathon checks
+        run: |
+          set -euo pipefail
+          for measure_id in \
+            CMS124FHIRCervicalCancerScreening \
+            CMS506FHIRSafeUseofOpioids \
+            CMS816FHIRHHHypo \
+            CMS529FHIRHybridHospitalWideReadmission; do
+            python3 scripts/compare_connectathon_jobs_local_vs_prod.py \
+              --local-api-base http://localhost:8000 \
+              --expected-only \
+              --measure-id "$measure_id" \
+              --output-dir "artifacts/connectathon-jobs-workflow/${measure_id}" \
+              --timeout-seconds 3600 \
+              --poll-seconds 5 \
+              --fail-on-mismatch
+          done
+
+      - name: Show jobs-path summary
+        if: always()
+        run: |
+          find artifacts/connectathon-jobs-workflow -name summary.md -print -exec sed -n '1,80p' {} \; || true
+
+      - name: Stop product API stack
+        if: always()
+        run: docker compose down -v

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -338,12 +338,6 @@ async def get_job_comparison(
             },
         )
 
-    result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
-    actual_results = result.scalars().all()
-
-    if not actual_results:
-        return {"has_expected": False, "matched": None, "total": None, "patients": []}
-
     measure_url = ""
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
@@ -368,12 +362,24 @@ async def get_job_comparison(
     if not expected_by_patient:
         return {"has_expected": False, "matched": None, "total": None, "patients": []}
 
+    result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
+    actual_by_patient = {mr.patient_id: mr for mr in result.scalars().all()}
+
     patients_list = []
     matched_count = 0
 
-    for mr in actual_results:
-        expected = expected_by_patient.get(mr.patient_id)
-        if not expected:
+    for patient_id, expected in sorted(expected_by_patient.items()):
+        mr = actual_by_patient.get(patient_id)
+        if not mr:
+            patients_list.append(
+                {
+                    "subject_reference": f"Patient/{patient_id}",
+                    "match": False,
+                    "mismatches": ["missing-result"],
+                    "expected": expected.expected_populations,
+                    "actual": {},
+                }
+            )
             continue
 
         actual_counts = _extract_population_counts(mr.measure_report)
@@ -391,9 +397,15 @@ async def get_job_comparison(
             }
         )
 
+    unexpected_result_count = len(set(actual_by_patient) - set(expected_by_patient))
+
     return {
         "has_expected": True,
         "matched": matched_count,
         "total": len(patients_list),
+        "expected_total": len(expected_by_patient),
+        "actual_total": len(actual_by_patient),
+        "missing_results": len(expected_by_patient) - len(set(expected_by_patient) & set(actual_by_patient)),
+        "unexpected_results": unexpected_result_count,
         "patients": patients_list,
     }

--- a/backend/app/routes/results.py
+++ b/backend/app/routes/results.py
@@ -31,6 +31,7 @@ async def get_results(
         return {
             "job_id": job_id,
             "total_patients": 0,
+            "failed_patients": 0,
             "populations": {
                 "initial_population": 0,
                 "denominator": 0,
@@ -51,18 +52,25 @@ async def get_results(
         "numerator_exclusion": 0,
     }
     patients_list = []
+    failed_patients = 0
 
     for mr in results:
         populations = mr.populations or {}
-        for key in pops:
-            if populations.get(key):
-                pops[key] += 1
+        is_error = bool(populations.get("error"))
+        if is_error:
+            failed_patients += 1
+        else:
+            for key in pops:
+                if populations.get(key):
+                    pops[key] += 1
         patients_list.append(
             {
                 "id": mr.id,
                 "patient_id": mr.patient_id,
                 "patient_name": mr.patient_name,
                 "populations": populations,
+                "status": "error" if is_error else "success",
+                "error_message": populations.get("error_message") if is_error else None,
             }
         )
 
@@ -75,6 +83,7 @@ async def get_results(
     return {
         "job_id": job_id,
         "total_patients": len(results),
+        "failed_patients": failed_patients,
         "populations": pops,
         "performance_rate": performance_rate,
         "patients": patients_list,
@@ -110,6 +119,8 @@ async def get_result(
         "patient_name": mr.patient_name,
         "measure_report": mr.measure_report,
         "populations": mr.populations,
+        "status": "error" if (mr.populations or {}).get("error") else "success",
+        "error_message": (mr.populations or {}).get("error_message"),
         "created_at": mr.created_at.isoformat() if mr.created_at else None,
     }
 

--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -21,6 +21,7 @@ from app.services.fhir_client import (
     push_resources,
     wipe_patient_data,
 )
+from app.services.validation import sanitize_error
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,21 @@ def _extract_patient_name(patient_resource: dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _error_measure_report(patient_id: str, exc: Exception) -> dict[str, Any]:
+    """Build a persisted per-patient error result for failed evaluations."""
+    return {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "processing",
+                "diagnostics": sanitize_error(exc),
+            }
+        ],
+        "subject": {"reference": f"Patient/{patient_id}"},
+    }
+
+
 async def _stop_or_delete_job(job_id: int) -> bool:
     """Return True when work should stop because the job was cancelled or deleted."""
     async with async_session() as session:
@@ -102,7 +118,7 @@ async def run_job(job_id: int) -> None:
     try:
         # Step 1: Wipe patient data from measure engine (cleanup from prior job)
         logger.info("Wiping prior patient data from measure engine", extra={"job_id": job_id})
-        await wipe_patient_data()
+        await wipe_patient_data(strict=False)
         if await _stop_or_delete_job(job_id):
             return
 
@@ -192,11 +208,15 @@ async def run_job(job_id: int) -> None:
                 return
             if job.status == JobStatus.cancelled:
                 return
-            job.status = JobStatus.complete
+            if job.total_patients and job.processed_patients == 0 and job.failed_patients > 0:
+                job.status = JobStatus.failed
+                job.error_message = f"All {job.failed_patients} patient evaluations failed"
+            else:
+                job.status = JobStatus.complete
             job.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
-        logger.info("Job complete", extra={"job_id": job_id})
+        logger.info("Job finalized", extra={"job_id": job_id})
 
     except Exception as exc:
         logger.exception("Job failed", extra={"job_id": job_id})
@@ -344,13 +364,37 @@ async def _process_single_batch(
                     processed += 1
 
                 except Exception as patient_exc:
+                    patient_name = _extract_patient_name(patient_map.get(patient_id, {}))
+                    sanitized_error = sanitize_error(patient_exc)
+                    error_report = _error_measure_report(patient_id, patient_exc)
+                    if await _stop_or_delete_job(job_id):
+                        return
+                    async with async_session() as session:
+                        result = MeasureResult(
+                            job_id=job_id,
+                            patient_id=patient_id,
+                            patient_name=patient_name,
+                            measure_report=error_report,
+                            populations={
+                                "initial_population": False,
+                                "denominator": False,
+                                "numerator": False,
+                                "denominator_exclusion": False,
+                                "numerator_exclusion": False,
+                                "error": True,
+                                "error_message": sanitized_error,
+                            },
+                        )
+                        session.add(result)
+                        await session.commit()
+
                     logger.warning(
                         "Failed to evaluate patient",
                         extra={
                             "job_id": job_id,
                             "batch_id": batch_id,
                             "patient_id": patient_id,
-                            "error": str(patient_exc),
+                            "error": sanitized_error,
                         },
                     )
                     failed += 1

--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -14,7 +14,6 @@ from app.db import async_session
 from app.models.job import Batch, BatchStatus, Job, JobStatus, MeasureResult
 from app.services.fhir_client import (
     BatchQueryStrategy,
-    DataRequirementsStrategy,
     _build_auth_headers,
     evaluate_measure,
     get_group_members,
@@ -296,7 +295,9 @@ async def _process_single_batch(
                 period_start = job.period_start
                 period_end = job.period_end
 
-            strategy = DataRequirementsStrategy(measure_id)
+            # Match the proven connectathon integration path: evaluate-measure
+            # needs each patient's full clinical graph on the measure engine.
+            strategy = BatchQueryStrategy()
 
             # ----------------------------------------------------------
             # Phase 1: Gather all patient data and push to measure engine

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -7,6 +7,7 @@ running validation against expected results, and comparing population counts.
 import asyncio
 import base64
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -358,6 +359,70 @@ def _fix_valueset_compose_for_hapi(resources: list[dict[str, Any]]) -> list[dict
     return result
 
 
+def _fix_library_deps_for_hapi(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Patch MADiE Library dependency URLs so HAPI can resolve sub-libraries."""
+    ecqi_prefix = "http://ecqi.healthit.gov/ecqms/Library/"
+    madie_prefix = "https://madie.cms.gov/Library/"
+
+    result = []
+    for resource in resources:
+        if resource.get("resourceType") != "Library":
+            result.append(resource)
+            continue
+
+        needs_fix = any(
+            artifact.get("type") == "depends-on" and artifact.get("resource", "").startswith(ecqi_prefix)
+            for artifact in resource.get("relatedArtifact", [])
+        )
+        if not needs_fix:
+            result.append(resource)
+            continue
+
+        resource = copy.deepcopy(resource)
+        for artifact in resource.get("relatedArtifact", []):
+            dep_url = artifact.get("resource", "")
+            if artifact.get("type") == "depends-on" and dep_url.startswith(ecqi_prefix):
+                artifact["resource"] = madie_prefix + dep_url[len(ecqi_prefix) :]
+        result.append(resource)
+    return result
+
+
+def _fix_duplicate_claim_ids(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Assign unique IDs to duplicate Claim resources from affected MADiE bundles."""
+    id_counts: dict[str, int] = {}
+    for resource in resources:
+        if resource.get("resourceType") == "Claim" and resource.get("id"):
+            id_counts[resource["id"]] = id_counts.get(resource["id"], 0) + 1
+    duplicates = {id_ for id_, count in id_counts.items() if count > 1}
+    if not duplicates:
+        return resources
+
+    result = []
+    seen: dict[str, int] = {}
+    for resource in resources:
+        if resource.get("resourceType") != "Claim" or resource.get("id") not in duplicates:
+            result.append(resource)
+            continue
+
+        resource = copy.deepcopy(resource)
+        original_id = resource["id"]
+        enc_ref = ""
+        for item in resource.get("item", []):
+            for encounter in item.get("encounter", []):
+                ref = encounter.get("reference", "")
+                if ref:
+                    enc_ref = ref.split("/")[-1][:16]
+                    break
+            if enc_ref:
+                break
+
+        seen[original_id] = seen.get(original_id, 0) + 1
+        suffix = enc_ref or str(seen[original_id])
+        resource["id"] = f"{original_id}-{suffix}"
+        result.append(resource)
+    return result
+
+
 def _get_missing_valueset_stubs(bundle_json: dict[str, Any]) -> list[dict[str, Any]]:
     """Return empty ValueSet stubs for ELM-declared ValueSets omitted by the bundle.
 
@@ -410,6 +475,76 @@ def _get_missing_valueset_stubs(bundle_json: dict[str, Any]) -> list[dict[str, A
     return stubs
 
 
+def _get_codesystem_stubs_from_valuesets(
+    resources: list[dict[str, Any]], bundle_json: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Create CodeSystem fragments for explicit ValueSet concepts when MADiE omits them."""
+    existing_codesystems = {
+        (resource.get("url"), resource.get("version"))
+        for resource in resources
+        if resource.get("resourceType") == "CodeSystem" and resource.get("url")
+    }
+    concepts_by_system: dict[str, dict[str, str]] = {}
+    versions_by_system: dict[str, set[str | None]] = {}
+
+    def add_concept(system: str | None, code: str | None, display: str | None = None) -> None:
+        if not system or not code:
+            return
+        concepts_by_system.setdefault(system, {})
+        concepts_by_system[system].setdefault(code, display or "")
+
+    def scan_contains(nodes: list[dict[str, Any]]) -> None:
+        for node in nodes:
+            add_concept(node.get("system"), node.get("code"), node.get("display"))
+            if node.get("contains"):
+                scan_contains(node["contains"])
+
+    def scan_versions(value: Any) -> None:
+        if isinstance(value, dict):
+            system = value.get("system")
+            if system:
+                versions_by_system.setdefault(system, set()).add(value.get("version"))
+            for child in value.values():
+                scan_versions(child)
+        elif isinstance(value, list):
+            for child in value:
+                scan_versions(child)
+
+    scan_versions(bundle_json)
+
+    for resource in resources:
+        if resource.get("resourceType") != "ValueSet":
+            continue
+        for include in resource.get("compose", {}).get("include", []):
+            system = include.get("system")
+            for concept in include.get("concept", []):
+                add_concept(system, concept.get("code"), concept.get("display"))
+        scan_contains(resource.get("expansion", {}).get("contains", []))
+
+    stubs = []
+    for system, concepts in sorted(concepts_by_system.items()):
+        versions = versions_by_system.get(system) or {None}
+        for version in sorted(versions, key=lambda value: value or ""):
+            if (system, version) in existing_codesystems:
+                continue
+            digest = hashlib.sha1(f"{system}|{version or ''}".encode("utf-8")).hexdigest()[:16]
+            stub = {
+                "resourceType": "CodeSystem",
+                "id": f"generated-codesystem-{digest}",
+                "url": system,
+                "status": "active",
+                "content": "complete",
+                "concept": [
+                    {"code": code, **({"display": display} if display else {})}
+                    for code, display in sorted(concepts.items())
+                ],
+            }
+            if version:
+                stub["version"] = version
+            stubs.append(stub)
+    return stubs
+
+
 async def _find_existing_valueset_id(
     url: str,
     client: httpx.AsyncClient,
@@ -429,18 +564,54 @@ async def _find_existing_valueset_id(
     return entries[0].get("resource", {}).get("id")
 
 
+async def _find_existing_codesystem_id(
+    url: str,
+    version: str | None,
+    client: httpx.AsyncClient,
+) -> str | None:
+    """Return the existing HAPI CodeSystem resource ID for a canonical URL/version."""
+    params: dict[str, str | int] = {"url": url, "_count": 50, "_elements": "id,url,version"}
+    if version:
+        params["version"] = version
+    resp = await client.get(
+        f"{settings.MEASURE_ENGINE_URL}/CodeSystem",
+        params=params,
+        headers={"Cache-Control": "no-cache", "Accept": "application/fhir+json"},
+    )
+    resp.raise_for_status()
+    entries = resp.json().get("entry", [])
+    for entry in entries:
+        resource = entry.get("resource", {})
+        resource_version = resource.get("version")
+        if (version and resource_version == version) or (not version and not resource_version):
+            return resource.get("id")
+    return None
+
+
+async def _delete_existing_valueset(existing_id: str, client: httpx.AsyncClient) -> None:
+    """Delete a stale ValueSet so HAPI rebuilds terminology tables from patched compose."""
+    resp = await client.delete(f"{settings.MEASURE_ENGINE_URL}/ValueSet/{existing_id}")
+    if resp.status_code not in {200, 204, 404}:
+        resp.raise_for_status()
+
+
 async def _prepare_measure_support_resources(
     resources: list[dict[str, Any]],
     bundle_json: dict[str, Any],
 ) -> list[dict[str, Any]]:
     """Prepare ValueSets/CodeSystems for HAPI upload.
 
-    Adds missing ELM ValueSet stubs only when HAPI does not already have that
-    URL, and remaps ValueSet IDs to existing HAPI resources to avoid HAPI-0902
-    URL+version uniqueness conflicts silently dropping updates inside a batch.
+    Adds missing ELM ValueSet stubs only when HAPI does not already have that URL.
+    Existing ValueSets for uploaded bundle URLs are deleted before re-upload so HAPI
+    refreshes its terminology tables from the patched compose. A PUT update can leave
+    stale expansion state behind, which returns all-zero populations in jobs.
     """
     prepared = _fix_valueset_compose_for_hapi(resources)
     stubs = _get_missing_valueset_stubs(bundle_json)
+    codesystem_stubs = _get_codesystem_stubs_from_valuesets(prepared, bundle_json)
+    if codesystem_stubs:
+        prepared = [*codesystem_stubs, *prepared]
+        logger.info("Prepared generated CodeSystem stubs", extra={"count": len(codesystem_stubs)})
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         if stubs:
@@ -457,14 +628,32 @@ async def _prepare_measure_support_resources(
                 logger.info("Prepared missing ValueSet stubs", extra={"count": len(filtered_stubs)})
 
         aligned = []
+        deleted_valueset_urls: set[str] = set()
         for resource in prepared:
+            if resource.get("resourceType") == "CodeSystem" and resource.get("id", "").startswith(
+                "generated-codesystem-"
+            ):
+                existing_id = await _find_existing_codesystem_id(
+                    resource["url"],
+                    resource.get("version"),
+                    client,
+                )
+                if existing_id and existing_id != resource.get("id"):
+                    continue
+                aligned.append(resource)
+                continue
+
             if resource.get("resourceType") != "ValueSet" or not resource.get("url"):
                 aligned.append(resource)
                 continue
             existing_id = await _find_existing_valueset_id(resource["url"], client)
-            if existing_id and existing_id != resource.get("id"):
-                resource = copy.deepcopy(resource)
-                resource["id"] = existing_id
+            if existing_id and resource["url"] not in deleted_valueset_urls:
+                await _delete_existing_valueset(existing_id, client)
+                deleted_valueset_urls.add(resource["url"])
+                logger.info(
+                    "Deleted existing ValueSet before patched reload",
+                    extra={"valueset_id": existing_id, "valueset_url": resource["url"]},
+                )
             aligned.append(resource)
 
     return aligned
@@ -485,6 +674,8 @@ async def triage_test_bundle(
     """
     _warn_unknown_bundle_types(bundle_json)
     measure_defs, clinical, test_cases = _classify_bundle_entries(bundle_json)
+    measure_defs = _fix_library_deps_for_hapi(measure_defs)
+    clinical = _fix_duplicate_claim_ids(clinical)
 
     # Push measure definitions to measure engine in two phases so shared ValueSets
     # (which trigger HAPI-0902 on re-upload) never block the Measure/Library load.

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -468,7 +468,7 @@ async def test_get_comparison_httpx_exception_returns_no_expected(client, test_s
 
 
 async def test_get_comparison_patient_not_in_expected_skipped(client, test_session):
-    """Actual patients with no matching ExpectedResult are excluded from comparison output."""
+    """Actual patients with no matching ExpectedResult are counted but excluded from comparison rows."""
     from unittest.mock import AsyncMock, patch
 
     import httpx as _httpx
@@ -534,7 +534,64 @@ async def test_get_comparison_patient_not_in_expected_skipped(client, test_sessi
     assert data["has_expected"] is True
     # Only p1 appears — p2 had no expected result and was skipped
     assert data["total"] == 1
+    assert data["actual_total"] == 2
+    assert data["unexpected_results"] == 1
     assert data["patients"][0]["subject_reference"] == "Patient/p1"
+
+
+async def test_get_comparison_reports_missing_expected_patient_results(client, test_session):
+    """Expected patients without MeasureResult rows fail comparison instead of being hidden."""
+    from unittest.mock import AsyncMock, patch
+
+    import httpx as _httpx
+
+    from app.models.job import Job, JobStatus
+    from app.models.validation import ExpectedResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2019-01-01",
+        period_end="2019-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    test_session.add(
+        ExpectedResult(
+            measure_url="https://example.com/Measure/CMS124",
+            patient_ref="p1",
+            expected_populations={"initial-population": 0, "denominator": 0, "numerator": 0},
+            period_start="2019-01-01",
+            period_end="2019-12-31",
+            source_bundle="test",
+        )
+    )
+    await test_session.commit()
+
+    measure_json = {"resourceType": "Measure", "id": "CMS124", "url": "https://example.com/Measure/CMS124"}
+    mock_resp = _httpx.Response(200, json=measure_json, request=_httpx.Request("GET", "http://test"))
+
+    with patch("app.routes.jobs.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.get = AsyncMock(return_value=mock_resp)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.get(f"/jobs/{job.id}/comparison")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_expected"] is True
+    assert data["matched"] == 0
+    assert data["total"] == 1
+    assert data["expected_total"] == 1
+    assert data["actual_total"] == 0
+    assert data["missing_results"] == 1
+    assert data["patients"][0]["match"] is False
+    assert data["patients"][0]["mismatches"] == ["missing-result"]
 
 
 async def test_get_comparison_with_mismatch(client, test_session):

--- a/backend/tests/test_routes_results.py
+++ b/backend/tests/test_routes_results.py
@@ -73,6 +73,54 @@ async def test_get_results_with_population_counts(client, test_session):
     # Performance rate = 1/2 * 100 = 50.0
     assert data["performance_rate"] == 50.0
     assert len(data["patients"]) == 2
+    assert data["failed_patients"] == 0
+    assert data["patients"][0]["status"] == "success"
+
+
+async def test_get_results_includes_patient_evaluation_errors(client, test_session):
+    """GET /results includes failed patient rows without counting them in populations."""
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://example.com/fhir",
+        status=JobStatus.failed,
+        total_patients=1,
+        failed_patients=1,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    mr = MeasureResult(
+        job_id=job.id,
+        patient_id="patient-error",
+        patient_name="Patient Error",
+        measure_report={
+            "resourceType": "OperationOutcome",
+            "issue": [{"severity": "error", "code": "processing", "diagnostics": "HAPI returned 400"}],
+        },
+        populations={
+            "initial_population": False,
+            "denominator": False,
+            "numerator": False,
+            "denominator_exclusion": False,
+            "numerator_exclusion": False,
+            "error": True,
+            "error_message": "HAPI returned 400",
+        },
+    )
+    test_session.add(mr)
+    await test_session.commit()
+
+    resp = await client.get(f"/results?job_id={job.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_patients"] == 1
+    assert data["failed_patients"] == 1
+    assert data["populations"]["initial_population"] == 0
+    assert data["patients"][0]["status"] == "error"
+    assert data["patients"][0]["error_message"] == "HAPI returned 400"
 
 
 async def test_get_results_empty(client):

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -404,8 +404,8 @@ async def test_get_cdr_auth_headers_reads_from_job_row(test_session, session_fac
     mock_auth.assert_called_once_with("bearer", {"token": "test-jwt"})
 
 
-async def test_process_batch_uses_data_requirements_strategy(test_session, session_factory):
-    """_process_single_batch uses DataRequirementsStrategy by default."""
+async def test_process_batch_uses_everything_strategy(test_session, session_factory):
+    """_process_single_batch uses $everything by default for complete patient graphs."""
     from unittest.mock import MagicMock
 
     from app.models.job import Batch, BatchStatus
@@ -436,7 +436,7 @@ async def test_process_batch_uses_data_requirements_strategy(test_session, sessi
 
     with (
         _make_session_factory_patch(session_factory),
-        patch("app.services.orchestrator.DataRequirementsStrategy") as mock_strategy_cls,
+        patch("app.services.orchestrator.BatchQueryStrategy") as mock_strategy_cls,
         patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
         patch(
             "app.services.orchestrator.evaluate_measure",
@@ -469,4 +469,4 @@ async def test_process_batch_uses_data_requirements_strategy(test_session, sessi
             auth_headers={},
         )
 
-    mock_strategy_cls.assert_called_once_with("CMS999")
+    mock_strategy_cls.assert_called_once_with()

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.job import Job, JobStatus, MeasureResult
 from app.services.orchestrator import (
+    _error_measure_report,
     _extract_patient_name,
     _extract_populations,
     _get_cdr_auth_headers,
@@ -73,6 +74,16 @@ class TestExtractPatientName:
     def test_no_name(self):
         assert _extract_patient_name({}) is None
         assert _extract_patient_name({"name": []}) is None
+
+
+def test_error_measure_report_sanitizes_internal_urls():
+    report = _error_measure_report("p1", Exception("HTTP 400 at http://hapi-fhir-measure:8080/fhir"))
+
+    assert report["resourceType"] == "OperationOutcome"
+    assert report["subject"]["reference"] == "Patient/p1"
+    diagnostics = report["issue"][0]["diagnostics"]
+    assert "hapi-fhir-measure" not in diagnostics
+    assert "8080" not in diagnostics
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +166,7 @@ async def test_run_job_happy_path(test_session, session_factory, mock_measure_re
         assert results[0].patient_id == "p1"
         assert results[0].patient_name == "Alice Test"
 
-    mock_wipe.assert_called_once()
+    mock_wipe.assert_awaited_once_with(strict=False)
 
 
 async def test_run_job_no_patients(test_session, session_factory):
@@ -278,11 +289,62 @@ async def test_run_job_partial_patient_failure(test_session, session_factory, mo
         assert job.processed_patients == 1
         assert job.failed_patients == 1
 
-        # Only one result should be stored
+        # One successful result and one per-patient error result should be stored.
         result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
         results = result.scalars().all()
-        assert len(results) == 1
-        assert results[0].patient_id == "p1"
+        assert len(results) == 2
+        by_patient = {r.patient_id: r for r in results}
+        assert by_patient["p1"].populations.get("error") is None
+        assert by_patient["p2"].populations["error"] is True
+        assert "Evaluation failed for p2" in by_patient["p2"].populations["error_message"]
+
+
+async def test_run_job_all_patient_failures_marks_job_failed(test_session, session_factory):
+    """run_job: if every patient evaluation fails, the job must not look successful."""
+    job_id = await _setup_job(test_session)
+
+    patients = [
+        {"resourceType": "Patient", "id": "p1", "name": [{"given": ["Alice"], "family": "Bad"}]},
+        {"resourceType": "Patient", "id": "p2", "name": [{"given": ["Bob"], "family": "Bad"}]},
+    ]
+
+    with (
+        _make_session_factory_patch(session_factory),
+        patch("app.services.orchestrator.wipe_patient_data", new_callable=AsyncMock),
+        patch("app.services.orchestrator._get_cdr_auth_headers", new_callable=AsyncMock, return_value={}),
+        patch("app.services.orchestrator._get_cdr_url", new_callable=AsyncMock, return_value="http://cdr/fhir"),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patients",
+            new_callable=AsyncMock,
+            return_value=patients,
+        ),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patient_data",
+            new_callable=AsyncMock,
+            return_value=[{"resourceType": "Patient", "id": "p1"}],
+        ),
+        patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch(
+            "app.services.orchestrator.evaluate_measure",
+            new_callable=AsyncMock,
+            side_effect=Exception("HAPI returned 400"),
+        ),
+    ):
+        await run_job(job_id)
+
+    async with session_factory() as session:
+        job = await session.get(Job, job_id)
+        assert job.status == JobStatus.failed
+        assert job.processed_patients == 0
+        assert job.failed_patients == 2
+        assert job.error_message == "All 2 patient evaluations failed"
+
+        result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
+        results = result.scalars().all()
+        assert len(results) == 2
+        assert all(r.populations["error"] is True for r in results)
 
 
 async def test_run_job_cancelled_before_batches(test_session, session_factory):

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -14,6 +14,7 @@ from app.services.validation import (
     _extract_population_counts,
     _extract_test_case_info,
     _fix_valueset_compose_for_hapi,
+    _get_codesystem_stubs_from_valuesets,
     _get_missing_valueset_stubs,
     _is_test_case_measure_report,
     _prepare_measure_support_resources,
@@ -1358,6 +1359,42 @@ class TestMissingValueSetStubs:
         assert stubs[0]["resourceType"] == "ValueSet"
         assert stubs[0]["status"] == "active"
 
+    def test_get_codesystem_stubs_from_valuesets_uses_bundle_coding_versions(self):
+        valueset = {
+            "resourceType": "ValueSet",
+            "id": "payer",
+            "url": "http://cts.nlm.nih.gov/fhir/ValueSet/payer",
+            "compose": {
+                "include": [
+                    {
+                        "system": "https://nahdo.org/sopt",
+                        "concept": [{"code": "1", "display": "MEDICARE"}],
+                    }
+                ]
+            },
+        }
+        bundle = {
+            "resourceType": "Bundle",
+            "entry": [
+                {"resource": valueset},
+                {
+                    "resource": {
+                        "resourceType": "Coverage",
+                        "id": "coverage",
+                        "type": {"coding": [{"system": "https://nahdo.org/sopt", "version": "9.2", "code": "1"}]},
+                    }
+                },
+            ],
+        }
+
+        stubs = _get_codesystem_stubs_from_valuesets([valueset], bundle)
+
+        versioned_stub = next(stub for stub in stubs if stub.get("version") == "9.2")
+        assert versioned_stub["resourceType"] == "CodeSystem"
+        assert versioned_stub["url"] == "https://nahdo.org/sopt"
+        assert versioned_stub["content"] == "complete"
+        assert versioned_stub["concept"] == [{"code": "1", "display": "MEDICARE"}]
+
     async def test_prepare_measure_support_resources_adds_missing_stubs(self):
         missing_url = "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3"
         bundle = self._bundle_with_elm([missing_url])
@@ -1399,7 +1436,7 @@ class TestMissingValueSetStubs:
 
         assert prepared == []
 
-    async def test_prepare_measure_support_resources_remaps_existing_valueset_id(self):
+    async def test_prepare_measure_support_resources_deletes_existing_valueset_before_reload(self):
         valueset = {
             "resourceType": "ValueSet",
             "id": "bundle-id",
@@ -1414,8 +1451,12 @@ class TestMissingValueSetStubs:
             "resourceType": "Bundle",
             "entry": [{"resource": {"resourceType": "ValueSet", "id": "existing-id", "url": valueset["url"]}}],
         }
+        mock_delete_response = MagicMock()
+        mock_delete_response.status_code = 204
+        mock_delete_response.raise_for_status = MagicMock()
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.delete = AsyncMock(return_value=mock_delete_response)
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
@@ -1423,5 +1464,8 @@ class TestMissingValueSetStubs:
         with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
             prepared = await _prepare_measure_support_resources([valueset], bundle)
 
-        assert prepared[0]["id"] == "existing-id"
+        mock_client.delete.assert_awaited_once()
+        assert str(mock_client.delete.await_args.args[0]).endswith("/ValueSet/existing-id")
+        prepared_valueset = next(resource for resource in prepared if resource.get("resourceType") == "ValueSet")
+        assert prepared_valueset["id"] == "bundle-id"
         assert valueset["id"] == "bundle-id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.enforce_referential_integrity_on_write=false
+      # Connectathon ValueSets exceed HAPI's default expansion limit of 1000.
+      # Keep the product stack aligned with the integration harness.
+      - hapi.fhir.maximum_expansion_size=50000
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
       - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
@@ -88,7 +91,10 @@ services:
       - hapi.fhir.reuse_cached_search_results_millis=0
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_multiple_delete=true
+      - hapi.fhir.allow_external_references=true
       - hapi.fhir.cr.enabled=true
+      - hapi.fhir.enforce_referential_integrity_on_write=false
+      - hapi.fhir.maximum_expansion_size=50000
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
       - spring.jpa.properties.hibernate.search.enabled=true
@@ -96,6 +102,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
       - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+      - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
       - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m
 
   seed:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -83,9 +83,10 @@ Integration tests are marked `@pytest.mark.integration` and live in `backend/tes
 | `test_connectathon_measures.py` | Parametrized per-test-case run across all connectathon bundles; skipped on the PR gate and included in the nightly source-of-truth job |
 | `test_full_workflow.py` | Full-stack pipeline covering job orchestration → measure eval → result storage; skipped on the PR gate and run in its own clean nightly job |
 
-The nightly `connectathon-measures.yml` workflow still runs once per night, but it now uses two clean jobs:
+The nightly `connectathon-measures.yml` workflow still runs once per night, but it now uses three clean jobs:
 - `source-of-truth` runs `test_golden_measures.py` and `test_connectathon_measures.py`.
 - `full-workflow` runs `test_full_workflow.py` by itself so it does not inherit the connectathon-loaded CDR state.
+- `jobs-workflow` starts the product Docker API stack and runs documented-pass connectathon measures through the real `/validation/upload-bundle` → `/jobs` → `/jobs/{id}/comparison` path. This catches product-path regressions that direct HAPI `$evaluate-measure` tests can miss.
 
 ---
 

--- a/frontend/src/components/PatientDetail.js
+++ b/frontend/src/components/PatientDetail.js
@@ -137,6 +137,7 @@ export default function PatientDetail({ result, onClose }) {
   ];
 
   const patientName = result.patient_name || result.patient_id || 'Unknown Patient';
+  const evaluationError = result.error_message || result.populations?.error_message;
 
   return (
     <div className={styles.overlay} onClick={onClose} role="dialog" aria-label={`Patient details for ${patientName}`}>
@@ -152,9 +153,14 @@ export default function PatientDetail({ result, onClose }) {
         {/* Population membership */}
         <section className={styles.section}>
           <h3 className={styles.sectionTitle}>Population Membership</h3>
+          {evaluationError && (
+            <div className={styles.error}>
+              <p>Evaluation failed: {evaluationError}</p>
+            </div>
+          )}
           <ul className={styles.populationList}>
             {populations.map(pop => {
-              const inPop = result[pop.key];
+              const inPop = result[pop.key] ?? result.populations?.[pop.key];
               if (inPop === undefined) return null;
               return (
                 <li key={pop.key} className={styles.populationItem}>

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -184,8 +184,10 @@ export default function JobsPage() {
 
   const getProgress = (job) => {
     if (job.progress !== undefined && job.progress !== null) return job.progress;
-    if (job.patients_processed && job.total_patients) {
-      return Math.round((job.patients_processed / job.total_patients) * 100);
+    const processedPatients = job.processed_patients ?? job.patients_processed ?? 0;
+    const failedPatients = job.failed_patients ?? 0;
+    if (job.total_patients) {
+      return Math.round(((processedPatients + failedPatients) / job.total_patients) * 100);
     }
     return 0;
   };
@@ -262,7 +264,10 @@ export default function JobsPage() {
                   const running = isRunning(job.status);
                   const progress = getProgress(job);
                   const completed = (job.status || '').toLowerCase() === 'completed' || (job.status || '').toLowerCase() === 'complete';
+                  const failed = (job.status || '').toLowerCase() === 'failed';
                   const deleting = job.delete_requested || deletingJobIds.includes(job.id);
+                  const processedPatients = job.processed_patients ?? job.patients_processed;
+                  const hasStoredResults = (processedPatients || 0) + (job.failed_patients || 0) > 0;
 
                   return (
                     <tr key={job.id}>
@@ -282,9 +287,10 @@ export default function JobsPage() {
                           <div className={styles.progressInfo}>
                             <ProgressBar value={progress} max={100} size="sm" />
                             <div className={styles.progressMeta}>
-                              {job.patients_processed !== undefined && job.total_patients !== undefined && (
-                                <span>{job.patients_processed.toLocaleString()} / {job.total_patients.toLocaleString()} patients</span>
+                              {processedPatients !== undefined && job.total_patients !== undefined && (
+                                <span>{processedPatients.toLocaleString()} / {job.total_patients.toLocaleString()} patients</span>
                               )}
+                              {job.failed_patients > 0 && <span>{job.failed_patients.toLocaleString()} failed</span>}
                               {job.batches_completed !== undefined && job.total_batches !== undefined && (
                                 <span>{job.batches_completed}/{job.total_batches} batches</span>
                               )}
@@ -296,6 +302,13 @@ export default function JobsPage() {
                           </div>
                         ) : completed ? (
                           <span className={styles.completedText}>100%</span>
+                        ) : failed && hasStoredResults ? (
+                          <div className={styles.progressMeta}>
+                            {processedPatients !== undefined && job.total_patients !== undefined && (
+                              <span>{processedPatients.toLocaleString()} / {job.total_patients.toLocaleString()} patients</span>
+                            )}
+                            {job.failed_patients > 0 && <span>{job.failed_patients.toLocaleString()} failed</span>}
+                          </div>
                         ) : (
                           '--'
                         )}
@@ -312,7 +325,7 @@ export default function JobsPage() {
                               Cancel
                             </button>
                           )}
-                          {completed && !deleting && (
+                          {(completed || (failed && hasStoredResults)) && !deleting && (
                             <Link to={`/results/${job.id}`} className={styles.viewLink}>
                               View Results
                             </Link>

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -35,7 +35,7 @@ export default function ResultsPage() {
   const [patientDetail, setPatientDetail] = useState(null);
   const [detailLoading, setDetailLoading] = useState(false);
 
-  // Load completed jobs for dropdown
+  // Load completed and failed jobs for dropdown; failed jobs can carry per-patient error rows.
   useEffect(() => {
     async function loadJobs() {
       try {
@@ -43,7 +43,7 @@ export default function ResultsPage() {
         const all = Array.isArray(data) ? data : data.jobs || [];
         const completed = all.filter(j => {
           const s = (j.status || '').toLowerCase();
-          return s === 'completed' || s === 'complete';
+          return s === 'completed' || s === 'complete' || s === 'failed';
         });
         setJobs(completed);
         const preferredId = routeJobId || selectedJobId;
@@ -136,6 +136,7 @@ export default function ResultsPage() {
   const numerator = populations.numerator;
   const denomExclusion = populations.denominator_exclusion;
   const performanceRate = results?.performance_rate;
+  const failedPatients = results?.failed_patients || selectedJob?.failed_patients || 0;
 
   return (
     <div className={styles.page}>
@@ -175,16 +176,18 @@ export default function ResultsPage() {
                 <tr>
                   <th>Patient ID</th>
                   <th>Name</th>
+                  <th>Status</th>
                   <th>Initial Pop</th>
                   <th>Denominator</th>
                   <th>Numerator</th>
+                  <th>Error</th>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {[1, 2, 3, 4, 5].map(i => (
                   <tr key={i}>
-                    {[1, 2, 3, 4, 5, 6].map(j => (
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map(j => (
                       <td key={j}><div className={`skeleton ${styles.skeletonCell}`} /></td>
                     ))}
                   </tr>
@@ -221,6 +224,9 @@ export default function ResultsPage() {
               {measureName && <h2 className={styles.measureName}>{measureName}</h2>}
               {period && <p className={styles.period}>Period: {period}</p>}
               {selectedJob?.cdr_name && <p className={styles.cdr}>CDR: {selectedJob.cdr_name}</p>}
+              {failedPatients > 0 && (
+                <p className={styles.errorSummary}>{failedPatients.toLocaleString()} patient evaluations failed.</p>
+              )}
             </div>
           )}
 
@@ -251,45 +257,59 @@ export default function ResultsPage() {
                 <tr>
                   <th>Patient ID</th>
                   <th>Name</th>
+                  <th>Status</th>
                   <th>Initial Pop</th>
                   <th>Denominator</th>
                   <th>Numerator</th>
+                  <th>Error</th>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {(Array.isArray(patients) ? patients : []).length === 0 ? (
                   <tr>
-                    <td colSpan={6} className={styles.emptyRow}>
+                    <td colSpan={8} className={styles.emptyRow}>
                       No individual patient results available.
                     </td>
                   </tr>
                 ) : (
-                  patients.map((patient, i) => (
-                    <tr key={patient.patient_id || patient.id || i}>
-                      <td className={styles.patientId}>
-                        {patient.patient_id || patient.id || '--'}
-                      </td>
-                      <td>{patient.patient_name || patient.name || '--'}</td>
-                      <td className={styles.boolCell}>
-                        {patient.populations?.initial_population ? <CheckMark /> : <CrossMark />}
-                      </td>
-                      <td className={styles.boolCell}>
-                        {patient.populations?.denominator ? <CheckMark /> : <CrossMark />}
-                      </td>
-                      <td className={styles.boolCell}>
-                        {patient.populations?.numerator ? <CheckMark /> : <CrossMark />}
-                      </td>
-                      <td>
-                        <button
-                          className={styles.detailBtn}
-                          onClick={() => handleViewPatient(patient)}
-                        >
-                          View Details
-                        </button>
-                      </td>
-                    </tr>
-                  ))
+                  patients.map((patient, i) => {
+                    const hasError = patient.status === 'error' || patient.populations?.error;
+
+                    return (
+                      <tr key={patient.patient_id || patient.id || i}>
+                        <td className={styles.patientId}>
+                          {patient.patient_id || patient.id || '--'}
+                        </td>
+                        <td>{patient.patient_name || patient.name || '--'}</td>
+                        <td>
+                          <span className={hasError ? styles.errorBadge : styles.successBadge}>
+                            {hasError ? 'Error' : 'Success'}
+                          </span>
+                        </td>
+                        <td className={styles.boolCell}>
+                          {hasError ? '--' : (patient.populations?.initial_population ? <CheckMark /> : <CrossMark />)}
+                        </td>
+                        <td className={styles.boolCell}>
+                          {hasError ? '--' : (patient.populations?.denominator ? <CheckMark /> : <CrossMark />)}
+                        </td>
+                        <td className={styles.boolCell}>
+                          {hasError ? '--' : (patient.populations?.numerator ? <CheckMark /> : <CrossMark />)}
+                        </td>
+                        <td className={styles.errorMessage} title={patient.error_message || undefined}>
+                          {patient.error_message || '--'}
+                        </td>
+                        <td>
+                          <button
+                            className={styles.detailBtn}
+                            onClick={() => handleViewPatient(patient)}
+                          >
+                            View Details
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
                 )}
               </tbody>
             </table>

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -53,6 +53,13 @@
   color: var(--color-text-secondary);
 }
 
+.errorSummary {
+  font-size: var(--font-size-body);
+  color: var(--color-error);
+  font-weight: var(--font-weight-semibold);
+  margin-top: var(--space-1);
+}
+
 /* Population cards */
 .cardsRow {
   display: flex;
@@ -153,6 +160,34 @@
 
 .cross {
   color: var(--color-text-tertiary);
+}
+
+.successBadge,
+.errorBadge {
+  display: inline-block;
+  padding: 2px var(--space-2);
+  border-radius: 100px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.successBadge {
+  background: var(--color-success-light);
+  color: var(--color-success);
+}
+
+.errorBadge {
+  background: var(--color-error-light);
+  color: var(--color-error);
+}
+
+.errorMessage {
+  max-width: 280px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .detailBtn {

--- a/scripts/compare_connectathon_jobs_local_vs_prod.py
+++ b/scripts/compare_connectathon_jobs_local_vs_prod.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Compare real Connectathon Jobs results between local and production MCT2 APIs.
+
+For each manifest measure, this script:
+  1. Uploads the measure bundle to both environments.
+  2. Adds/replaces a FHIR Group containing that bundle's Patient resources.
+  3. Starts a real /jobs calculation using the measure id and that Group.
+  4. Polls /jobs/{id} to a terminal state.
+  5. Fetches /results?job_id={id} and writes patient-level diff artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "seed" / "connectathon-bundles" / "manifest.json"
+TERMINAL_JOB_STATUSES = {"complete", "completed", "failed", "cancelled", "canceled"}
+
+
+def _normalize_base_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _http_json(
+    method: str,
+    url: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> Any:
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code} {body[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {url} failed: {exc.reason}") from exc
+
+
+def _multipart_body(field_name: str, filename: str, content: bytes) -> tuple[bytes, str]:
+    boundary = f"codex-{uuid.uuid4().hex}"
+    parts = [
+        f"--{boundary}\r\n".encode("utf-8"),
+        (
+            f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+            "Content-Type: application/json\r\n\r\n"
+        ).encode("utf-8"),
+        content,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode("utf-8"),
+    ]
+    return b"".join(parts), boundary
+
+
+def _bundle_resources(bundle: dict[str, Any], resource_type: str) -> list[dict[str, Any]]:
+    return [
+        entry.get("resource", {})
+        for entry in bundle.get("entry", [])
+        if entry.get("resource", {}).get("resourceType") == resource_type
+    ]
+
+
+def _measure_id_from_bundle(bundle: dict[str, Any]) -> str:
+    measures = _bundle_resources(bundle, "Measure")
+    if not measures or not measures[0].get("id"):
+        raise ValueError("Bundle does not contain a Measure resource with an id")
+    return str(measures[0]["id"])
+
+
+def _bundle_with_patient_group(bundle_path: Path, group_id: str) -> bytes:
+    """Return bundle JSON bytes with a Group/{group_id} for all bundle patients."""
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle = copy.deepcopy(bundle)
+    patients = [p for p in _bundle_resources(bundle, "Patient") if p.get("id")]
+    group = {
+        "resourceType": "Group",
+        "id": group_id,
+        "type": "person",
+        "actual": True,
+        "name": group_id,
+        "member": [{"entity": {"reference": f"Patient/{patient['id']}"}} for patient in patients],
+    }
+
+    replaced = False
+    for entry in bundle.get("entry", []):
+        resource = entry.get("resource", {})
+        if resource.get("resourceType") == "Group" and resource.get("id") == group_id:
+            entry["resource"] = group
+            replaced = True
+            break
+
+    if not replaced:
+        bundle.setdefault("entry", []).append(
+            {
+                "resource": group,
+                "request": {
+                    "method": "PUT",
+                    "url": f"Group/{group_id}",
+                },
+            }
+        )
+
+    return json.dumps(bundle, separators=(",", ":")).encode("utf-8")
+
+
+def upload_bundle(api_base: str, bundle_path: Path, group_id: str) -> int:
+    content = _bundle_with_patient_group(bundle_path, group_id)
+    body, boundary = _multipart_body("file", bundle_path.name, content)
+    response = _http_json(
+        "POST",
+        f"{api_base}/validation/upload-bundle",
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    return int(response["id"])
+
+
+def wait_for_upload(api_base: str, upload_id: int, timeout_seconds: int, poll_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        response = _http_json("GET", f"{api_base}/validation/uploads")
+        for upload in response.get("uploads", []):
+            if upload.get("id") != upload_id:
+                continue
+            status = upload.get("status")
+            if status in {"complete", "failed"}:
+                return upload
+            break
+        time.sleep(poll_seconds)
+    raise TimeoutError(f"Upload {upload_id} did not finish within {timeout_seconds}s on {api_base}")
+
+
+def create_job(api_base: str, measure_id: str, group_id: str, period: dict[str, str]) -> int:
+    response = _http_json(
+        "POST",
+        f"{api_base}/jobs",
+        json_body={
+            "measure_id": measure_id,
+            "group_id": group_id,
+            "period_start": period["start"],
+            "period_end": period["end"],
+        },
+    )
+    return int(response["id"])
+
+
+def wait_for_job(api_base: str, job_id: int, timeout_seconds: int, poll_seconds: int) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        job = _http_json("GET", f"{api_base}/jobs/{job_id}")
+        if str(job.get("status", "")).lower() in TERMINAL_JOB_STATUSES:
+            return job
+        time.sleep(poll_seconds)
+    raise TimeoutError(f"Job {job_id} did not finish within {timeout_seconds}s on {api_base}")
+
+
+def get_results(api_base: str, job_id: int) -> dict[str, Any]:
+    return _http_json("GET", f"{api_base}/results?job_id={job_id}")
+
+
+def normalize_job_result(job: dict[str, Any], results: dict[str, Any]) -> dict[str, Any]:
+    patients = {}
+    for patient in results.get("patients", []):
+        patient_id = patient.get("patient_id") or patient.get("id")
+        if not patient_id:
+            continue
+        populations = patient.get("populations") or {}
+        patients[patient_id] = {
+            "patient_name": patient.get("patient_name"),
+            "status": patient.get("status") or ("error" if populations.get("error") else "success"),
+            "populations": {
+                "initial_population": bool(populations.get("initial_population")),
+                "denominator": bool(populations.get("denominator")),
+                "numerator": bool(populations.get("numerator")),
+                "denominator_exclusion": bool(populations.get("denominator_exclusion")),
+                "numerator_exclusion": bool(populations.get("numerator_exclusion")),
+            },
+            "error": bool(populations.get("error")),
+            "error_message": patient.get("error_message") or populations.get("error_message"),
+        }
+
+    return {
+        "job": {
+            "id": job.get("id"),
+            "status": job.get("status"),
+            "error_message": job.get("error_message"),
+            "total_patients": job.get("total_patients"),
+            "processed_patients": job.get("processed_patients"),
+            "failed_patients": job.get("failed_patients"),
+        },
+        "results": {
+            "total_patients": results.get("total_patients"),
+            "failed_patients": results.get("failed_patients"),
+            "populations": results.get("populations") or {},
+            "performance_rate": results.get("performance_rate"),
+            "patients": patients,
+        },
+    }
+
+
+def compare_normalized(local: dict[str, Any], production: dict[str, Any]) -> dict[str, Any]:
+    local_patients = local["results"]["patients"]
+    production_patients = production["results"]["patients"]
+    patient_ids = sorted(set(local_patients) | set(production_patients))
+
+    patient_diffs = []
+    for patient_id in patient_ids:
+        local_patient = local_patients.get(patient_id)
+        production_patient = production_patients.get(patient_id)
+        if local_patient == production_patient:
+            continue
+        patient_diffs.append(
+            {
+                "patient_id": patient_id,
+                "local": local_patient,
+                "production": production_patient,
+            }
+        )
+
+    local_job = local["job"]
+    production_job = production["job"]
+    job_counts_match = {
+        key: local_job.get(key) == production_job.get(key)
+        for key in ("status", "total_patients", "processed_patients", "failed_patients")
+    }
+    aggregate_match = local["results"] == production["results"] or (
+        local["results"].get("total_patients") == production["results"].get("total_patients")
+        and local["results"].get("failed_patients") == production["results"].get("failed_patients")
+        and local["results"].get("populations") == production["results"].get("populations")
+        and local["results"].get("performance_rate") == production["results"].get("performance_rate")
+        and len(patient_diffs) == 0
+    )
+
+    return {
+        "matches": all(job_counts_match.values()) and aggregate_match,
+        "job_counts_match": job_counts_match,
+        "patient_diff_count": len(patient_diffs),
+        "patient_diffs": patient_diffs,
+        "local_job": local_job,
+        "production_job": production_job,
+        "local_results_summary": {
+            key: local["results"].get(key)
+            for key in ("total_patients", "failed_patients", "populations", "performance_rate")
+        },
+        "production_results_summary": {
+            key: production["results"].get(key)
+            for key in ("total_patients", "failed_patients", "populations", "performance_rate")
+        },
+    }
+
+
+def markdown_for_measure(measure_id: str, measure_fhir_id: str, group_id: str, comparison: dict[str, Any]) -> str:
+    lines = [
+        f"# {measure_id}",
+        "",
+        f"- Measure FHIR id: `{measure_fhir_id}`",
+        f"- Group id: `{group_id}`",
+        f"- Match: `{'yes' if comparison['matches'] else 'no'}`",
+        f"- Patient diffs: `{comparison['patient_diff_count']}`",
+        "",
+        "## Job Counts",
+        "",
+        "| Environment | Job ID | Status | Total | Processed | Failed |",
+        "|---|---:|---|---:|---:|---:|",
+    ]
+    for label, key in (("Local", "local_job"), ("Production", "production_job")):
+        job = comparison[key]
+        lines.append(
+            f"| {label} | {job.get('id')} | {job.get('status')} | {job.get('total_patients')} | "
+            f"{job.get('processed_patients')} | {job.get('failed_patients')} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Result Aggregates",
+            "",
+            "| Environment | Result Rows | Failed Rows | Initial Pop | Denominator | Numerator | Denom Excl | Perf Rate |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for label, key in (("Local", "local_results_summary"), ("Production", "production_results_summary")):
+        result = comparison[key]
+        pops = result.get("populations") or {}
+        lines.append(
+            f"| {label} | {result.get('total_patients')} | {result.get('failed_patients')} | "
+            f"{pops.get('initial_population')} | {pops.get('denominator')} | {pops.get('numerator')} | "
+            f"{pops.get('denominator_exclusion')} | {result.get('performance_rate')} |"
+        )
+
+    if comparison["patient_diffs"]:
+        lines.extend(["", "## Patient Diffs", ""])
+        for diff in comparison["patient_diffs"][:50]:
+            lines.append(f"### `{diff['patient_id']}`")
+            lines.append("")
+            lines.append(f"- Local: `{json.dumps(diff['local'], sort_keys=True)}`")
+            lines.append(f"- Production: `{json.dumps(diff['production'], sort_keys=True)}`")
+            lines.append("")
+        if len(comparison["patient_diffs"]) > 50:
+            lines.append(f"Only first 50 of {len(comparison['patient_diffs'])} diffs shown.")
+            lines.append("")
+    else:
+        lines.extend(["", "## Patient Diffs", "", "No patient-level differences detected.", ""])
+
+    return "\n".join(lines)
+
+
+def summary_markdown(results: list[dict[str, Any]]) -> str:
+    lines = [
+        "# Connectathon Jobs Local vs Production Summary",
+        "",
+        "| Measure | Match | Local status | Production status | Local rows | Production rows | Patient diffs |",
+        "|---|---|---|---|---:|---:|---:|",
+    ]
+    for result in results:
+        comparison = result["comparison"]
+        lines.append(
+            f"| {result['measure_id']} | {'yes' if comparison['matches'] else 'no'} | "
+            f"{comparison['local_job'].get('status')} | {comparison['production_job'].get('status')} | "
+            f"{comparison['local_results_summary'].get('total_patients')} | "
+            f"{comparison['production_results_summary'].get('total_patients')} | "
+            f"{comparison['patient_diff_count']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--local-api-base", default="http://localhost:8000")
+    parser.add_argument("--production-api-base", default="https://api.98-89-219-217.nip.io")
+    parser.add_argument("--manifest", default=str(MANIFEST_PATH))
+    parser.add_argument("--measure-id", help="Optional manifest measure id to run")
+    parser.add_argument(
+        "--output-dir",
+        default=str(REPO_ROOT / "artifacts" / "connectathon-jobs-local-vs-prod"),
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--poll-seconds", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = Path(args.manifest)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    measures = manifest.get("measures", [])
+    if args.measure_id:
+        measures = [m for m in measures if m.get("id") == args.measure_id]
+        if not measures:
+            raise SystemExit(f"Measure id not found in manifest: {args.measure_id}")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    local_api = _normalize_base_url(args.local_api_base)
+    production_api = _normalize_base_url(args.production_api_base)
+
+    all_results = []
+    for measure in measures:
+        measure_id = measure["id"]
+        bundle_path = manifest_path.parent / measure["bundle_file"]
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        measure_fhir_id = _measure_id_from_bundle(bundle)
+        group_id = measure_fhir_id
+
+        print(f"[measure] {measure_id} measure={measure_fhir_id} group={group_id}", flush=True)
+
+        local_upload_id = upload_bundle(local_api, bundle_path, group_id)
+        production_upload_id = upload_bundle(production_api, bundle_path, group_id)
+        local_upload = wait_for_upload(local_api, local_upload_id, args.timeout_seconds, args.poll_seconds)
+        production_upload = wait_for_upload(production_api, production_upload_id, args.timeout_seconds, args.poll_seconds)
+
+        local_job_id = create_job(local_api, measure_fhir_id, group_id, measure["period"])
+        production_job_id = create_job(production_api, measure_fhir_id, group_id, measure["period"])
+
+        local_job = wait_for_job(local_api, local_job_id, args.timeout_seconds, args.poll_seconds)
+        production_job = wait_for_job(production_api, production_job_id, args.timeout_seconds, args.poll_seconds)
+
+        local_results = get_results(local_api, local_job_id)
+        production_results = get_results(production_api, production_job_id)
+
+        normalized_local = normalize_job_result(local_job, local_results)
+        normalized_production = normalize_job_result(production_job, production_results)
+        comparison = compare_normalized(normalized_local, normalized_production)
+
+        payload = {
+            "measure_id": measure_id,
+            "measure_fhir_id": measure_fhir_id,
+            "group_id": group_id,
+            "bundle_file": measure["bundle_file"],
+            "local_upload": local_upload,
+            "production_upload": production_upload,
+            "local": normalized_local,
+            "production": normalized_production,
+            "comparison": comparison,
+        }
+        all_results.append(payload)
+
+        (output_dir / f"{measure_id}.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        (output_dir / f"{measure_id}.md").write_text(
+            markdown_for_measure(measure_id, measure_fhir_id, group_id, comparison),
+            encoding="utf-8",
+        )
+
+    summary_payload = {"generated_at_epoch": int(time.time()), "results": all_results}
+    (output_dir / "summary.json").write_text(json.dumps(summary_payload, indent=2, sort_keys=True), encoding="utf-8")
+    (output_dir / "summary.md").write_text(summary_markdown(all_results), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/compare_connectathon_jobs_local_vs_prod.py
+++ b/scripts/compare_connectathon_jobs_local_vs_prod.py
@@ -180,7 +180,52 @@ def get_results(api_base: str, job_id: int) -> dict[str, Any]:
     return _http_json("GET", f"{api_base}/results?job_id={job_id}")
 
 
-def normalize_job_result(job: dict[str, Any], results: dict[str, Any]) -> dict[str, Any]:
+def get_job_comparison(api_base: str, job_id: int) -> dict[str, Any]:
+    return _http_json("GET", f"{api_base}/jobs/{job_id}/comparison")
+
+
+def normalize_expected_comparison(comparison: dict[str, Any]) -> dict[str, Any]:
+    patients = {}
+    for patient in comparison.get("patients", []):
+        subject_reference = patient.get("subject_reference") or ""
+        patient_id = subject_reference.removeprefix("Patient/") or subject_reference
+        if not patient_id:
+            continue
+        patients[patient_id] = {
+            "match": bool(patient.get("match")),
+            "mismatches": sorted(patient.get("mismatches") or []),
+            "expected": patient.get("expected") or {},
+            "actual": patient.get("actual") or {},
+        }
+
+    return {
+        "has_expected": bool(comparison.get("has_expected")),
+        "matched": comparison.get("matched"),
+        "total": comparison.get("total"),
+        "expected_total": comparison.get("expected_total", comparison.get("total")),
+        "actual_total": comparison.get("actual_total"),
+        "missing_results": comparison.get("missing_results", 0),
+        "unexpected_results": comparison.get("unexpected_results", 0),
+        "patients": patients,
+    }
+
+
+def expected_comparison_passed(comparison: dict[str, Any]) -> bool:
+    return (
+        comparison.get("has_expected") is True
+        and comparison.get("total") is not None
+        and comparison.get("matched") == comparison.get("total")
+        and comparison.get("total") == comparison.get("expected_total")
+        and comparison.get("missing_results", 0) == 0
+        and comparison.get("unexpected_results", 0) == 0
+    )
+
+
+def normalize_job_result(
+    job: dict[str, Any],
+    results: dict[str, Any],
+    expected_comparison: dict[str, Any],
+) -> dict[str, Any]:
     patients = {}
     for patient in results.get("patients", []):
         patient_id = patient.get("patient_id") or patient.get("id")
@@ -217,6 +262,7 @@ def normalize_job_result(job: dict[str, Any], results: dict[str, Any]) -> dict[s
             "performance_rate": results.get("performance_rate"),
             "patients": patients,
         },
+        "expected_comparison": normalize_expected_comparison(expected_comparison),
     }
 
 
@@ -239,6 +285,23 @@ def compare_normalized(local: dict[str, Any], production: dict[str, Any]) -> dic
             }
         )
 
+    local_expected = local["expected_comparison"]
+    production_expected = production["expected_comparison"]
+    expected_patient_ids = sorted(set(local_expected["patients"]) | set(production_expected["patients"]))
+    expected_patient_diffs = []
+    for patient_id in expected_patient_ids:
+        local_patient = local_expected["patients"].get(patient_id)
+        production_patient = production_expected["patients"].get(patient_id)
+        if local_patient == production_patient:
+            continue
+        expected_patient_diffs.append(
+            {
+                "patient_id": patient_id,
+                "local": local_patient,
+                "production": production_patient,
+            }
+        )
+
     local_job = local["job"]
     production_job = production["job"]
     job_counts_match = {
@@ -252,12 +315,30 @@ def compare_normalized(local: dict[str, Any], production: dict[str, Any]) -> dic
         and local["results"].get("performance_rate") == production["results"].get("performance_rate")
         and len(patient_diffs) == 0
     )
+    expected_summary_match = {
+        key: local_expected.get(key) == production_expected.get(key)
+        for key in (
+            "has_expected",
+            "matched",
+            "total",
+            "expected_total",
+            "actual_total",
+            "missing_results",
+            "unexpected_results",
+        )
+    }
 
     return {
-        "matches": all(job_counts_match.values()) and aggregate_match,
+        "matches": all(job_counts_match.values()) and aggregate_match and all(expected_summary_match.values())
+        and len(expected_patient_diffs) == 0,
         "job_counts_match": job_counts_match,
+        "expected_summary_match": expected_summary_match,
         "patient_diff_count": len(patient_diffs),
         "patient_diffs": patient_diffs,
+        "expected_patient_diff_count": len(expected_patient_diffs),
+        "expected_patient_diffs": expected_patient_diffs,
+        "local_expected_passed": expected_comparison_passed(local_expected),
+        "production_expected_passed": expected_comparison_passed(production_expected),
         "local_job": local_job,
         "production_job": production_job,
         "local_results_summary": {
@@ -267,6 +348,30 @@ def compare_normalized(local: dict[str, Any], production: dict[str, Any]) -> dic
         "production_results_summary": {
             key: production["results"].get(key)
             for key in ("total_patients", "failed_patients", "populations", "performance_rate")
+        },
+        "local_expected_summary": {
+            key: local_expected.get(key)
+            for key in (
+                "has_expected",
+                "matched",
+                "total",
+                "expected_total",
+                "actual_total",
+                "missing_results",
+                "unexpected_results",
+            )
+        },
+        "production_expected_summary": {
+            key: production_expected.get(key)
+            for key in (
+                "has_expected",
+                "matched",
+                "total",
+                "expected_total",
+                "actual_total",
+                "missing_results",
+                "unexpected_results",
+            )
         },
     }
 
@@ -278,7 +383,10 @@ def markdown_for_measure(measure_id: str, measure_fhir_id: str, group_id: str, c
         f"- Measure FHIR id: `{measure_fhir_id}`",
         f"- Group id: `{group_id}`",
         f"- Match: `{'yes' if comparison['matches'] else 'no'}`",
+        f"- Local expected pass: `{'yes' if comparison['local_expected_passed'] else 'no'}`",
+        f"- Production expected pass: `{'yes' if comparison['production_expected_passed'] else 'no'}`",
         f"- Patient diffs: `{comparison['patient_diff_count']}`",
+        f"- Expected comparison diffs: `{comparison['expected_patient_diff_count']}`",
         "",
         "## Job Counts",
         "",
@@ -310,6 +418,23 @@ def markdown_for_measure(measure_id: str, measure_fhir_id: str, group_id: str, c
             f"{pops.get('denominator_exclusion')} | {result.get('performance_rate')} |"
         )
 
+    lines.extend(
+        [
+            "",
+            "## Expected Comparison",
+            "",
+            "| Environment | Has Expected | Matched | Total | Expected Total | Actual Total | Missing | Unexpected |",
+            "|---|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for label, key in (("Local", "local_expected_summary"), ("Production", "production_expected_summary")):
+        expected = comparison[key]
+        lines.append(
+            f"| {label} | {expected.get('has_expected')} | {expected.get('matched')} | {expected.get('total')} | "
+            f"{expected.get('expected_total')} | {expected.get('actual_total')} | "
+            f"{expected.get('missing_results')} | {expected.get('unexpected_results')} |"
+        )
+
     if comparison["patient_diffs"]:
         lines.extend(["", "## Patient Diffs", ""])
         for diff in comparison["patient_diffs"][:50]:
@@ -324,6 +449,20 @@ def markdown_for_measure(measure_id: str, measure_fhir_id: str, group_id: str, c
     else:
         lines.extend(["", "## Patient Diffs", "", "No patient-level differences detected.", ""])
 
+    if comparison["expected_patient_diffs"]:
+        lines.extend(["", "## Expected Comparison Diffs", ""])
+        for diff in comparison["expected_patient_diffs"][:50]:
+            lines.append(f"### `{diff['patient_id']}`")
+            lines.append("")
+            lines.append(f"- Local: `{json.dumps(diff['local'], sort_keys=True)}`")
+            lines.append(f"- Production: `{json.dumps(diff['production'], sort_keys=True)}`")
+            lines.append("")
+        if len(comparison["expected_patient_diffs"]) > 50:
+            lines.append(f"Only first 50 of {len(comparison['expected_patient_diffs'])} diffs shown.")
+            lines.append("")
+    else:
+        lines.extend(["", "## Expected Comparison Diffs", "", "No expected-comparison differences detected.", ""])
+
     return "\n".join(lines)
 
 
@@ -331,17 +470,19 @@ def summary_markdown(results: list[dict[str, Any]]) -> str:
     lines = [
         "# Connectathon Jobs Local vs Production Summary",
         "",
-        "| Measure | Match | Local status | Production status | Local rows | Production rows | Patient diffs |",
-        "|---|---|---|---|---:|---:|---:|",
+        "| Measure | Parity | Local expected | Production expected | Local status | Production status | Local rows | Production rows | Patient diffs | Expected diffs |",
+        "|---|---|---|---|---|---|---:|---:|---:|---:|",
     ]
     for result in results:
         comparison = result["comparison"]
         lines.append(
             f"| {result['measure_id']} | {'yes' if comparison['matches'] else 'no'} | "
+            f"{'pass' if comparison['local_expected_passed'] else 'fail'} | "
+            f"{'pass' if comparison['production_expected_passed'] else 'fail'} | "
             f"{comparison['local_job'].get('status')} | {comparison['production_job'].get('status')} | "
             f"{comparison['local_results_summary'].get('total_patients')} | "
             f"{comparison['production_results_summary'].get('total_patients')} | "
-            f"{comparison['patient_diff_count']} |"
+            f"{comparison['patient_diff_count']} | {comparison['expected_patient_diff_count']} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -351,6 +492,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--local-api-base", default="http://localhost:8000")
     parser.add_argument("--production-api-base", default="https://api.98-89-219-217.nip.io")
+    parser.add_argument(
+        "--expected-only",
+        action="store_true",
+        help="Run only the local API and validate it against expected results without starting a production job.",
+    )
     parser.add_argument("--manifest", default=str(MANIFEST_PATH))
     parser.add_argument("--measure-id", help="Optional manifest measure id to run")
     parser.add_argument(
@@ -359,6 +505,26 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--timeout-seconds", type=int, default=3600)
     parser.add_argument("--poll-seconds", type=int, default=5)
+    parser.add_argument(
+        "--fail-on-mismatch",
+        action="store_true",
+        help="Exit non-zero when parity, expected comparison, or job completion checks fail.",
+    )
+    parser.add_argument(
+        "--fail-on-parity-mismatch",
+        action="store_true",
+        help="Exit non-zero when local and production job outputs differ.",
+    )
+    parser.add_argument(
+        "--fail-on-expected-mismatch",
+        action="store_true",
+        help="Exit non-zero when either environment does not match loaded expected results.",
+    )
+    parser.add_argument(
+        "--fail-on-job-failure",
+        action="store_true",
+        help="Exit non-zero when either job does not complete successfully.",
+    )
     return parser.parse_args()
 
 
@@ -389,21 +555,35 @@ def main() -> int:
         print(f"[measure] {measure_id} measure={measure_fhir_id} group={group_id}", flush=True)
 
         local_upload_id = upload_bundle(local_api, bundle_path, group_id)
-        production_upload_id = upload_bundle(production_api, bundle_path, group_id)
         local_upload = wait_for_upload(local_api, local_upload_id, args.timeout_seconds, args.poll_seconds)
-        production_upload = wait_for_upload(production_api, production_upload_id, args.timeout_seconds, args.poll_seconds)
 
         local_job_id = create_job(local_api, measure_fhir_id, group_id, measure["period"])
-        production_job_id = create_job(production_api, measure_fhir_id, group_id, measure["period"])
-
         local_job = wait_for_job(local_api, local_job_id, args.timeout_seconds, args.poll_seconds)
-        production_job = wait_for_job(production_api, production_job_id, args.timeout_seconds, args.poll_seconds)
 
         local_results = get_results(local_api, local_job_id)
-        production_results = get_results(production_api, production_job_id)
+        local_expected_comparison = get_job_comparison(local_api, local_job_id)
+        normalized_local = normalize_job_result(local_job, local_results, local_expected_comparison)
 
-        normalized_local = normalize_job_result(local_job, local_results)
-        normalized_production = normalize_job_result(production_job, production_results)
+        if args.expected_only:
+            production_upload = None
+            normalized_production = normalized_local
+        else:
+            production_upload_id = upload_bundle(production_api, bundle_path, group_id)
+            production_upload = wait_for_upload(
+                production_api,
+                production_upload_id,
+                args.timeout_seconds,
+                args.poll_seconds,
+            )
+            production_job_id = create_job(production_api, measure_fhir_id, group_id, measure["period"])
+            production_job = wait_for_job(production_api, production_job_id, args.timeout_seconds, args.poll_seconds)
+            production_results = get_results(production_api, production_job_id)
+            production_expected_comparison = get_job_comparison(production_api, production_job_id)
+            normalized_production = normalize_job_result(
+                production_job,
+                production_results,
+                production_expected_comparison,
+            )
         comparison = compare_normalized(normalized_local, normalized_production)
 
         payload = {
@@ -428,6 +608,29 @@ def main() -> int:
     summary_payload = {"generated_at_epoch": int(time.time()), "results": all_results}
     (output_dir / "summary.json").write_text(json.dumps(summary_payload, indent=2, sort_keys=True), encoding="utf-8")
     (output_dir / "summary.md").write_text(summary_markdown(all_results), encoding="utf-8")
+    failures = []
+    for result in all_results:
+        measure_id = result["measure_id"]
+        comparison = result["comparison"]
+        if (args.fail_on_mismatch or args.fail_on_parity_mismatch) and not comparison["matches"]:
+            failures.append(f"{measure_id}: local/prod parity mismatch")
+        if (args.fail_on_mismatch or args.fail_on_expected_mismatch) and not comparison["local_expected_passed"]:
+            failures.append(f"{measure_id}: local job does not match expected results")
+        if (args.fail_on_mismatch or args.fail_on_expected_mismatch) and not comparison["production_expected_passed"]:
+            failures.append(f"{measure_id}: production job does not match expected results")
+        if args.fail_on_mismatch or args.fail_on_job_failure:
+            for label, key in (("local", "local_job"), ("production", "production_job")):
+                status = str(comparison[key].get("status", "")).lower()
+                if status not in {"complete", "completed"}:
+                    failures.append(f"{measure_id}: {label} job status is {status or 'unknown'}")
+
+    if failures:
+        print("Connectathon jobs comparison failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(f"Artifacts written to {output_dir}", file=sys.stderr)
+        return 1
+
     return 0
 
 


### PR DESCRIPTION
## Summary
- Add a real `/jobs` Connectathon comparison runner that uploads bundles, creates bundle patient Groups, starts real Jobs, fetches `/results`, fetches `/jobs/{id}/comparison`, and writes JSON/Markdown patient-level artifacts.
- Add a nightly `jobs-workflow` job that starts the product Docker API stack and runs documented-pass connectathon measures through `/validation/upload-bundle` -> `/jobs` -> `/jobs/{id}/comparison`.
- Fix product-path bundle loading to match the harness more closely: patched Library deps, duplicate Claim IDs, refreshed ValueSets, generated missing CodeSystems, and HAPI expansion/search settings in the product compose stack.
- Fix comparison semantics so expected patients with missing `MeasureResult` rows fail visibly instead of being hidden.
- Switch Jobs patient gathering to the batch `$everything` path used by the connectathon harness.

## Why
The nightly Connectathon table was proving the direct HAPI harness, not the real product Jobs workflow. CMS124 exposed the gap: the doc said `33/33`, while a real local `/jobs` run initially matched only `4/33`. After these fixes CMS124 now passes `33/33` on the real Jobs path.

## Current Jobs-Path Findings
- Passing locally through real `/jobs`: `CMS124FHIRCervicalCancerScreening`, `CMS816FHIRHHHypo`, `CMS529FHIRHybridHospitalWideReadmission`.
- Still failing locally through real `/jobs`: `CMS506FHIRSafeUseofOpioids` completes with 38 rows but all populations are zero, matching only `7/38` expected patients. The new nightly jobs gate intentionally exposes this instead of masking it.
- Existing external blocker remains: `CMS1017FHIRHHFI` still fails under HAPI scoring-type behavior.

## Validation
- `python3 -m ruff format --check app tests`
- `python3 -m ruff check app tests`
- `python3 -m pytest tests/test_services_validation.py tests/test_routes_jobs.py tests/test_services_orchestrator.py` -> `129 passed`
- `python3 -m py_compile scripts/compare_connectathon_jobs_local_vs_prod.py`
- Local Docker jobs-path canaries:
- `CMS124FHIRCervicalCancerScreening` -> `33/33` expected match
- `CMS816FHIRHHHypo` -> `9/9` expected match
- `CMS529FHIRHybridHospitalWideReadmission` -> `53/53` expected match
- `CMS506FHIRSafeUseofOpioids` -> fails `7/38`, now caught by the jobs-path gate
