### PR TITLE
fix: SSM deploy document + reconcile script corrections

### DIFF
--- a/scripts/reconcile-db-password.sh
+++ b/scripts/reconcile-db-password.sh
@@ -60,20 +60,20 @@ if [[ -z "$PW" ]]; then
     die 1 "POSTGRES_PASSWORD is empty in '${ENV_FILE}'."
 fi
 
-# ── run ALTER ROLE via parameterized psql ─────────────────────────────────────
-# :'newpw' uses psql's variable interpolation with proper literal quoting —
-# immune to SQL injection regardless of what $PW contains.
+# ── run ALTER ROLE via psql stdin ─────────────────────────────────────────────
+# Pipe the SQL via stdin to avoid psql variable-interpolation issues with
+# `docker compose exec -c`. The password is safe for direct SQL string
+# substitution: fetch-prod-secrets.sh validates it against
+# ^[A-Za-z0-9+/=_.-]{16,128}$ so it can never contain single quotes.
 # PGPASSWORD is scoped to the subprocess only (via `exec -e`).
-if ! out=$(docker compose \
+if ! out=$(printf "ALTER ROLE mct2 PASSWORD '%s';" "$PW" | docker compose \
     -f "$COMPOSE_BASE" \
     -f "$COMPOSE_PROD" \
     exec -T \
     -e PGPASSWORD="$PW" \
     db \
     psql -U mct2 -d mct2 \
-    -v ON_ERROR_STOP=1 \
-    -v newpw="$PW" \
-    -c "ALTER ROLE mct2 PASSWORD :'newpw'" 2>&1); then
+    -v ON_ERROR_STOP=1 2>&1); then
     # Redact the password from any captured output before printing.
     safe_out="${out//$PW/***REDACTED***}"
     printf '[!] reconcile-db-password: ALTER ROLE via psql failed\n' >&2

--- a/scripts/tests/docker
+++ b/scripts/tests/docker
@@ -8,9 +8,13 @@
 # On "fail": exits 1 and emits the PGPASSWORD value on stderr so the
 # redaction test can verify the script scrubs it from output.
 
-# Record the call for assertion later.
+# Record the call (args + any stdin) for assertion later.
 if [[ -n "${STUB_DOCKER_CALLS:-}" ]]; then
     printf '%s\n' "$*" >> "$STUB_DOCKER_CALLS"
+    # Capture stdin if it is not a terminal (piped input from reconcile script).
+    if [[ ! -t 0 ]]; then
+        cat >> "$STUB_DOCKER_CALLS"
+    fi
 fi
 
 SCENARIO="${STUB_DOCKER_SCENARIO:-ok}"

--- a/ssm/leonard-deploy-document.json
+++ b/ssm/leonard-deploy-document.json
@@ -7,7 +7,7 @@
       "name": "deploy",
       "inputs": {
         "runCommand": [
-          "sudo -u ec2-user bash -c 'cd /opt/leonard && git fetch origin && git reset --hard FETCH_HEAD'",
+          "sudo -u ec2-user bash -c 'cd /opt/leonard && git fetch origin && git reset --hard origin/main'",
           "bash /opt/leonard/scripts/deploy-prod.sh"
         ],
         "timeoutSeconds": 900

--- a/ssm/leonard-deploy-document.json
+++ b/ssm/leonard-deploy-document.json
@@ -7,10 +7,8 @@
       "name": "deploy",
       "inputs": {
         "runCommand": [
-          "cd /opt/leonard",
-          "git fetch origin",
-          "git reset --hard FETCH_HEAD",
-          "scripts/deploy-prod.sh"
+          "sudo -u ec2-user bash -c 'cd /opt/leonard && git fetch origin && git reset --hard FETCH_HEAD'",
+          "bash /opt/leonard/scripts/deploy-prod.sh"
         ],
         "timeoutSeconds": 900
       }


### PR DESCRIPTION
## Summary

Three fixes needed after the initial prod deploy attempt (#138):

- **SSM document: run git as ec2-user** — SSM runs as root but `/opt/leonard` is owned by `ec2-user`; git >= 2.35.2 refuses to operate in directories owned by another user. Use `sudo -u ec2-user` for the fetch+reset step.
- **SSM document: use `origin/main` not `FETCH_HEAD`** — `FETCH_HEAD` is unreliable when multiple branches are fetched; it may point to a non-main branch. Use `origin/main` explicitly.
- **reconcile: use `printf|psql` stdin instead of `:'newpw'`** — psql variable interpolation (`:'varname'`) does not expand when invoked via `docker compose exec -T` with `-c`. Switch to piping SQL via stdin. Safe because `fetch-prod-secrets.sh` validates the password against `^[A-Za-z0-9+/=_.-]{16,128}$` (no single quotes possible).

## Test plan

- [ ] Merge this PR
- [ ] Trigger prod deploy — should get through reconcile step cleanly
- [ ] `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)