### PR TITLE
fix: rebuild images on deploy (add --build to docker compose up)

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -155,9 +155,12 @@ done
 printf '[+] Reconciling DB password...\n'
 LEONARD_DIR="$LEONARD_DIR" "$RECONCILE_SCRIPT"
 
-# ── step 7: bring up remaining services ──────────────────────────────────────
-printf '[+] Starting remaining services...\n'
-"${COMPOSE[@]}" up -d
+# ── step 7: build and bring up remaining services ────────────────────────────
+# --build ensures locally-built images (backend, frontend, seed) are rebuilt
+# from the current Dockerfile so the new entrypoint and code are picked up.
+# Services using pre-built images (hapi, postgres, caddy) are unaffected.
+printf '[+] Building and starting remaining services...\n'
+"${COMPOSE[@]}" up -d --build
 
 # ── step 8: health check ──────────────────────────────────────────────────────
 printf '[+] Waiting for API health check...\n'


### PR DESCRIPTION
## Summary

- `deploy-prod.sh` was calling `docker compose up -d` without `--build`
- After `git reset --hard origin/main`, the Dockerfile on disk is current but the cached Docker image is stale (built before Part A landed)
- The new `backend/docker-entrypoint.sh` (reads Docker secret, assembles `DATABASE_URL`) was not in the cached image
- Backend fell back to the hardcoded `mct2:mct2` default, but postgres now has the new SSM-sourced password → `InvalidPasswordError`
- Fix: add `--build` so locally-built services (backend, frontend, seed) are rebuilt on every deploy; pre-built images (hapi, postgres, caddy) are unaffected

## Test plan

- [ ] Merge this PR
- [ ] Trigger prod deploy — backend should rebuild, read Docker secret, connect successfully
- [ ] `https://api.98-89-219-217.nip.io/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)