### PR TITLE
fix: wait for HAPI sync after bundle upload

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 """Application configuration loaded from environment variables."""
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -16,10 +17,29 @@ class Settings(BaseSettings):
     MAX_WORKERS: int = 4
     MAX_RETRIES: int = 3
     HAPI_INDEX_WAIT_SECONDS: int = 5  # Wait after pushing patients before evaluating measures
+    PATIENT_DATA_STRATEGY: str = "batch"
+    VALUESET_RELOAD_MODE: str = "delete"
+    HAPI_SYNC_AFTER_UPLOAD: bool = True
     LOG_LEVEL: str = "INFO"
     ALLOWED_ORIGINS: str = "*"  # Comma-separated origins, or "*" for all (local dev default)
 
     model_config = {"env_prefix": "", "case_sensitive": True}
+
+    @field_validator("PATIENT_DATA_STRATEGY")
+    @classmethod
+    def validate_patient_data_strategy(cls, value: str) -> str:
+        allowed = {"batch", "data_requirements"}
+        if value not in allowed:
+            raise ValueError(f"PATIENT_DATA_STRATEGY must be one of: {', '.join(sorted(allowed))}")
+        return value
+
+    @field_validator("VALUESET_RELOAD_MODE")
+    @classmethod
+    def validate_valueset_reload_mode(cls, value: str) -> str:
+        allowed = {"delete", "remap"}
+        if value not in allowed:
+            raise ValueError(f"VALUESET_RELOAD_MODE must be one of: {', '.join(sorted(allowed))}")
+        return value
 
 
 def parse_allowed_origins(raw: str) -> list[str]:

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -128,6 +128,19 @@ def _batch_to_response(batch) -> dict:
     }
 
 
+def _empty_comparison_response() -> dict:
+    return {
+        "has_expected": False,
+        "matched": None,
+        "total": None,
+        "expected_total": 0,
+        "actual_total": 0,
+        "missing_results": 0,
+        "unexpected_results": 0,
+        "patients": [],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -338,12 +351,6 @@ async def get_job_comparison(
             },
         )
 
