### PR TITLE
fix: attach AmazonSSMManagedInstanceCore in bootstrap-aws.sh

### DIFF
--- a/scripts/bootstrap-aws.sh
+++ b/scripts/bootstrap-aws.sh
@@ -133,6 +133,27 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 4b. Attach AmazonSSMManagedInstanceCore — required for SSM Run Command
+# ---------------------------------------------------------------------------
+SSM_CORE_ARN="arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+echo "[+] Checking AmazonSSMManagedInstanceCore attachment ..."
+ATTACHED_CORE=$(aws iam list-attached-role-policies \
+  --role-name "$ROLE_NAME" \
+  --region "$REGION" \
+  --query "AttachedPolicies[?PolicyArn=='${SSM_CORE_ARN}'].PolicyArn" \
+  --output text)
+if [ -n "$ATTACHED_CORE" ]; then
+  echo "[=] AmazonSSMManagedInstanceCore already attached — skipping"
+else
+  echo "[+] Attaching AmazonSSMManagedInstanceCore ..."
+  aws iam attach-role-policy \
+    --role-name "$ROLE_NAME" \
+    --policy-arn "$SSM_CORE_ARN" \
+    --region "$REGION"
+  echo "[✓] AmazonSSMManagedInstanceCore attached"
+fi
+
+# ---------------------------------------------------------------------------
 # 5. Instance profile — skip if exists
 # ---------------------------------------------------------------------------
 echo "[+] Checking instance profile $PROFILE_NAME ..."


### PR DESCRIPTION
## Summary
- `AmazonSSMManagedInstanceCore` was manually attached to `leonard-ec2-prod` role after the SSM agent failed to register post stop/start
- Without it the SSM agent gets `AccessDenied` on `ssm:UpdateInstanceInformation` and sleeps 30 min before retry
- This adds an idempotent step 4b to `bootstrap-aws.sh` so future runs wire it correctly

## Test plan
- [x] SSM `Online` immediately after restarting the agent (verified live in prod)
- [x] `bootstrap-aws.sh` passes `--already attached` guard on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)