### PR TITLE
fix: clear POSTGRES_PASSWORD in prod overlay to avoid conflict with POSTGRES_PASSWORD_FILE

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,7 @@ services:
   db:
     restart: unless-stopped
     environment:
+      POSTGRES_PASSWORD: ""
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     secrets:
       - postgres_password


### PR DESCRIPTION
## Summary

- The base `docker-compose.yml` sets `POSTGRES_PASSWORD=mct2` for local dev
- The prod overlay (`docker-compose.prod.yml`) adds `POSTGRES_PASSWORD_FILE` for Docker secrets
- When both files are loaded together, postgres errors: `both POSTGRES_PASSWORD and POSTGRES_PASSWORD_FILE are set (but are exclusive)`
- Fix: set `POSTGRES_PASSWORD: ""` in the prod overlay to clear the base value; postgres checks `[ -n "$POSTGRES_PASSWORD" ]` so empty string is treated as unset

## Root cause

This caused the initial prod deploy (Part A, #135) to fail with `[!] db container became unhealthy`. The db container was recreated with the new Docker secrets config, hit the exclusive-env error on startup, and never became healthy.

## Test plan

- [ ] Merge this PR
- [ ] Trigger prod deploy via `workflow_dispatch` on the Deploy workflow
- [ ] Verify db container starts healthy and backend connects without `InvalidPasswordError`
- [ ] Check `docker compose logs db` shows postgres startup without the exclusivity error

🤖 Generated with [Claude Code](https://claude.com/claude-code)