-    result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
-    actual_results = result.scalars().all()
-
-    if not actual_results:
-        return {"has_expected": False, "matched": None, "total": None, "patients": []}
-
     measure_url = ""
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
@@ -354,7 +361,7 @@ async def get_job_comparison(
         logger.warning("Could not resolve measure URL for comparison", extra={"measure_id": job.measure_id})
 
     if not measure_url:
-        return {"has_expected": False, "matched": None, "total": None, "patients": []}
+        return _empty_comparison_response()
 
     exp_result = await session.execute(
         select(ExpectedResult).where(
@@ -366,14 +373,26 @@ async def get_job_comparison(
     expected_by_patient = {er.patient_ref: er for er in exp_result.scalars().all()}
 
     if not expected_by_patient:
-        return {"has_expected": False, "matched": None, "total": None, "patients": []}
+        return _empty_comparison_response()
+
+    result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
+    actual_by_patient = {mr.patient_id: mr for mr in result.scalars().all()}
 
     patients_list = []
     matched_count = 0
 
-    for mr in actual_results:
-        expected = expected_by_patient.get(mr.patient_id)
-        if not expected:
+    for patient_id, expected in sorted(expected_by_patient.items()):
+        mr = actual_by_patient.get(patient_id)
+        if not mr:
+            patients_list.append(
+                {
+                    "subject_reference": f"Patient/{patient_id}",
+                    "match": False,
+                    "mismatches": ["missing-result"],
+                    "expected": expected.expected_populations,
+                    "actual": {},
+                }
+            )
             continue
 
         actual_counts = _extract_population_counts(mr.measure_report)
@@ -391,9 +410,15 @@ async def get_job_comparison(
             }
         )
 
+    unexpected_result_count = len(set(actual_by_patient) - set(expected_by_patient))
+
     return {
         "has_expected": True,
         "matched": matched_count,
         "total": len(patients_list),
+        "expected_total": len(expected_by_patient),
+        "actual_total": len(actual_by_patient),
+        "missing_results": len(expected_by_patient) - len(set(expected_by_patient) & set(actual_by_patient)),
+        "unexpected_results": unexpected_result_count,
         "patients": patients_list,
     }

--- a/backend/app/routes/results.py
+++ b/backend/app/routes/results.py
@@ -31,6 +31,7 @@ async def get_results(
         return {
             "job_id": job_id,
             "total_patients": 0,
+            "failed_patients": 0,
             "populations": {
                 "initial_population": 0,
                 "denominator": 0,
@@ -51,18 +52,25 @@ async def get_results(
         "numerator_exclusion": 0,
     }
     patients_list = []
+    failed_patients = 0
 
     for mr in results:
         populations = mr.populations or {}
-        for key in pops:
-            if populations.get(key):
-                pops[key] += 1
+        is_error = bool(populations.get("error"))
+        if is_error:
+            failed_patients += 1
+        else:
+            for key in pops:
+                if populations.get(key):
+                    pops[key] += 1
         patients_list.append(
             {
                 "id": mr.id,
                 "patient_id": mr.patient_id,
                 "patient_name": mr.patient_name,
                 "populations": populations,
+                "status": "error" if is_error else "success",
+                "error_message": populations.get("error_message") if is_error else None,
             }
         )
 
@@ -75,6 +83,7 @@ async def get_results(
     return {
         "job_id": job_id,
         "total_patients": len(results),
+        "failed_patients": failed_patients,
         "populations": pops,
         "performance_rate": performance_rate,
         "patients": patients_list,
@@ -110,6 +119,8 @@ async def get_result(
         "patient_name": mr.patient_name,
         "measure_report": mr.measure_report,
         "populations": mr.populations,
+        "status": "error" if (mr.populations or {}).get("error") else "success",
+        "error_message": (mr.populations or {}).get("error_message"),
         "created_at": mr.created_at.isoformat() if mr.created_at else None,
     }
 

--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -369,6 +369,126 @@ class DataRequirementsStrategy(DataAcquisitionStrategy):
 # Direct FHIR helper functions (measure engine interaction)
 # ---------------------------------------------------------------------------
 
+_REINDEX_POLL_INTERVAL = 5
+_VALUESET_EXPANSION_POLL_INTERVAL = 10
+
+
+def trigger_reindex_and_wait(base_url: str, probe_patient_id: str | None = None, timeout_s: int = 300) -> None:
+    """Trigger HAPI Encounter reindexing and wait until patient reference search works."""
+    headers = {"Content-Type": "application/fhir+json"}
+    params = {"resourceType": "Parameters", "parameter": [{"name": "type", "valueString": "Encounter"}]}
+    started_at = time.monotonic()
+    polls = 0
+
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.post(f"{base_url}/$reindex", json=params, headers=headers)
+        if resp.status_code != 202:
+            logger.warning(
+                "HAPI reindex trigger returned unexpected status",
+                extra={"base_url": base_url, "status_code": resp.status_code, "body": resp.text[:200]},
+            )
+
+        if not probe_patient_id:
+            try:
+                probe_resp = client.get(f"{base_url}/Patient?_count=1", timeout=10.0)
+                probe_resp.raise_for_status()
+                entries = probe_resp.json().get("entry", [])
+                if entries:
+                    probe_patient_id = entries[0].get("resource", {}).get("id")
+            except Exception as exc:
+                logger.warning(
+                    "Unable to select HAPI reindex probe patient",
+                    extra={"base_url": base_url, "error": str(exc)},
+                )
+
+        if not probe_patient_id:
+            logger.warning(
+                "HAPI reindex wait skipped because no probe patient was available",
+                extra={"base_url": base_url},
+            )
+            return
+
+        deadline = started_at + timeout_s
+        while time.monotonic() < deadline:
+            polls += 1
+            try:
+                probe_resp = client.get(f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10.0)
+                if probe_resp.status_code == 200 and probe_resp.json().get("entry"):
+                    duration_s = round(time.monotonic() - started_at, 3)
+                    logger.info("HAPI reindex complete", extra={"duration_s": duration_s, "polls": polls})
+                    return
+            except Exception:
+                pass
+            time.sleep(_REINDEX_POLL_INTERVAL)
+
+    duration_s = round(time.monotonic() - started_at, 3)
+    logger.warning(
+        "HAPI reindex timed out",
+        extra={"duration_s": duration_s, "polls": polls, "probe_patient_id": probe_patient_id},
+    )
+
+
+def wait_for_valueset_expansion(base_url: str, valueset_urls: list[str], timeout_s: int = 600) -> dict[str, int]:
+    """Wait until HAPI can serve $expand for each ValueSet URL and return expansion totals."""
+    expanded: dict[str, int] = {}
+    if not valueset_urls:
+        return expanded
+
+    unique_urls = sorted({url for url in valueset_urls if url})
+    pending: dict[str, str] = {}
+    with httpx.Client(timeout=30.0) as client:
+        for valueset_url in unique_urls:
+            try:
+                lookup = client.get(
+                    f"{base_url}/ValueSet",
+                    params={"url": valueset_url, "_count": 1, "_elements": "id,url"},
+                    headers={"Cache-Control": "no-cache", "Accept": "application/fhir+json"},
+                )
+                lookup.raise_for_status()
+                entries = lookup.json().get("entry", [])
+                if not entries:
+                    logger.warning("ValueSet not found for expansion wait", extra={"valueset_url": valueset_url})
+                    continue
+                valueset_id = entries[0].get("resource", {}).get("id")
+                if not valueset_id:
+                    logger.warning("ValueSet lookup returned no id", extra={"valueset_url": valueset_url})
+                    continue
+                pending[valueset_url] = valueset_id
+            except Exception as exc:
+                logger.warning(
+                    "ValueSet lookup failed before expansion wait",
+                    extra={"valueset_url": valueset_url, "error": str(exc)},
+                )
+
+        deadline = time.monotonic() + timeout_s
+        polls = 0
+        while pending and time.monotonic() < deadline:
+            polls += 1
+            newly_done: set[str] = set()
+            for valueset_url, valueset_id in list(pending.items()):
+                try:
+                    resp = client.post(f"{base_url}/ValueSet/{valueset_id}/$expand?count=2", timeout=15.0)
+                    if resp.status_code == 200:
+                        body = resp.json()
+                        expanded[valueset_url] = int(
+                            body.get("expansion", {}).get("total", len(body.get("expansion", {}).get("contains", [])))
+                        )
+                        newly_done.add(valueset_url)
+                except Exception:
+                    pass
+            for valueset_url in newly_done:
+                pending.pop(valueset_url, None)
+            if pending:
+                time.sleep(_VALUESET_EXPANSION_POLL_INTERVAL)
+
+        for valueset_url, valueset_id in pending.items():
+            logger.warning(
+                "ValueSet expansion timed out",
+                extra={"valueset_url": valueset_url, "valueset_id": valueset_id, "polls": polls},
+            )
+
+    return expanded
+
 
 def _normalize_measure_def(r: dict[str, Any]) -> dict[str, Any]:
     """Ensure Library resources have a url so HAPI 8.x can resolve canonical refs.

--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -21,6 +21,7 @@ from app.services.fhir_client import (
     push_resources,
     wipe_patient_data,
 )
+from app.services.validation import sanitize_error
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,28 @@ def _extract_patient_name(patient_resource: dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _error_measure_report(patient_id: str, exc: Exception) -> dict[str, Any]:
+    """Build a persisted per-patient error result for failed evaluations."""
+    return {
+        "resourceType": "OperationOutcome",
+        "issue": [
+            {
+                "severity": "error",
+                "code": "processing",
+                "diagnostics": sanitize_error(exc),
+            }
+        ],
+        "subject": {"reference": f"Patient/{patient_id}"},
+    }
+
+
+def _patient_data_strategy(measure_id: str):
+    """Create the configured patient data acquisition strategy."""
+    if settings.PATIENT_DATA_STRATEGY == "data_requirements":
+        return DataRequirementsStrategy(measure_id)
+    return BatchQueryStrategy()
+
+
 async def _stop_or_delete_job(job_id: int) -> bool:
     """Return True when work should stop because the job was cancelled or deleted."""
     async with async_session() as session:
@@ -102,7 +125,7 @@ async def run_job(job_id: int) -> None:
     try:
         # Step 1: Wipe patient data from measure engine (cleanup from prior job)
         logger.info("Wiping prior patient data from measure engine", extra={"job_id": job_id})
-        await wipe_patient_data()
+        await wipe_patient_data(strict=False)
         if await _stop_or_delete_job(job_id):
             return
 
@@ -192,11 +215,15 @@ async def run_job(job_id: int) -> None:
                 return
             if job.status == JobStatus.cancelled:
                 return
-            job.status = JobStatus.complete
+            if job.total_patients and job.processed_patients == 0 and job.failed_patients > 0:
+                job.status = JobStatus.failed
+                job.error_message = f"All {job.failed_patients} patient evaluations failed"
+            else:
+                job.status = JobStatus.complete
             job.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
-        logger.info("Job complete", extra={"job_id": job_id})
+        logger.info("Job finalized", extra={"job_id": job_id})
 
     except Exception as exc:
         logger.exception("Job failed", extra={"job_id": job_id})
@@ -276,7 +303,11 @@ async def _process_single_batch(
                 period_start = job.period_start
                 period_end = job.period_end
 
-            strategy = DataRequirementsStrategy(measure_id)
+            strategy = _patient_data_strategy(measure_id)
+            logger.info(
+                "Using patient data strategy",
+                extra={"strategy": settings.PATIENT_DATA_STRATEGY, "job_id": job_id, "batch_id": batch_id},
+            )
 
             # ----------------------------------------------------------
             # Phase 1: Gather all patient data and push to measure engine
@@ -344,13 +375,37 @@ async def _process_single_batch(
                     processed += 1
 
                 except Exception as patient_exc:
+                    patient_name = _extract_patient_name(patient_map.get(patient_id, {}))
+                    sanitized_error = sanitize_error(patient_exc)
+                    error_report = _error_measure_report(patient_id, patient_exc)
+                    if await _stop_or_delete_job(job_id):
+                        return
+                    async with async_session() as session:
+                        result = MeasureResult(
+                            job_id=job_id,
+                            patient_id=patient_id,
+                            patient_name=patient_name,
+                            measure_report=error_report,
+                            populations={
+                                "initial_population": False,
+                                "denominator": False,
+                                "numerator": False,
+                                "denominator_exclusion": False,
+                                "numerator_exclusion": False,
+                                "error": True,
+                                "error_message": sanitized_error,
+                            },
+                        )
+                        session.add(result)
+                        await session.commit()
+
                     logger.warning(
                         "Failed to evaluate patient",
                         extra={
                             "job_id": job_id,
                             "batch_id": batch_id,
                             "patient_id": patient_id,
-                            "error": str(patient_exc),
+                            "error": sanitized_error,
                         },
                     )
                     failed += 1

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -7,6 +7,7 @@ running validation against expected results, and comparing population counts.
 import asyncio
 import base64
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -33,6 +34,8 @@ from app.services.fhir_client import (
     _build_auth_headers,
     evaluate_measure,
     push_resources,
+    trigger_reindex_and_wait,
+    wait_for_valueset_expansion,
     wipe_patient_data,
 )
 
@@ -358,6 +361,70 @@ def _fix_valueset_compose_for_hapi(resources: list[dict[str, Any]]) -> list[dict
     return result
 
 
+def _fix_library_deps_for_hapi(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Patch MADiE Library dependency URLs so HAPI can resolve sub-libraries."""
+    ecqi_prefix = "http://ecqi.healthit.gov/ecqms/Library/"
+    madie_prefix = "https://madie.cms.gov/Library/"
+
+    result = []
+    for resource in resources:
+        if resource.get("resourceType") != "Library":
+            result.append(resource)
+            continue
+
+        needs_fix = any(
+            artifact.get("type") == "depends-on" and artifact.get("resource", "").startswith(ecqi_prefix)
+            for artifact in resource.get("relatedArtifact", [])
+        )
+        if not needs_fix:
+            result.append(resource)
+            continue
+
+        resource = copy.deepcopy(resource)
+        for artifact in resource.get("relatedArtifact", []):
+            dep_url = artifact.get("resource", "")
+            if artifact.get("type") == "depends-on" and dep_url.startswith(ecqi_prefix):
+                artifact["resource"] = madie_prefix + dep_url[len(ecqi_prefix) :]
+        result.append(resource)
+    return result
+
+
+def _fix_duplicate_claim_ids(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Assign unique IDs to duplicate Claim resources from affected MADiE bundles."""
+    id_counts: dict[str, int] = {}
+    for resource in resources:
+        if resource.get("resourceType") == "Claim" and resource.get("id"):
+            id_counts[resource["id"]] = id_counts.get(resource["id"], 0) + 1
+    duplicates = {id_ for id_, count in id_counts.items() if count > 1}
+    if not duplicates:
+        return resources
+
+    result = []
+    seen: dict[str, int] = {}
+    for resource in resources:
+        if resource.get("resourceType") != "Claim" or resource.get("id") not in duplicates:
+            result.append(resource)
+            continue
+
+        resource = copy.deepcopy(resource)
+        original_id = resource["id"]
+        enc_ref = ""
+        for item in resource.get("item", []):
+            for encounter in item.get("encounter", []):
+                ref = encounter.get("reference", "")
+                if ref:
+                    enc_ref = ref.split("/")[-1][:16]
+                    break
+            if enc_ref:
+                break
+
+        seen[original_id] = seen.get(original_id, 0) + 1
+        suffix = enc_ref or str(seen[original_id])
+        resource["id"] = f"{original_id}-{suffix}"
+        result.append(resource)
+    return result
+
+
 def _get_missing_valueset_stubs(bundle_json: dict[str, Any]) -> list[dict[str, Any]]:
     """Return empty ValueSet stubs for ELM-declared ValueSets omitted by the bundle.
 
@@ -410,6 +477,76 @@ def _get_missing_valueset_stubs(bundle_json: dict[str, Any]) -> list[dict[str, A
     return stubs
 
 
+def _get_codesystem_stubs_from_valuesets(
+    resources: list[dict[str, Any]], bundle_json: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Create CodeSystem fragments for explicit ValueSet concepts when MADiE omits them."""
+    existing_codesystems = {
+        (resource.get("url"), resource.get("version"))
+        for resource in resources
+        if resource.get("resourceType") == "CodeSystem" and resource.get("url")
+    }
+    concepts_by_system: dict[str, dict[str, str]] = {}
+    versions_by_system: dict[str, set[str | None]] = {}
+
+    def add_concept(system: str | None, code: str | None, display: str | None = None) -> None:
+        if not system or not code:
+            return
+        concepts_by_system.setdefault(system, {})
+        concepts_by_system[system].setdefault(code, display or "")
+
+    def scan_contains(nodes: list[dict[str, Any]]) -> None:
+        for node in nodes:
+            add_concept(node.get("system"), node.get("code"), node.get("display"))
+            if node.get("contains"):
+                scan_contains(node["contains"])
+
+    def scan_versions(value: Any) -> None:
+        if isinstance(value, dict):
+            system = value.get("system")
+            if system:
+                versions_by_system.setdefault(system, set()).add(value.get("version"))
+            for child in value.values():
+                scan_versions(child)
+        elif isinstance(value, list):
+            for child in value:
+                scan_versions(child)
+
+    scan_versions(bundle_json)
+
+    for resource in resources:
+        if resource.get("resourceType") != "ValueSet":
+            continue
+        for include in resource.get("compose", {}).get("include", []):
+            system = include.get("system")
+            for concept in include.get("concept", []):
+                add_concept(system, concept.get("code"), concept.get("display"))
+        scan_contains(resource.get("expansion", {}).get("contains", []))
+
+    stubs = []
+    for system, concepts in sorted(concepts_by_system.items()):
+        versions = versions_by_system.get(system) or {None}
+        for version in sorted(versions, key=lambda value: value or ""):
+            if (system, version) in existing_codesystems:
+                continue
+            digest = hashlib.sha1(f"{system}|{version or ''}".encode("utf-8")).hexdigest()[:16]
+            stub = {
+                "resourceType": "CodeSystem",
+                "id": f"generated-codesystem-{digest}",
+                "url": system,
+                "status": "active",
+                "content": "complete",
+                "concept": [
+                    {"code": code, **({"display": display} if display else {})}
+                    for code, display in sorted(concepts.items())
+                ],
+            }
+            if version:
+                stub["version"] = version
+            stubs.append(stub)
+    return stubs
+
+
 async def _find_existing_valueset_id(
     url: str,
     client: httpx.AsyncClient,
@@ -429,18 +566,53 @@ async def _find_existing_valueset_id(
     return entries[0].get("resource", {}).get("id")
 
 
+async def _find_existing_codesystem_id(
+    url: str,
+    version: str | None,
+    client: httpx.AsyncClient,
+) -> str | None:
+    """Return the existing HAPI CodeSystem resource ID for a canonical URL/version."""
+    params: dict[str, str | int] = {"url": url, "_count": 50, "_elements": "id,url,version"}
+    if version:
+        params["version"] = version
+    resp = await client.get(
+        f"{settings.MEASURE_ENGINE_URL}/CodeSystem",
+        params=params,
+        headers={"Cache-Control": "no-cache", "Accept": "application/fhir+json"},
+    )
+    resp.raise_for_status()
+    entries = resp.json().get("entry", [])
+    for entry in entries:
+        resource = entry.get("resource", {})
+        resource_version = resource.get("version")
+        if (version and resource_version == version) or (not version and not resource_version):
+            return resource.get("id")
+    return None
+
+
+async def _delete_existing_valueset(existing_id: str, client: httpx.AsyncClient) -> None:
+    """Delete a stale ValueSet so HAPI rebuilds terminology tables from patched compose."""
+    resp = await client.delete(f"{settings.MEASURE_ENGINE_URL}/ValueSet/{existing_id}")
+    if resp.status_code not in {200, 204, 404}:
+        resp.raise_for_status()
+
+
 async def _prepare_measure_support_resources(
     resources: list[dict[str, Any]],
     bundle_json: dict[str, Any],
 ) -> list[dict[str, Any]]:
     """Prepare ValueSets/CodeSystems for HAPI upload.
 
-    Adds missing ELM ValueSet stubs only when HAPI does not already have that
-    URL, and remaps ValueSet IDs to existing HAPI resources to avoid HAPI-0902
-    URL+version uniqueness conflicts silently dropping updates inside a batch.
+    Adds missing ELM ValueSet stubs only when HAPI does not already have that URL.
+    Existing ValueSets are handled according to VALUESET_RELOAD_MODE: delete stale
+    resources before re-upload, or remap to the existing HAPI resource ID.
     """
     prepared = _fix_valueset_compose_for_hapi(resources)
     stubs = _get_missing_valueset_stubs(bundle_json)
+    codesystem_stubs = _get_codesystem_stubs_from_valuesets(prepared, bundle_json)
+    if codesystem_stubs:
+        prepared = [*codesystem_stubs, *prepared]
+        logger.info("Prepared generated CodeSystem stubs", extra={"count": len(codesystem_stubs)})
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         if stubs:
@@ -457,17 +629,56 @@ async def _prepare_measure_support_resources(
                 logger.info("Prepared missing ValueSet stubs", extra={"count": len(filtered_stubs)})
 
         aligned = []
+        deleted_valueset_urls: set[str] = set()
         for resource in prepared:
+            if resource.get("resourceType") == "CodeSystem" and resource.get("id", "").startswith(
+                "generated-codesystem-"
+            ):
+                existing_id = await _find_existing_codesystem_id(
+                    resource["url"],
+                    resource.get("version"),
+                    client,
+                )
+                if existing_id and existing_id != resource.get("id"):
+                    continue
+                aligned.append(resource)
+                continue
+
             if resource.get("resourceType") != "ValueSet" or not resource.get("url"):
                 aligned.append(resource)
                 continue
             existing_id = await _find_existing_valueset_id(resource["url"], client)
-            if existing_id and existing_id != resource.get("id"):
-                resource = copy.deepcopy(resource)
-                resource["id"] = existing_id
+            if existing_id:
+                logger.info(
+                    "ValueSet reload",
+                    extra={
+                        "mode": settings.VALUESET_RELOAD_MODE,
+                        "valueset_id": existing_id,
+                        "valueset_url": resource["url"],
+                    },
+                )
+                if settings.VALUESET_RELOAD_MODE == "delete":
+                    if resource["url"] not in deleted_valueset_urls:
+                        await _delete_existing_valueset(existing_id, client)
+                        deleted_valueset_urls.add(resource["url"])
+                elif existing_id != resource.get("id"):
+                    resource = copy.deepcopy(resource)
+                    resource["id"] = existing_id
+            else:
+                logger.info(
+                    "ValueSet reload",
+                    extra={"mode": settings.VALUESET_RELOAD_MODE, "valueset_id": None, "valueset_url": resource["url"]},
+                )
             aligned.append(resource)
 
     return aligned
+
+
+def _valueset_urls(resources: list[dict[str, Any]]) -> list[str]:
+    """Return canonical ValueSet URLs from a resource list."""
+    return [
+        resource["url"] for resource in resources if resource.get("resourceType") == "ValueSet" and resource.get("url")
+    ]
 
 
 async def triage_test_bundle(
@@ -485,6 +696,9 @@ async def triage_test_bundle(
     """
     _warn_unknown_bundle_types(bundle_json)
     measure_defs, clinical, test_cases = _classify_bundle_entries(bundle_json)
+    measure_defs = _fix_library_deps_for_hapi(measure_defs)
+    clinical = _fix_duplicate_claim_ids(clinical)
+    support_resources: list[dict[str, Any]] = []
 
     # Push measure definitions to measure engine in two phases so shared ValueSets
     # (which trigger HAPI-0902 on re-upload) never block the Measure/Library load.
@@ -554,6 +768,24 @@ async def triage_test_bundle(
             "Clinical resources loaded to CDR",
             extra={"count": len(clinical), "cdr_url": cdr_url},
         )
+
+    if settings.HAPI_SYNC_AFTER_UPLOAD:
+        sync_started = datetime.now(timezone.utc)
+        await asyncio.to_thread(trigger_reindex_and_wait, settings.MEASURE_ENGINE_URL)
+        valueset_urls = _valueset_urls([*measure_defs, *clinical])
+        valueset_urls.extend(_valueset_urls(support_resources))
+        expanded = await asyncio.to_thread(wait_for_valueset_expansion, settings.MEASURE_ENGINE_URL, valueset_urls)
+        unique_valueset_count = len({url for url in valueset_urls if url})
+        logger.info(
+            "HAPI sync complete",
+            extra={
+                "reindex_duration_s": round((datetime.now(timezone.utc) - sync_started).total_seconds(), 3),
+                "vs_count_expanded": len(expanded),
+                "vs_count_timeout": max(unique_valueset_count - len(expanded), 0),
+            },
+        )
+    else:
+        logger.info("HAPI sync skipped (HAPI_SYNC_AFTER_UPLOAD=False)")
 
     return {
         "measures_loaded": sum(1 for r in measure_defs if r.get("resourceType") == "Measure"),

--- a/backend/tests/integration/_helpers.py
+++ b/backend/tests/integration/_helpers.py
@@ -6,6 +6,21 @@ from typing import Any
 
 import pytest
 
+from app.services.validation import (
+    _fix_duplicate_claim_ids as fix_duplicate_claim_ids,
+)
+from app.services.validation import (
+    _fix_library_deps_for_hapi as fix_library_deps_for_hapi,
+)
+
+__all__ = [
+    "fail_with_context",
+    "fix_duplicate_claim_ids",
+    "fix_library_deps_for_hapi",
+    "fix_valueset_compose_for_hapi",
+    "make_put_bundle",
+]
+
 
 def fix_valueset_compose_for_hapi(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Patch ValueSets so HAPI can expand them.
@@ -60,100 +75,6 @@ def fix_valueset_compose_for_hapi(resources: list[dict[str, Any]]) -> list[dict[
 
             _flatten_contains(r["expansion"].get("contains", []))
             r["compose"] = {"include": [{"system": sys, "concept": codes} for sys, codes in codes_by_system.items()]}
-        result.append(r)
-    return result
-
-
-def fix_library_deps_for_hapi(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Patch Library relatedArtifact dependency URLs to match actual Library URLs.
-
-    MADiE bundles (≥ v0.4.x) ship Libraries whose canonical ``url`` is
-    ``https://madie.cms.gov/Library/{name}`` but whose ``relatedArtifact.depends-on``
-    entries reference ``http://ecqi.healthit.gov/ecqms/Library/{name}|{version}``.
-
-    HAPI resolves Library dependencies by canonical URL lookup, so this mismatch
-    causes every sub-library (FHIRHelpers, QICoreCommon, etc.) to be silently
-    unresolvable — the CQL evaluation proceeds but with a broken library chain,
-    returning IP=0 for every patient.
-
-    Fix: rewrite any ``relatedArtifact.resource`` that starts with the ecqi
-    prefix to use the ``madie.cms.gov`` prefix, which matches the Library ``url``
-    field that was actually loaded into HAPI.
-    """
-    _ECQI_PREFIX = "http://ecqi.healthit.gov/ecqms/Library/"
-    _MADIE_PREFIX = "https://madie.cms.gov/Library/"
-
-    result = []
-    for r in resources:
-        if r.get("resourceType") != "Library":
-            result.append(r)
-            continue
-
-        needs_fix = any(
-            ra.get("type") == "depends-on" and ra.get("resource", "").startswith(_ECQI_PREFIX)
-            for ra in r.get("relatedArtifact", [])
-        )
-        if not needs_fix:
-            result.append(r)
-            continue
-
-        r = copy.deepcopy(r)
-        for ra in r.get("relatedArtifact", []):
-            dep_url = ra.get("resource", "")
-            if ra.get("type") == "depends-on" and dep_url.startswith(_ECQI_PREFIX):
-                tail = dep_url[len(_ECQI_PREFIX) :]  # e.g. "FHIRHelpers|4.4.000"
-                ra["resource"] = _MADIE_PREFIX + tail
-        result.append(r)
-    return result
-
-
-def fix_duplicate_claim_ids(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Assign unique IDs to Claim resources that share a duplicate ID.
-
-    MADiE v0.3.x CMS71 bundles export all Claim resources with the same ID.
-    When loaded via PUT batch, only the last write survives — every other patient
-    loses their Claim, so ``hasPrincipalDiagnosisOf()`` (QICore v6 fluent function
-    that looks up principal diagnosis via Claim.diagnosis) returns null for 82 of
-    83 patients and every patient evaluates to IP=0.
-
-    Fix: detect Claims with a duplicate ID and replace the ID with a deterministic
-    slug derived from the first encounter reference in the Claim's items.  Falls
-    back to a sequential counter if no encounter reference is present.
-    """
-    from collections import Counter
-
-    id_counts = Counter(r.get("id", "") for r in resources if r.get("resourceType") == "Claim")
-    duplicates = {id_ for id_, n in id_counts.items() if n > 1}
-    if not duplicates:
-        return resources
-
-    result = []
-    seen: dict[str, int] = {}
-    for r in resources:
-        if r.get("resourceType") != "Claim" or r.get("id") not in duplicates:
-            result.append(r)
-            continue
-
-        r = copy.deepcopy(r)
-        original_id = r["id"]
-        # Derive a unique ID from the first item → encounter reference
-        enc_ref = ""
-        for item in r.get("item", []):
-            for enc in item.get("encounter", []):
-                ref = enc.get("reference", "")
-                if ref:
-                    enc_ref = ref.split("/")[-1][:16]
-                    break
-            if enc_ref:
-                break
-
-        if enc_ref:
-            new_id = f"claim-{enc_ref}"
-        else:
-            seen[original_id] = seen.get(original_id, 0) + 1
-            new_id = f"{original_id}-{seen[original_id]}"
-
-        r["id"] = new_id
         result.append(r)
     return result
 

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -468,7 +468,7 @@ async def test_get_comparison_httpx_exception_returns_no_expected(client, test_s
 
 
 async def test_get_comparison_patient_not_in_expected_skipped(client, test_session):
-    """Actual patients with no matching ExpectedResult are excluded from comparison output."""
+    """Actual patients with no matching ExpectedResult are counted but excluded from comparison rows."""
     from unittest.mock import AsyncMock, patch
 
     import httpx as _httpx
@@ -534,7 +534,64 @@ async def test_get_comparison_patient_not_in_expected_skipped(client, test_sessi
     assert data["has_expected"] is True
     # Only p1 appears — p2 had no expected result and was skipped
     assert data["total"] == 1
+    assert data["actual_total"] == 2
+    assert data["unexpected_results"] == 1
     assert data["patients"][0]["subject_reference"] == "Patient/p1"
+
+
+async def test_get_comparison_reports_missing_expected_patient_results(client, test_session):
+    """Expected patients without MeasureResult rows fail comparison instead of being hidden."""
+    from unittest.mock import AsyncMock, patch
+
+    import httpx as _httpx
+
+    from app.models.job import Job, JobStatus
+    from app.models.validation import ExpectedResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2019-01-01",
+        period_end="2019-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    test_session.add(
+        ExpectedResult(
+            measure_url="https://example.com/Measure/CMS124",
+            patient_ref="p1",
+            expected_populations={"initial-population": 0, "denominator": 0, "numerator": 0},
+            period_start="2019-01-01",
+            period_end="2019-12-31",
+            source_bundle="test",
+        )
+    )
+    await test_session.commit()
+
+    measure_json = {"resourceType": "Measure", "id": "CMS124", "url": "https://example.com/Measure/CMS124"}
+    mock_resp = _httpx.Response(200, json=measure_json, request=_httpx.Request("GET", "http://test"))
+
+    with patch("app.routes.jobs.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.get = AsyncMock(return_value=mock_resp)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.get(f"/jobs/{job.id}/comparison")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_expected"] is True
+    assert data["matched"] == 0
+    assert data["total"] == 1
+    assert data["expected_total"] == 1
+    assert data["actual_total"] == 0
+    assert data["missing_results"] == 1
+    assert data["patients"][0]["match"] is False
+    assert data["patients"][0]["mismatches"] == ["missing-result"]
 
 
 async def test_get_comparison_with_mismatch(client, test_session):

--- a/backend/tests/test_routes_results.py
+++ b/backend/tests/test_routes_results.py
@@ -73,6 +73,54 @@ async def test_get_results_with_population_counts(client, test_session):
     # Performance rate = 1/2 * 100 = 50.0
     assert data["performance_rate"] == 50.0
     assert len(data["patients"]) == 2
+    assert data["failed_patients"] == 0
+    assert data["patients"][0]["status"] == "success"
+
+
+async def test_get_results_includes_patient_evaluation_errors(client, test_session):
+    """GET /results includes failed patient rows without counting them in populations."""
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://example.com/fhir",
+        status=JobStatus.failed,
+        total_patients=1,
+        failed_patients=1,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    mr = MeasureResult(
+        job_id=job.id,
+        patient_id="patient-error",
+        patient_name="Patient Error",
+        measure_report={
+            "resourceType": "OperationOutcome",
+            "issue": [{"severity": "error", "code": "processing", "diagnostics": "HAPI returned 400"}],
+        },
+        populations={
+            "initial_population": False,
+            "denominator": False,
+            "numerator": False,
+            "denominator_exclusion": False,
+            "numerator_exclusion": False,
+            "error": True,
+            "error_message": "HAPI returned 400",
+        },
+    )
+    test_session.add(mr)
+    await test_session.commit()
+
+    resp = await client.get(f"/results?job_id={job.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_patients"] == 1
+    assert data["failed_patients"] == 1
+    assert data["populations"]["initial_population"] == 0
+    assert data["patients"][0]["status"] == "error"
+    assert data["patients"][0]["error_message"] == "HAPI returned 400"
 
 
 async def test_get_results_empty(client):

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -14,7 +14,9 @@ from app.services.fhir_client import (
     list_measures,
     push_resources,
     resolve_evaluated_resource,
+    trigger_reindex_and_wait,
     upload_measure_bundle,
+    wait_for_valueset_expansion,
     wipe_patient_data,
 )
 from app.services.fhir_client import (
@@ -1199,3 +1201,112 @@ async def test_data_requirements_strategy_gather_patients_delegates_to_batch():
 
     assert len(patients) == 1
     assert patients[0]["id"] == "p1"
+
+
+class FakeSyncResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSyncClient:
+    def __init__(self, *, get_responses: list[FakeSyncResponse], post_responses: list[FakeSyncResponse]) -> None:
+        self.get_responses = get_responses
+        self.post_responses = post_responses
+        self.get_calls: list[str] = []
+        self.post_calls: list[tuple[str, dict | None]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url: str, **kwargs):
+        self.get_calls.append(url)
+        return self.get_responses.pop(0)
+
+    def post(self, url: str, json: dict | None = None, **kwargs):
+        self.post_calls.append((url, json))
+        return self.post_responses.pop(0)
+
+
+def test_trigger_reindex_and_wait_posts_202_and_polls_success(monkeypatch, caplog):
+    client = FakeSyncClient(
+        get_responses=[
+            FakeSyncResponse(200, {"entry": [{"resource": {"id": "p1"}}]}),
+            FakeSyncResponse(200, {"entry": [{"resource": {"id": "e1"}}]}),
+        ],
+        post_responses=[FakeSyncResponse(202)],
+    )
+
+    monkeypatch.setattr("app.services.fhir_client.httpx.Client", lambda **kwargs: client)
+    monkeypatch.setattr("app.services.fhir_client.time.sleep", lambda seconds: None)
+
+    with caplog.at_level("INFO"):
+        trigger_reindex_and_wait("http://hapi/fhir")
+
+    assert client.post_calls[0][0] == "http://hapi/fhir/$reindex"
+    assert client.post_calls[0][1] == {
+        "resourceType": "Parameters",
+        "parameter": [{"name": "type", "valueString": "Encounter"}],
+    }
+    assert client.get_calls == [
+        "http://hapi/fhir/Patient?_count=1",
+        "http://hapi/fhir/Encounter?patient=p1&_count=1",
+    ]
+    assert "HAPI reindex complete" in caplog.text
+
+
+def test_trigger_reindex_and_wait_logs_timeout(monkeypatch, caplog):
+    client = FakeSyncClient(get_responses=[], post_responses=[FakeSyncResponse(202)])
+    monkeypatch.setattr("app.services.fhir_client.httpx.Client", lambda **kwargs: client)
+
+    with caplog.at_level("WARNING"):
+        trigger_reindex_and_wait("http://hapi/fhir", probe_patient_id="p1", timeout_s=0)
+
+    assert client.post_calls[0][0] == "http://hapi/fhir/$reindex"
+    assert "HAPI reindex timed out" in caplog.text
+
+
+def test_wait_for_valueset_expansion_returns_per_url_status(monkeypatch, caplog):
+    client = FakeSyncClient(
+        get_responses=[
+            FakeSyncResponse(200, {"entry": []}),
+            FakeSyncResponse(200, {"entry": [{"resource": {"id": "vs-ok"}}]}),
+        ],
+        post_responses=[
+            FakeSyncResponse(200, {"expansion": {"total": 42, "contains": [{"code": "a"}]}}),
+        ],
+    )
+    monkeypatch.setattr("app.services.fhir_client.httpx.Client", lambda **kwargs: client)
+    monkeypatch.setattr("app.services.fhir_client.time.sleep", lambda seconds: None)
+
+    with caplog.at_level("WARNING"):
+        expanded = wait_for_valueset_expansion("http://hapi/fhir", ["http://vs/ok", "http://vs/missing"], timeout_s=1)
+
+    assert expanded == {"http://vs/ok": 42}
+    assert client.post_calls == [("http://hapi/fhir/ValueSet/vs-ok/$expand?count=2", None)]
+    assert "ValueSet not found for expansion wait" in caplog.text
+
+
+def test_wait_for_valueset_expansion_logs_timeout(monkeypatch, caplog):
+    client = FakeSyncClient(
+        get_responses=[FakeSyncResponse(200, {"entry": [{"resource": {"id": "vs-timeout"}}]})],
+        post_responses=[],
+    )
+    monkeypatch.setattr("app.services.fhir_client.httpx.Client", lambda **kwargs: client)
+
+    with caplog.at_level("WARNING"):
+        expanded = wait_for_valueset_expansion("http://hapi/fhir", ["http://vs/timeout"], timeout_s=0)
+
+    assert expanded == {}
+    assert "ValueSet expansion timed out" in caplog.text

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.job import Job, JobStatus, MeasureResult
 from app.services.orchestrator import (
+    _error_measure_report,
     _extract_patient_name,
     _extract_populations,
     _get_cdr_auth_headers,
@@ -73,6 +74,16 @@ class TestExtractPatientName:
     def test_no_name(self):
         assert _extract_patient_name({}) is None
         assert _extract_patient_name({"name": []}) is None
+
+
+def test_error_measure_report_sanitizes_internal_urls():
+    report = _error_measure_report("p1", Exception("HTTP 400 at http://hapi-fhir-measure:8080/fhir"))
+
+    assert report["resourceType"] == "OperationOutcome"
+    assert report["subject"]["reference"] == "Patient/p1"
+    diagnostics = report["issue"][0]["diagnostics"]
+    assert "hapi-fhir-measure" not in diagnostics
+    assert "8080" not in diagnostics
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +166,7 @@ async def test_run_job_happy_path(test_session, session_factory, mock_measure_re
         assert results[0].patient_id == "p1"
         assert results[0].patient_name == "Alice Test"
 
-    mock_wipe.assert_called_once()
+    mock_wipe.assert_awaited_once_with(strict=False)
 
 
 async def test_run_job_no_patients(test_session, session_factory):
@@ -278,11 +289,62 @@ async def test_run_job_partial_patient_failure(test_session, session_factory, mo
         assert job.processed_patients == 1
         assert job.failed_patients == 1
 
-        # Only one result should be stored
+        # One successful result and one per-patient error result should be stored.
         result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
         results = result.scalars().all()
-        assert len(results) == 1
-        assert results[0].patient_id == "p1"
+        assert len(results) == 2
+        by_patient = {r.patient_id: r for r in results}
+        assert by_patient["p1"].populations.get("error") is None
+        assert by_patient["p2"].populations["error"] is True
+        assert "Evaluation failed for p2" in by_patient["p2"].populations["error_message"]
+
+
+async def test_run_job_all_patient_failures_marks_job_failed(test_session, session_factory):
+    """run_job: if every patient evaluation fails, the job must not look successful."""
+    job_id = await _setup_job(test_session)
+
+    patients = [
+        {"resourceType": "Patient", "id": "p1", "name": [{"given": ["Alice"], "family": "Bad"}]},
+        {"resourceType": "Patient", "id": "p2", "name": [{"given": ["Bob"], "family": "Bad"}]},
+    ]
+
+    with (
+        _make_session_factory_patch(session_factory),
+        patch("app.services.orchestrator.wipe_patient_data", new_callable=AsyncMock),
+        patch("app.services.orchestrator._get_cdr_auth_headers", new_callable=AsyncMock, return_value={}),
+        patch("app.services.orchestrator._get_cdr_url", new_callable=AsyncMock, return_value="http://cdr/fhir"),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patients",
+            new_callable=AsyncMock,
+            return_value=patients,
+        ),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patient_data",
+            new_callable=AsyncMock,
+            return_value=[{"resourceType": "Patient", "id": "p1"}],
+        ),
+        patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch(
+            "app.services.orchestrator.evaluate_measure",
+            new_callable=AsyncMock,
+            side_effect=Exception("HAPI returned 400"),
+        ),
+    ):
+        await run_job(job_id)
+
+    async with session_factory() as session:
+        job = await session.get(Job, job_id)
+        assert job.status == JobStatus.failed
+        assert job.processed_patients == 0
+        assert job.failed_patients == 2
+        assert job.error_message == "All 2 patient evaluations failed"
+
+        result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
+        results = result.scalars().all()
+        assert len(results) == 2
+        assert all(r.populations["error"] is True for r in results)
 
 
 async def test_run_job_cancelled_before_batches(test_session, session_factory):
@@ -342,12 +404,87 @@ async def test_get_cdr_auth_headers_reads_from_job_row(test_session, session_fac
     mock_auth.assert_called_once_with("bearer", {"token": "test-jwt"})
 
 
-async def test_process_batch_uses_data_requirements_strategy(test_session, session_factory):
-    """_process_single_batch uses DataRequirementsStrategy by default."""
+async def test_process_batch_uses_everything_strategy(test_session, session_factory, monkeypatch):
+    """_process_single_batch uses $everything by default for complete patient graphs."""
     from unittest.mock import MagicMock
 
     from app.models.job import Batch, BatchStatus
     from app.services.orchestrator import _process_single_batch
+
+    monkeypatch.setattr("app.services.orchestrator.settings.PATIENT_DATA_STRATEGY", "batch")
+
+    job = Job(
+        measure_id="CMS999",
+        period_start="2026-01-01",
+        period_end="2026-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.running,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    batch = Batch(
+        job_id=job.id,
+        batch_number=1,
+        patient_ids=["p1"],
+        status=BatchStatus.pending,
+    )
+    test_session.add(batch)
+    await test_session.commit()
+    await test_session.refresh(batch)
+
+    patient_map = {"p1": {"resourceType": "Patient", "id": "p1"}}
+
+    with (
+        _make_session_factory_patch(session_factory),
+        patch("app.services.orchestrator.BatchQueryStrategy") as mock_strategy_cls,
+        patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "app.services.orchestrator.evaluate_measure",
+            new_callable=AsyncMock,
+            return_value={
+                "resourceType": "MeasureReport",
+                "status": "complete",
+                "group": [
+                    {
+                        "population": [
+                            {"code": {"coding": [{"code": "initial-population"}]}, "count": 1},
+                            {"code": {"coding": [{"code": "denominator"}]}, "count": 1},
+                            {"code": {"coding": [{"code": "numerator"}]}, "count": 0},
+                        ]
+                    }
+                ],
+            },
+        ),
+        patch("app.services.orchestrator.wipe_patient_data", new_callable=AsyncMock),
+    ):
+        mock_strategy = MagicMock()
+        mock_strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "p1"}])
+        mock_strategy_cls.return_value = mock_strategy
+
+        await _process_single_batch(
+            job_id=job.id,
+            batch_id=batch.id,
+            patient_map=patient_map,
+            cdr_url="http://cdr/fhir",
+            auth_headers={},
+        )
+
+    mock_strategy_cls.assert_called_once_with()
+
+
+async def test_process_batch_uses_data_requirements_strategy_when_configured(
+    test_session, session_factory, monkeypatch
+):
+    """_process_single_batch can be rolled back to DataRequirementsStrategy by env config."""
+    from unittest.mock import MagicMock
+
+    from app.models.job import Batch, BatchStatus
+    from app.services.orchestrator import _process_single_batch
+
+    monkeypatch.setattr("app.services.orchestrator.settings.PATIENT_DATA_STRATEGY", "data_requirements")
 
     job = Job(
         measure_id="CMS999",
@@ -376,6 +513,7 @@ async def test_process_batch_uses_data_requirements_strategy(test_session, sessi
         _make_session_factory_patch(session_factory),
         patch("app.services.orchestrator.DataRequirementsStrategy") as mock_strategy_cls,
         patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.asyncio.sleep", new_callable=AsyncMock),
         patch(
             "app.services.orchestrator.evaluate_measure",
             new_callable=AsyncMock,
@@ -393,7 +531,6 @@ async def test_process_batch_uses_data_requirements_strategy(test_session, sessi
                 ],
             },
         ),
-        patch("app.services.orchestrator.wipe_patient_data", new_callable=AsyncMock),
     ):
         mock_strategy = MagicMock()
         mock_strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "p1"}])

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -14,6 +14,7 @@ from app.services.validation import (
     _extract_population_counts,
     _extract_test_case_info,
     _fix_valueset_compose_for_hapi,
+    _get_codesystem_stubs_from_valuesets,
     _get_missing_valueset_stubs,
     _is_test_case_measure_report,
     _prepare_measure_support_resources,
@@ -25,6 +26,13 @@ from app.services.validation import (
     sanitize_error,
     triage_test_bundle,
 )
+
+
+@pytest.fixture(autouse=True)
+def disable_hapi_sync_after_upload(monkeypatch):
+    """Keep existing triage tests from exercising product HAPI sync waits."""
+    monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", False)
+
 
 # ---------------------------------------------------------------------------
 # sanitize_error
@@ -507,6 +515,7 @@ class TestTriageTestBundle:
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
             with patch("app.services.validation.settings") as mock_settings:
                 mock_settings.DEFAULT_CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
+                mock_settings.HAPI_SYNC_AFTER_UPLOAD = False
                 result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         # Measure + Library = 2 measure defs → push_resources called once for defs
@@ -571,6 +580,7 @@ class TestTriageTestBundle:
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
             with patch("app.services.validation.settings") as mock_settings:
                 mock_settings.DEFAULT_CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
+                mock_settings.HAPI_SYNC_AFTER_UPLOAD = False
                 result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
 
         # clinical data pushed with auth headers
@@ -621,6 +631,7 @@ class TestTriageTestBundle:
         with patch("app.services.validation.push_resources", new_callable=AsyncMock) as mock_push:
             with patch("app.services.validation.settings") as mock_settings:
                 mock_settings.DEFAULT_CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
+                mock_settings.HAPI_SYNC_AFTER_UPLOAD = False
                 result = await triage_test_bundle(bundle, "defs-only.json", test_session)
 
         assert result["measures_loaded"] == 1
@@ -729,6 +740,48 @@ class TestTriageTestBundle:
 
         assert result["expected_results_loaded"] == 1
         assert refreshed_count == 1
+
+    async def test_hapi_sync_after_upload_calls_reindex_and_valueset_wait(
+        self, test_session, mock_test_bundle_with_expected, monkeypatch
+    ):
+        """When enabled, triage blocks on HAPI reindex and ValueSet expansion readiness."""
+        stub = {"resourceType": "ValueSet", "id": "stub-vs", "url": "http://example.com/ValueSet/stub"}
+        monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", True)
+        monkeypatch.setattr("app.services.validation.settings.MEASURE_ENGINE_URL", "http://measure/fhir")
+
+        with (
+            patch("app.services.validation.push_resources", new_callable=AsyncMock),
+            patch(
+                "app.services.validation._prepare_measure_support_resources",
+                new_callable=AsyncMock,
+                return_value=[stub],
+            ),
+            patch("app.services.validation.trigger_reindex_and_wait") as mock_reindex,
+            patch("app.services.validation.wait_for_valueset_expansion", return_value={stub["url"]: 1}) as mock_wait,
+        ):
+            result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        assert result["measures_loaded"] == 1
+        mock_reindex.assert_called_once_with("http://measure/fhir")
+        mock_wait.assert_called_once()
+        assert mock_wait.call_args.args[0] == "http://measure/fhir"
+        assert stub["url"] in mock_wait.call_args.args[1]
+
+    async def test_hapi_sync_after_upload_false_skips_sync_helpers(
+        self, test_session, mock_test_bundle_with_expected, monkeypatch
+    ):
+        monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", False)
+
+        with (
+            patch("app.services.validation.push_resources", new_callable=AsyncMock),
+            patch("app.services.validation.trigger_reindex_and_wait") as mock_reindex,
+            patch("app.services.validation.wait_for_valueset_expansion") as mock_wait,
+        ):
+            result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        assert result["measures_loaded"] == 1
+        mock_reindex.assert_not_called()
+        mock_wait.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1358,6 +1411,42 @@ class TestMissingValueSetStubs:
         assert stubs[0]["resourceType"] == "ValueSet"
         assert stubs[0]["status"] == "active"
 
+    def test_get_codesystem_stubs_from_valuesets_uses_bundle_coding_versions(self):
+        valueset = {
+            "resourceType": "ValueSet",
+            "id": "payer",
+            "url": "http://cts.nlm.nih.gov/fhir/ValueSet/payer",
+            "compose": {
+                "include": [
+                    {
+                        "system": "https://nahdo.org/sopt",
+                        "concept": [{"code": "1", "display": "MEDICARE"}],
+                    }
+                ]
+            },
+        }
+        bundle = {
+            "resourceType": "Bundle",
+            "entry": [
+                {"resource": valueset},
+                {
+                    "resource": {
+                        "resourceType": "Coverage",
+                        "id": "coverage",
+                        "type": {"coding": [{"system": "https://nahdo.org/sopt", "version": "9.2", "code": "1"}]},
+                    }
+                },
+            ],
+        }
+
+        stubs = _get_codesystem_stubs_from_valuesets([valueset], bundle)
+
+        versioned_stub = next(stub for stub in stubs if stub.get("version") == "9.2")
+        assert versioned_stub["resourceType"] == "CodeSystem"
+        assert versioned_stub["url"] == "https://nahdo.org/sopt"
+        assert versioned_stub["content"] == "complete"
+        assert versioned_stub["concept"] == [{"code": "1", "display": "MEDICARE"}]
+
     async def test_prepare_measure_support_resources_adds_missing_stubs(self):
         missing_url = "http://cts.nlm.nih.gov/fhir/ValueSet/1.2.3"
         bundle = self._bundle_with_elm([missing_url])
@@ -1399,7 +1488,13 @@ class TestMissingValueSetStubs:
 
         assert prepared == []
 
-    async def test_prepare_measure_support_resources_remaps_existing_valueset_id(self):
+    @pytest.mark.parametrize(
+        ("reload_mode", "expected_id", "delete_called"),
+        [("delete", "bundle-id", True), ("remap", "existing-id", False)],
+    )
+    async def test_prepare_measure_support_resources_handles_existing_valueset_by_reload_mode(
+        self, reload_mode, expected_id, delete_called, monkeypatch
+    ):
         valueset = {
             "resourceType": "ValueSet",
             "id": "bundle-id",
@@ -1407,6 +1502,7 @@ class TestMissingValueSetStubs:
             "expansion": {"contains": [{"system": "http://loinc.org", "code": "1234-5"}]},
         }
         bundle = {"resourceType": "Bundle", "entry": [{"resource": valueset}]}
+        monkeypatch.setattr("app.services.validation.settings.VALUESET_RELOAD_MODE", reload_mode)
 
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
@@ -1414,8 +1510,12 @@ class TestMissingValueSetStubs:
             "resourceType": "Bundle",
             "entry": [{"resource": {"resourceType": "ValueSet", "id": "existing-id", "url": valueset["url"]}}],
         }
+        mock_delete_response = MagicMock()
+        mock_delete_response.status_code = 204
+        mock_delete_response.raise_for_status = MagicMock()
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.delete = AsyncMock(return_value=mock_delete_response)
         mock_ctx = MagicMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
@@ -1423,5 +1523,11 @@ class TestMissingValueSetStubs:
         with patch("app.services.validation.httpx.AsyncClient", return_value=mock_ctx):
             prepared = await _prepare_measure_support_resources([valueset], bundle)
 
-        assert prepared[0]["id"] == "existing-id"
+        if delete_called:
+            mock_client.delete.assert_awaited_once()
+            assert str(mock_client.delete.await_args.args[0]).endswith("/ValueSet/existing-id")
+        else:
+            mock_client.delete.assert_not_awaited()
+        prepared_valueset = next(resource for resource in prepared if resource.get("resourceType") == "ValueSet")
+        assert prepared_valueset["id"] == expected_id
         assert valueset["id"] == "bundle-id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       - DATABASE_URL=postgresql+asyncpg://mct2:mct2@db:5432/mct2
       - MEASURE_ENGINE_URL=http://hapi-fhir-measure:8080/fhir
       - DEFAULT_CDR_URL=http://hapi-fhir-cdr:8080/fhir
-      - CONNECTATHON_BUNDLES_DIR=/seed/connectathon-bundles
+      - CONNECTATHON_BUNDLES_DIR=/seed/disabled-connectathon-bundles # Manual uploads exercise HAPI sync; don't gate health on startup replay.
+      - PATIENT_DATA_STRATEGY=${PATIENT_DATA_STRATEGY:-batch}
+      - VALUESET_RELOAD_MODE=${VALUESET_RELOAD_MODE:-delete}
+      - HAPI_SYNC_AFTER_UPLOAD=${HAPI_SYNC_AFTER_UPLOAD:-true}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\""]
       interval: 10s
@@ -65,6 +68,7 @@ services:
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.enforce_referential_integrity_on_write=false
+      - hapi.fhir.maximum_expansion_size=50000 # Connectathon ValueSets exceed HAPI's default expansion limit.
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
       - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
@@ -88,7 +92,10 @@ services:
       - hapi.fhir.reuse_cached_search_results_millis=0
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_multiple_delete=true
+      - hapi.fhir.allow_external_references=true # Match integration harness; bundles reference external canonicals.
       - hapi.fhir.cr.enabled=true
+      - hapi.fhir.enforce_referential_integrity_on_write=false # Match harness; MADiE bundles can omit referenced resources.
+      - hapi.fhir.maximum_expansion_size=50000 # Connectathon ValueSets exceed HAPI's default expansion limit.
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
       - spring.jpa.properties.hibernate.search.enabled=true
@@ -96,6 +103,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
       - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+      - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100 # Reduce HAPI search-index lag after uploads.
       - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m
 
   seed:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,6 +89,12 @@ The nightly `connectathon-measures.yml` workflow still runs once per night, but 
 
 ---
 
+## Troubleshooting measure IP undercount
+
+If `/jobs` reports lower initial population counts than the direct-HAPI integration harness, check `HAPI_SYNC_AFTER_UPLOAD`, `PATIENT_DATA_STRATEGY`, and `VALUESET_RELOAD_MODE` first. HAPI indexes Encounter patient references and expands large ValueSets asynchronously after bundle upload, so MCT2 waits for reindex and `$expand` readiness before jobs can run against freshly uploaded Connectathon bundles. To isolate a regression, temporarily set `HAPI_SYNC_AFTER_UPLOAD=False`, `PATIENT_DATA_STRATEGY=data_requirements`, or `VALUESET_RELOAD_MODE=remap` and restart the backend.
+
+---
+
 ## Connectathon Measure Tests (manifest-driven)
 
 `backend/tests/integration/test_connectathon_measures.py` runs one parametrized pytest case per test-case `MeasureReport` found in the connectathon bundles. The set of measures under test — and which ones trigger strict assertions — is controlled entirely by `seed/connectathon-bundles/manifest.json`.


### PR DESCRIPTION
## Summary
- Fixes real MCT2 /jobs runs returning all-zero or under-counted populations for Connectathon measures that pass the direct-HAPI integration harness.
- Ports the two harness sync helpers (_trigger_reindex_and_wait, _wait_for_valueset_expansion) into the product path. After /validation/upload-bundle completes, MCT2 now blocks until HAPI has finished indexing Encounter reference-search params and expanding all bundle ValueSets — before the user can start a /jobs evaluation.
- Switches default patient-data gather from DataRequirementsStrategy to BatchQueryStrategy so the measure engine sees full clinical graphs per patient.
- Persists per-patient evaluation errors as MeasureResult rows (populations.error=True) so failures are visible instead of silently returning zero. Jobs where every patient fails now transition to JobStatus.failed.
- Ports bundle-fixing helpers (Library dependency URLs, duplicate Claim IDs, generated CodeSystem stubs) so MADiE connectathon bundles upload cleanly.
- All three risky behavior changes are gated behind env vars so ops can revert without a redeploy:
  - PATIENT_DATA_STRATEGY (batch | data_requirements)
  - VALUESET_RELOAD_MODE (delete | remap)
  - HAPI_SYNC_AFTER_UPLOAD (bool)

## Why
Root cause: HAPI indexes reference-search params and expands ValueSets asynchronously. The /jobs path was starting $evaluate-measure before either completed, so the CQL engine's Encounter?patient={id} queries returned empty and patients dropped from the initial population. The integration harness has always waited for these; the product path didn't. Full investigation in ../mct2-diag/ (local, not in repo) documenting diagnostic evidence across 11 Connectathon measures.

## Measured impact
Baseline vs post-fix, on the same MADiE bundles, same local docker stack:

| Measure | Baseline | After | Delta |
|---|---|---|---|
| CMS124 | 22/33 | 33/33 | +11 |
| CMS506 | 17/38 | 38/38 | +21 |
| CMS816 | 5/9 | 9/9 | +4 |
| CMS130 | 27/64 | 63/64 | +36 (1 residual; tracked in #141) |
| CMS125 | 24/66 | 56/66 | +32 (10 residual; HAPI-0831, tracked in #141) |

## Rollback
Set HAPI_SYNC_AFTER_UPLOAD=False, PATIENT_DATA_STRATEGY=data_requirements, VALUESET_RELOAD_MODE=remap in the backend's env and restart. Restores pre-fix behavior with no data migration. Instant.

## Not in this PR (follow-ups, linked issues)
- Nightly CI gate exercising /jobs for the green measures — separate PR.
- Frontend failed-job dropdown + error badges — separate PR, independent.
- CMS122 denominator_exclusion anomaly — issue #140, separate root cause.
- HAPI-0831 large-ValueSet async pre-expansion — issue #141, upstream HAPI behavior.

## Validation
- ruff clean
- Unit tests: 298 passing including new coverage for reindex helpers, sync integration, both strategy values, both reload modes
- Manual /jobs smoke on CMS124, CMS506, CMS816 reproduces the "After" column above
- Manual flag rollback: from a clean volume with `HAPI_SYNC_AFTER_UPLOAD=False`, backend env showed `HAPI_SYNC_AFTER_UPLOAD=False`, logs showed `HAPI sync skipped (HAPI_SYNC_AFTER_UPLOAD=False)`, and CMS816 reproduced the baseline-shape undercount:

```text
# CMS816FHIRHHHypo

- Measure FHIR id: `CMS816FHIRHHHypo`
- Group id: `CMS816FHIRHHHypo`
- Match: `yes`
- Local expected pass: `no`
- Production expected pass: `no`
- Patient diffs: `0`
- Expected comparison diffs: `0`

## Job Counts

| Environment | Job ID | Status | Total | Processed | Failed |
|---|---:|---|---:|---:|---:|
| Local | 1 | complete | 9 | 9 | 0 |
| Production | 1 | complete | 9 | 9 | 0 |

## Result Aggregates

| Environment | Result Rows | Failed Rows | Initial Pop | Denominator | Numerator | Denom Excl | Perf Rate |
|---|---:|---:|---:|---:|---:|---:|---:|
| Local | 9 | 0 | 4 | 4 | 3 | 0 | 75.0 |
| Production | 9 | 0 | 4 | 4 | 3 | 0 | 75.0 |

## Expected Comparison

| Environment | Has Expected | Matched | Total | Expected Total | Actual Total | Missing | Unexpected |
|---|---|---:|---:|---:|---:|---:|---:|
| Local | True | 5 | 9 | 9 | 9 | 0 | 0 |
| Production | True | 5 | 9 | 9 | 9 | 0 | 0 |
```
