### PR TITLE
fix: expose batch counts in job API and add Results page actions

### DIFF
--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.db import get_session
 from app.dependencies import CDRContext, get_active_cdr
-from app.models.job import Job, JobStatus, MeasureResult
+from app.models.job import BatchStatus, Job, JobStatus, MeasureResult
 from app.models.validation import ExpectedResult
 from app.services.fhir_client import _build_auth_headers, _validate_ssrf_url, list_groups
 from app.services.validation import _extract_population_counts, compare_populations
@@ -63,6 +63,8 @@ class JobResponse(BaseModel):
     total_patients: int
     processed_patients: int
     failed_patients: int
+    total_batches: int = 0
+    batches_completed: int = 0
     delete_requested: bool
     created_at: str
     completed_at: Optional[str]
@@ -94,6 +96,7 @@ class JobDetailResponse(JobResponse):
 
 
 def _job_to_response(job: Job) -> dict:
+    batches = job.batches if job.batches is not None else []
     return {
         "id": job.id,
         "measure_id": job.measure_id,
@@ -108,6 +111,8 @@ def _job_to_response(job: Job) -> dict:
         "total_patients": job.total_patients,
         "processed_patients": job.processed_patients,
         "failed_patients": job.failed_patients,
+        "total_batches": len(batches),
+        "batches_completed": sum(1 for b in batches if b.status == BatchStatus.complete),
         "delete_requested": job.delete_requested,
         "created_at": job.created_at.isoformat() if job.created_at else None,
         "completed_at": job.completed_at.isoformat() if job.completed_at else None,

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -319,6 +319,32 @@ async def test_create_job_stamps_cdr_auth_type_as_string_value(client, test_sess
     assert job.cdr_auth_type == "bearer"
 
 
+async def test_list_jobs_includes_batch_counts(client, test_session):
+    """GET /jobs includes total_batches and batches_completed counts."""
+    from app.models.job import Batch, BatchStatus, Job, JobStatus
+
+    job = Job(
+        measure_id="measure-1",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="https://example.com/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.flush()
+    test_session.add(Batch(job_id=job.id, batch_number=1, patient_ids=["p1"], status=BatchStatus.complete))
+    test_session.add(Batch(job_id=job.id, batch_number=2, patient_ids=["p2"], status=BatchStatus.complete))
+    test_session.add(Batch(job_id=job.id, batch_number=3, patient_ids=["p3"], status=BatchStatus.pending))
+    await test_session.commit()
+
+    resp = await client.get("/jobs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["total_batches"] == 3
+    assert data[0]["batches_completed"] == 2
+
+
 async def test_list_jobs_includes_delete_requested(client, test_session):
     """GET /jobs includes delete_requested so the UI can reflect pending deletion."""
     from app.models.job import Job

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './ResultsPage.module.css';
-import { getJobs, getResults, getResult } from '../api/client';
+import { getJobs, getResults, getResult, createJob } from '../api/client';
+import { useToast } from '../components/Toast';
 import PatientDetail from '../components/PatientDetail';
 import ComparisonView from '../components/ComparisonView';
 
@@ -22,9 +23,59 @@ function CrossMark() {
   return <span className={styles.cross} aria-label="No" title="No">&#10007;</span>;
 }
 
+function timeAgo(dateStr) {
+  if (!dateStr) return null;
+  const diff = Math.floor((Date.now() - new Date(dateStr)) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function exportCsv(patients, measureName, period) {
+  const header = ['Patient ID', 'Name', 'Initial Population', 'Denominator', 'Numerator', 'Denom Exclusion'];
+  const rows = patients.map(p => [
+    p.patient_id || p.id || '',
+    p.patient_name || p.name || '',
+    p.populations?.initial_population ? 'Yes' : 'No',
+    p.populations?.denominator ? 'Yes' : 'No',
+    p.populations?.numerator ? 'Yes' : 'No',
+    p.populations?.denominator_exclusion ? 'Yes' : 'No',
+  ]);
+  const csv = [header, ...rows].map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `results-${measureName || 'measure'}-${period || 'period'}.csv`.replace(/\s+/g, '-');
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+const FILTER_OPTIONS = [
+  { value: 'all', label: 'All Patients' },
+  { value: 'numerator', label: 'In Numerator' },
+  { value: 'denominator_only', label: 'Denominator (not Numerator)' },
+  { value: 'excluded', label: 'Denominator Exclusion' },
+  { value: 'not_in_denominator', label: 'Not in Denominator' },
+];
+
+function applyFilter(patients, filter) {
+  if (filter === 'all') return patients;
+  return patients.filter(p => {
+    const pop = p.populations || {};
+    if (filter === 'numerator') return pop.numerator;
+    if (filter === 'denominator_only') return pop.denominator && !pop.numerator;
+    if (filter === 'excluded') return pop.denominator_exclusion;
+    if (filter === 'not_in_denominator') return !pop.denominator;
+    return true;
+  });
+}
+
 export default function ResultsPage() {
   const { jobId: routeJobId } = useParams();
   const navigate = useNavigate();
+  const toast = useToast();
 
   const [jobs, setJobs] = useState([]);
   const [selectedJobId, setSelectedJobId] = useState(routeJobId || '');
@@ -34,6 +85,8 @@ export default function ResultsPage() {
   const [selectedPatient, setSelectedPatient] = useState(null);
   const [patientDetail, setPatientDetail] = useState(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  const [populationFilter, setPopulationFilter] = useState('all');
+  const [rerunning, setRerunning] = useState(false);
 
   // Load completed jobs for dropdown
   useEffect(() => {
@@ -96,6 +149,7 @@ export default function ResultsPage() {
   const handleJobChange = (e) => {
     const id = e.target.value;
     setSelectedJobId(id);
+    setPopulationFilter('all');
     navigate(`/results/${id}`, { replace: true });
   };
 
@@ -121,11 +175,32 @@ export default function ResultsPage() {
     setPatientDetail(null);
   }, []);
 
+  const handleRerun = async () => {
+    if (!selectedJob) return;
+    setRerunning(true);
+    try {
+      await createJob({
+        measure_id: selectedJob.measure_id,
+        measure_name: selectedJob.measure_name,
+        group_id: selectedJob.group_id || undefined,
+        period_start: selectedJob.period_start || undefined,
+        period_end: selectedJob.period_end || undefined,
+      });
+      toast.success('Re-run started — check the Jobs page');
+      navigate('/jobs');
+    } catch (err) {
+      toast.error(`Failed to start re-run: ${err.message}`);
+    } finally {
+      setRerunning(false);
+    }
+  };
+
   const selectedJob = jobs.find(j => String(j.id) === String(selectedJobId));
 
   // Extract aggregate data — API returns { populations: {...}, patients: [...], ... }
   const populations = results?.populations || {};
-  const patients = results?.patients || [];
+  const allPatients = results?.patients || [];
+  const patients = applyFilter(allPatients, populationFilter);
   const measureName = results?.measure_name || selectedJob?.measure_name || selectedJob?.measure_id || '';
   const period = selectedJob?.period_start && selectedJob?.period_end
     ? `${selectedJob.period_start} to ${selectedJob.period_end}`
@@ -136,6 +211,8 @@ export default function ResultsPage() {
   const numerator = populations.numerator;
   const denomExclusion = populations.denominator_exclusion;
   const performanceRate = results?.performance_rate;
+
+  const completedAgo = selectedJob?.completed_at ? timeAgo(selectedJob.completed_at) : null;
 
   return (
     <div className={styles.page}>
@@ -157,6 +234,27 @@ export default function ResultsPage() {
                 </option>
               ))}
             </select>
+          </div>
+        )}
+        {selectedJobId && results && (
+          <div className={styles.headerActions}>
+            <button
+              className={styles.btnSecondary}
+              onClick={() => exportCsv(allPatients, measureName, period)}
+              disabled={allPatients.length === 0}
+            >
+              Export CSV
+            </button>
+            {selectedJob && (
+              <button
+                className={styles.btnPrimary}
+                onClick={handleRerun}
+                disabled={rerunning}
+                aria-busy={rerunning}
+              >
+                {rerunning ? 'Starting…' : 'Re-run'}
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -218,7 +316,11 @@ export default function ResultsPage() {
           {/* Measure header */}
           {(measureName || period) && (
             <div className={styles.measureHeader}>
-              {measureName && <h2 className={styles.measureName}>{measureName}</h2>}
+              <div className={styles.measureTitleRow}>
+                {measureName && <h2 className={styles.measureName}>{measureName}</h2>}
+                <span className={styles.completeBadge}>Complete</span>
+                {completedAgo && <span className={styles.completedAgo}>Calculated {completedAgo}</span>}
+              </div>
               {period && <p className={styles.period}>Period: {period}</p>}
               {selectedJob?.cdr_name && <p className={styles.cdr}>CDR: {selectedJob.cdr_name}</p>}
             </div>
@@ -246,6 +348,21 @@ export default function ResultsPage() {
 
           {/* Patient list */}
           <div className={styles.tableWrapper}>
+            <div className={styles.tableToolbar}>
+              <span className={styles.patientCount}>
+                {patients.length.toLocaleString()} of {allPatients.length.toLocaleString()} patients
+              </span>
+              <select
+                className={styles.filterSelect}
+                value={populationFilter}
+                onChange={e => setPopulationFilter(e.target.value)}
+                aria-label="Filter by population"
+              >
+                {FILTER_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
             <table aria-label="Patient results">
               <thead>
                 <tr>
@@ -258,10 +375,12 @@ export default function ResultsPage() {
                 </tr>
               </thead>
               <tbody>
-                {(Array.isArray(patients) ? patients : []).length === 0 ? (
+                {patients.length === 0 ? (
                   <tr>
                     <td colSpan={6} className={styles.emptyRow}>
-                      No individual patient results available.
+                      {allPatients.length > 0
+                        ? 'No patients match this filter.'
+                        : 'No individual patient results available.'}
                     </td>
                   </tr>
                 ) : (

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -16,10 +16,56 @@
 }
 
 .jobSelector {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.headerActions {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: var(--space-2);
+}
+
+.btnSecondary {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  min-height: 36px;
+  transition: background var(--transition);
+}
+
+.btnSecondary:hover:not(:disabled) {
+  background: var(--color-bg-secondary);
+}
+
+.btnSecondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btnPrimary {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  min-height: 36px;
+  transition: background var(--transition);
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.btnPrimary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .jobLabel {
@@ -41,10 +87,32 @@
   margin-bottom: var(--space-6);
 }
 
+.measureTitleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-1);
+}
+
 .measureName {
   font-size: var(--font-size-section);
   font-weight: var(--font-weight-semibold);
-  margin-bottom: var(--space-1);
+}
+
+.completeBadge {
+  display: inline-block;
+  padding: 2px var(--space-2);
+  border-radius: 100px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-success-light);
+  color: var(--color-success);
+}
+
+.completedAgo {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
 }
 
 .period,
@@ -120,6 +188,30 @@
   font-size: var(--font-size-body);
   color: var(--color-text-secondary);
   margin-bottom: var(--space-6);
+}
+
+/* Table toolbar */
+.tableToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.patientCount {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.filterSelect {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  min-height: 32px;
+  max-width: 240px;
 }
 
 /* Patient table */


### PR DESCRIPTION
## Summary

- **Bug fix: batch grid never rendered** — `_job_to_response()` omitted `total_batches` and `batches_completed`, so the frontend's `totalBatches` was always 0 and the batch-progress grid was permanently hidden. Added both fields to `JobResponse` and computed them from `job.batches` (the `lazy="selectin"` relationship already loads it, so no extra query).
- **Results page: Export CSV** — client-side CSV download from the already-loaded patient list (no backend round-trip needed).
- **Results page: Re-run button** — creates a new job with the same measure/period/group params and navigates to the Jobs page.
- **Results page: Population filter** — dropdown to filter the patient table by numerator, denominator-only, denominator exclusion, or not-in-denominator.
- **Results page: Complete badge + time ago** — measure header now shows a green "Complete" badge and "Calculated Xm ago" alongside the measure name.

## Test plan

- [ ] Run a job and watch the batch grid appear on the Jobs page as batches complete
- [ ] On the Results page, verify Export CSV downloads a valid file with all patients
- [ ] Click Re-run and confirm a new job appears in the Jobs list with the same measure/period
- [ ] Use the population filter dropdown and confirm the patient count updates correctly
- [ ] Verify "Complete" badge and "Calculated X ago" appear in the Results header
- [ ] `python3 -m pytest backend/tests/test_routes_jobs.py -q` → 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)