### PR TITLE
[codex] Refresh mobile clinical UI

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0066CC" />
     <meta name="description" content="MCT2 - Healthcare Quality Measure Calculation Tool" />
     <title>MCT2</title>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,9 +36,18 @@ const SEARCH_PLACEHOLDER = {
   '/settings': 'Search…',
 };
 
+function MenuIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+      <path d="M3 5h12M3 9h12M3 13h12" />
+    </svg>
+  );
+}
+
 export default function App() {
   const location = useLocation();
   const navigate = useNavigate();
+  const [navOpen, setNavOpen] = useState(false);
   const [cdrStatus, setCdrStatus] = useState('unknown');
   const [cdrName, setCdrName] = useState('');
   const [theme, setTheme] = useState(() => localStorage.getItem('mct2-theme') || 'light');
@@ -54,6 +63,7 @@ export default function App() {
   // Clear search on navigation
   useEffect(() => {
     setQuery('');
+    setNavOpen(false);
   }, [location.pathname]);
 
   // CDR health check
@@ -90,6 +100,10 @@ export default function App() {
         setQuery('');
         return;
       }
+      if (e.key === 'Escape') {
+        setNavOpen(false);
+        return;
+      }
       if (!isInput && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         if (e.key === 'm' || e.key === 'M') navigate('/measures');
         else if (e.key === 'j' || e.key === 'J') navigate('/jobs');
@@ -108,7 +122,13 @@ export default function App() {
 
   return (
     <SearchContext.Provider value={{ query, setQuery }}>
-      <div className={styles.screen}>
+      <div className={`${styles.screen} ${navOpen ? styles.navOpen : ''}`}>
+        <button
+          className={styles.navBackdrop}
+          type="button"
+          aria-label="Close navigation"
+          onClick={() => setNavOpen(false)}
+        />
         {/* Brand */}
         <div className={styles.brand}>
           <div className={styles.brandMark}>M</div>
@@ -117,6 +137,15 @@ export default function App() {
 
         {/* Topbar */}
         <header className={styles.topbar}>
+          <button
+            className={styles.hamburger}
+            type="button"
+            aria-label="Open navigation"
+            aria-expanded={navOpen}
+            onClick={() => setNavOpen(true)}
+          >
+            <MenuIcon />
+          </button>
           <span className={styles.crumb}>{pageTitle}</span>
           <div className={styles.spacer} />
           <div className={styles.topbarRight}>
@@ -152,6 +181,15 @@ export default function App() {
 
         {/* Sidebar nav */}
         <nav className={styles.nav} aria-label="Main navigation">
+          <button
+            className={styles.navClose}
+            type="button"
+            aria-label="Close navigation"
+            onClick={() => setNavOpen(false)}
+          >
+            <XIcon />
+            <span>Close</span>
+          </button>
           <div className={styles.navGroupLabel}>Workspace</div>
           {NAV_ITEMS.map(({ path, label, Icon, kbd }) => (
             <NavLink

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -204,7 +204,7 @@ export default function App() {
           ))}
 
           <div className={styles.navGroupLabel} style={{ marginTop: 16 }}>Data source</div>
-          <div className={styles.navItem} style={{ cursor: 'default' }}>
+          <div className={styles.dataSourceItem}>
             <span className={styles.navIcon}>
               <span className={`${styles.smallDot} ${cdrOk ? styles.smallDotOk : styles.smallDotErr}`} />
             </span>

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -197,7 +197,7 @@
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--line);
-  background: var(--bg-elevated);
+  background: var(--bg-sunken);
   padding: 12px 0;
   overflow-y: auto;
 }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -34,8 +34,8 @@
   width: 22px;
   height: 22px;
   border-radius: 5px;
-  background: var(--accent);
-  color: oklch(0.99 0 0);
+  background: var(--text);
+  color: var(--bg-elevated);
   font-family: var(--font-mono);
   font-size: 13px;
   font-weight: 600;
@@ -216,6 +216,7 @@
   align-items: center;
   gap: 10px;
   padding: 7px 16px;
+  border: 1px solid transparent;
   color: var(--text-muted);
   font-size: 13px;
   text-decoration: none;
@@ -233,14 +234,16 @@
 }
 
 .navItemActive {
-  background: var(--accent-wash);
-  color: var(--accent-ink);
+  background: var(--bg-elevated);
+  border-color: var(--line);
+  box-shadow: var(--shadow-card);
+  color: var(--text);
   font-weight: 500;
 }
 
 .navItemActive:hover {
-  background: var(--accent-wash);
-  color: var(--accent-ink);
+  background: var(--bg-elevated);
+  color: var(--text);
 }
 
 .navIcon {
@@ -269,9 +272,9 @@
 
 .navItemActive .navKbd {
   opacity: 1;
-  background: var(--accent-wash);
-  border-color: var(--accent-wash);
-  color: var(--accent-ink);
+  background: var(--bg-sunken);
+  border-color: var(--line);
+  color: var(--text-dim);
 }
 
 .navItemSettings {

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -278,6 +278,17 @@
   margin-top: auto;
 }
 
+.dataSourceItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 6px;
+  padding: 7px 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: default;
+}
+
 /* Data source dots */
 .smallDot {
   display: inline-block;

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -6,9 +6,16 @@
     "brand topbar"
     "nav   main";
   height: 100vh;
+  min-height: 100dvh;
   width: 100vw;
   overflow: hidden;
   background: var(--bg);
+}
+
+.navBackdrop,
+.hamburger,
+.navClose {
+  display: none;
 }
 
 /* Brand cell */
@@ -324,4 +331,123 @@
   grid-area: main;
   overflow-y: auto;
   background: var(--bg);
+}
+
+@media (max-width: 820px) {
+  .screen {
+    grid-template-columns: 1fr;
+    grid-template-rows: var(--topbar-height) 1fr;
+    grid-template-areas:
+      "topbar"
+      "main";
+    height: auto;
+    min-height: 100vh;
+    min-height: 100dvh;
+    overflow: visible;
+  }
+
+  .brand {
+    display: none;
+  }
+
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    padding: 0 calc(12px + env(safe-area-inset-right)) 0 calc(12px + env(safe-area-inset-left));
+    gap: 8px;
+  }
+
+  .hamburger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--bg-elevated);
+    color: var(--text);
+    flex-shrink: 0;
+  }
+
+  .crumb {
+    font-size: 15px;
+  }
+
+  .topbarRight {
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .cdrChip {
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .searchWrap {
+    min-width: 0;
+    width: min(42vw, 220px);
+    padding: 4px 8px;
+  }
+
+  .searchInput {
+    font-size: 13px;
+  }
+
+  .kbdInline {
+    display: none;
+  }
+
+  .nav {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: 82vw;
+    max-width: 320px;
+    z-index: 60;
+    transform: translateX(-100%);
+    transition: transform 240ms ease;
+    padding-top: calc(16px + env(safe-area-inset-top));
+    box-shadow: 0 0 40px oklch(0 0 0 / 0);
+  }
+
+  .navOpen .nav {
+    transform: translateX(0);
+    box-shadow: 0 0 40px oklch(0 0 0 / 0.25);
+  }
+
+  .navBackdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: oklch(0 0 0 / 0.4);
+    border: 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 160ms ease;
+  }
+
+  .navOpen .navBackdrop {
+    display: block;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .navClose {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px 14px;
+    margin-bottom: 6px;
+    color: var(--text-dim);
+    border-bottom: 1px solid var(--line-soft);
+    text-align: left;
+    font-size: 12px;
+  }
+
+  .main {
+    min-width: 0;
+    overflow: visible;
+  }
 }

--- a/frontend/src/components/ComparisonView.js
+++ b/frontend/src/components/ComparisonView.js
@@ -11,7 +11,7 @@ function MatchIcon({ match }) {
 function PopCount({ code, expected, actual }) {
   const match = expected === actual;
   return (
-    <td className={match ? styles.countMatch : styles.countMismatch} title={`Expected: ${expected}, Actual: ${actual}`}>
+    <td data-label={POPULATION_LABELS[code]} className={match ? styles.countMatch : styles.countMismatch} title={`Expected: ${expected}, Actual: ${actual}`}>
       <span className={styles.countVal}>{actual ?? 0}</span>
       {!match && <span className={styles.countExpected}>(exp: {expected ?? 0})</span>}
     </td>
@@ -92,8 +92,8 @@ export default function ComparisonView({ jobId }) {
           <tbody>
             {patients.slice(0, 50).map((p, i) => (
               <tr key={p.subject_reference || i} className={p.match ? styles.rowMatch : styles.rowMismatch}>
-                <td className={styles.patientRef}>{p.subject_reference}</td>
-                <td className={styles.statusCell}><MatchIcon match={p.match} /></td>
+                <td data-label="Patient" className={styles.patientRef}>{p.subject_reference}</td>
+                <td data-label="Status" className={styles.statusCell}><MatchIcon match={p.match} /></td>
                 {POPULATION_CODES.map(code => (
                   <PopCount
                     key={code}

--- a/frontend/src/components/ComparisonView.module.css
+++ b/frontend/src/components/ComparisonView.module.css
@@ -141,3 +141,27 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
+
+@media (max-width: 820px) {
+  .summary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .tableWrapper {
+    overflow: visible;
+  }
+
+  .patientRef {
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
+
+  .statusCell,
+  .countMatch,
+  .countMismatch {
+    text-align: left;
+  }
+}

--- a/frontend/src/components/ConfirmDialog.module.css
+++ b/frontend/src/components/ConfirmDialog.module.css
@@ -96,3 +96,28 @@
   background: var(--accent);
   color: oklch(0.99 0 0);
 }
+
+@media (max-width: 820px) {
+  .backdrop {
+    align-items: flex-end;
+    display: flex;
+    justify-content: center;
+    padding: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom));
+  }
+
+  .panel {
+    width: 100%;
+    padding: 20px;
+  }
+
+  .actions {
+    flex-direction: column-reverse;
+  }
+
+  .cancelBtn,
+  .confirmBtn {
+    width: 100%;
+    min-height: 40px;
+  }
+}

--- a/frontend/src/components/PatientDetail.module.css
+++ b/frontend/src/components/PatientDetail.module.css
@@ -272,3 +272,36 @@
 .fhirJson :global(.number) { color: var(--warn); }
 .fhirJson :global(.boolean) { color: var(--accent); }
 .fhirJson :global(.null) { color: var(--text-dim); }
+
+@media (max-width: 820px) {
+  .overlay {
+    align-items: flex-end;
+    justify-content: center;
+  }
+
+  .drawer {
+    width: 100%;
+    height: auto;
+    min-height: 60dvh;
+    max-height: 92dvh;
+    border-left: none;
+    border-top: 1px solid var(--line);
+    border-top-left-radius: var(--radius-lg);
+    border-top-right-radius: var(--radius-lg);
+  }
+
+  .drawerHeader,
+  .drawerBody {
+    padding: 16px;
+  }
+
+  .sectionHeader,
+  .factRow {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .toggleBtn {
+    align-self: flex-start;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,6 +107,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg);
   color: var(--text);
+  min-height: 100%;
 }
 
 body {
@@ -115,6 +116,8 @@ body {
   color: var(--text);
   background: var(--bg);
   line-height: 1.5;
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* Pulse animation for PulseDot */
@@ -223,4 +226,73 @@ input:focus, select:focus, textarea:focus {
   background: var(--line-soft);
   border-radius: var(--radius-sm);
   animation: skeleton 1.5s ease-in-out infinite;
+}
+
+@media (max-width: 820px) {
+  body {
+    overflow-x: hidden;
+  }
+
+  table {
+    min-width: 0 !important;
+  }
+
+  table thead {
+    display: none;
+  }
+
+  table,
+  table tbody,
+  table tr,
+  table td {
+    display: block;
+    width: 100%;
+  }
+
+  table tr {
+    background: var(--bg-elevated);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    margin-bottom: 8px;
+    padding: 10px 12px;
+  }
+
+  table td {
+    border-bottom: none;
+    padding: 7px 0;
+    display: grid;
+    grid-template-columns: 88px minmax(0, 1fr);
+    align-items: baseline;
+    column-gap: 8px;
+    min-width: 0;
+    text-align: right;
+  }
+
+  table td > * {
+    grid-column: 2;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  table td::before {
+    content: attr(data-label);
+    grid-column: 1;
+    max-width: 88px;
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-align: left;
+    text-transform: uppercase;
+  }
+
+  table td:not([data-label])::before,
+  table td[data-label=""]::before {
+    display: none;
+  }
+
+  table td[colspan] {
+    display: block;
+    text-align: center;
+  }
 }

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -181,6 +181,23 @@ export default function JobsPage() {
     return 0;
   };
 
+  const getCohortName = (job) => {
+    if (job.group_name) return job.group_name;
+    const group = groups.find(g => String(g.id) === String(job.group_id));
+    return group?.name || job.cohort || job.group_id || 'All patients';
+  };
+
+  const getPatientCount = (job) => {
+    const processed = job.processed_patients ?? job.patients_processed;
+    const total = job.total_patients;
+    if (processed != null && total != null && isRunning(job.status)) {
+      return `${processed.toLocaleString()} / ${total.toLocaleString()}`;
+    }
+    if (total != null) return total.toLocaleString();
+    if (processed != null) return processed.toLocaleString();
+    return '--';
+  };
+
   const q = query.trim().toLowerCase();
   const activeJob = jobs.find(j => isRunning(j.status));
   const filteredJobs = jobs.filter(j => {
@@ -225,6 +242,7 @@ export default function JobsPage() {
                   {activeJob.period_start && activeJob.period_end && (
                     <span className={styles.mono}>{activeJob.period_start} → {activeJob.period_end}</span>
                   )}
+                  <span>Cohort: {getCohortName(activeJob)}</span>
                   <span>Elapsed {formatElapsed(activeJob.started_at || activeJob.created_at)}</span>
                 </div>
               </div>
@@ -289,6 +307,8 @@ export default function JobsPage() {
               <tr>
                 <th>Measure</th>
                 <th>Period</th>
+                <th>Cohort</th>
+                <th>Patients</th>
                 <th>Status</th>
                 <th>Started</th>
                 <th style={{ width: 40 }}></th>
@@ -296,7 +316,7 @@ export default function JobsPage() {
             </thead>
             <tbody>
               {filteredJobs.length === 0 ? (
-                <tr><td colSpan={5} className={styles.emptyRow}>
+                <tr><td colSpan={7} className={styles.emptyRow}>
                   {q ? `No jobs match "${q}".` : 'No calculations yet. Click "New calculation" to get started.'}
                 </td></tr>
               ) : (
@@ -311,18 +331,20 @@ export default function JobsPage() {
                       onClick={() => complete && navigate(`/results/${job.id}`)}
                       style={{ cursor: complete ? 'pointer' : 'default' }}
                     >
-                      <td>
+                      <td data-label="Measure">
                         <div className={styles.jobMeta}>
                           <div className={styles.jobName}>{getMeasureName(job)}</div>
                           <div className={`${styles.mono} ${styles.jobId}`}>{job.id}</div>
                         </div>
                       </td>
-                      <td className={`${styles.mono} ${styles.periodCell}`}>
+                      <td data-label="Period" className={`${styles.mono} ${styles.periodCell}`}>
                         {job.period_start && job.period_end ? `${job.period_start} – ${job.period_end}` : '--'}
                       </td>
-                      <td><StatusBadge status={job.status} /></td>
-                      <td className={styles.dateCell}>{formatDateTime(job.started_at || job.created_at)}</td>
-                      <td>
+                      <td data-label="Cohort" className={styles.cohortCell}>{getCohortName(job)}</td>
+                      <td data-label="Patients" className={styles.patientCountCell}>{getPatientCount(job)}</td>
+                      <td data-label="Status"><StatusBadge status={job.status} /></td>
+                      <td data-label="Started" className={styles.dateCell}>{formatDateTime(job.started_at || job.created_at)}</td>
+                      <td data-label="Actions">
                         <KebabMenu items={[
                           { label: 'View results', icon: <ViewIcon />, disabled: !complete, onClick: () => navigate(`/results/${job.id}`) },
                           { label: 'Re-run', icon: <SparkIcon />, onClick: () => {} },

--- a/frontend/src/pages/JobsPage.module.css
+++ b/frontend/src/pages/JobsPage.module.css
@@ -276,6 +276,11 @@
   white-space: nowrap;
 }
 .periodCell { color: var(--text-muted); white-space: nowrap; }
+.cohortCell,
+.patientCountCell {
+  font-size: 12px;
+  color: var(--text-muted);
+}
 .dateCell { font-size: 12px; color: var(--text-dim); white-space: nowrap; }
 
 .emptyRow {
@@ -406,4 +411,165 @@
   color: var(--text);
   font-family: var(--font-ui);
   font-size: 13px;
+}
+
+@media (max-width: 820px) {
+  .page {
+    max-width: none;
+    padding: 16px calc(16px + env(safe-area-inset-right)) 24px calc(16px + env(safe-area-inset-left));
+  }
+
+  .pageHeader,
+  .heroTop,
+  .heroProgressTop {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .btnPrimary,
+  .btnGhost {
+    justify-content: center;
+    width: 100%;
+    min-height: 40px;
+  }
+
+  .heroCard {
+    padding: 16px;
+  }
+
+  .heroSub {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px 12px;
+  }
+
+  .heroEta {
+    margin-left: 0;
+  }
+
+  .card {
+    overflow: hidden;
+    border: 1px solid var(--line);
+    background: var(--bg-elevated);
+    box-shadow: none;
+  }
+
+  .cardHeader {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .card table,
+  .card tbody {
+    display: block;
+  }
+
+  .card tr {
+    display: block;
+    border: none;
+    border-radius: 0;
+    margin: 0;
+    padding: 14px;
+  }
+
+  .card tr + tr {
+    border-top: 1px solid var(--line-soft);
+  }
+
+  .card td {
+    display: grid;
+    grid-template-columns: 88px minmax(0, 1fr);
+    align-items: baseline;
+    gap: 8px;
+    padding: 5px 0;
+    text-align: right;
+  }
+
+  .card td::after {
+    display: none;
+  }
+
+  .row:hover td {
+    background: transparent;
+  }
+
+  .jobMeta {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
+    gap: 10px;
+    text-align: right;
+  }
+
+  .jobName {
+    overflow-wrap: anywhere;
+    text-align: left;
+  }
+
+  .jobId {
+    font-size: 11px;
+    max-width: 76px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .periodCell,
+  .cohortCell,
+  .patientCountCell,
+  .dateCell {
+    white-space: normal;
+  }
+
+  .cohortCell,
+  .patientCountCell {
+    color: var(--text);
+  }
+
+  .card td[data-label="Status"] .badge {
+    justify-self: end;
+    width: auto;
+    max-width: max-content;
+  }
+
+  .card td[data-label="Actions"] {
+    align-items: center;
+  }
+
+  .card td[data-label="Actions"] > * {
+    justify-self: end;
+  }
+
+  .modalBackdrop {
+    align-items: flex-end;
+    justify-content: center;
+    padding: 0 12px calc(12px + env(safe-area-inset-bottom));
+  }
+
+  .sheet {
+    width: 100%;
+    height: auto;
+    max-height: 92dvh;
+    border: 1px solid var(--line);
+    border-bottom: none;
+    border-top-left-radius: var(--radius-lg);
+    border-top-right-radius: var(--radius-lg);
+  }
+
+  .sheetHeader,
+  .sheetBody,
+  .sheetFooter {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .fieldRow,
+  .sheetFooter {
+    flex-direction: column;
+  }
+
+  .sheetFooter {
+    flex-direction: column-reverse;
+  }
 }

--- a/frontend/src/pages/MeasuresPage.js
+++ b/frontend/src/pages/MeasuresPage.js
@@ -186,11 +186,11 @@ export default function MeasuresPage() {
               ) : (
                 visible.map((measure, i) => (
                   <tr key={measure.id || i} className={styles.row}>
-                    <td><span className={styles.mono}>{measure.id || '--'}</span></td>
-                    <td className={styles.measureName}>{getMeasureDisplayName(measure)}</td>
-                    <td className={styles.mono} style={{ color: 'var(--text-muted)' }}>{getMeasureVersion(measure)}</td>
-                    <td><StatusBadge status={getMeasureStatus(measure)} /></td>
-                    <td>
+                    <td data-label="ID"><span className={styles.mono}>{measure.id || '--'}</span></td>
+                    <td data-label="Measure" className={styles.measureName}>{getMeasureDisplayName(measure)}</td>
+                    <td data-label="Version" className={styles.mono} style={{ color: 'var(--text-muted)' }}>{getMeasureVersion(measure)}</td>
+                    <td data-label="Status"><StatusBadge status={getMeasureStatus(measure)} /></td>
+                    <td data-label="Actions">
                       <div className={styles.actionGroup}>
                         <a href="/jobs" className={styles.calcBtn}>Calculate</a>
                         <KebabMenu items={[

--- a/frontend/src/pages/MeasuresPage.module.css
+++ b/frontend/src/pages/MeasuresPage.module.css
@@ -171,3 +171,126 @@
   background: var(--bg-sunken);
   color: var(--text);
 }
+
+@media (max-width: 820px) {
+  .page {
+    max-width: none;
+    padding: 16px calc(16px + env(safe-area-inset-right)) 24px calc(16px + env(safe-area-inset-left));
+  }
+
+  .pageHeader {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .headerActions,
+  .btnPrimary {
+    width: 100%;
+  }
+
+  .btnPrimary {
+    justify-content: center;
+    min-height: 40px;
+  }
+
+  .card {
+    overflow: visible;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .card table,
+  .card tbody {
+    display: block;
+  }
+
+  .card tr {
+    display: block;
+    padding: 16px;
+  }
+
+  .card td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 0;
+    text-align: left;
+  }
+
+  .card td::after {
+    display: none;
+  }
+
+  .card td::before {
+    flex: 0 0 auto;
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .card td[data-label="Measure"] {
+    display: block;
+    padding: 0 0 8px;
+  }
+
+  .card td[data-label="Measure"]::before {
+    display: none;
+  }
+
+  .card td[data-label="ID"] {
+    display: block;
+    padding: 0 0 12px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .card td[data-label="ID"]::before {
+    display: none;
+  }
+
+  .row:hover td {
+    background: transparent;
+  }
+
+  .measureName {
+    display: block;
+    max-width: none;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.28;
+    color: var(--text);
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
+
+  .card td[data-label="ID"] .mono {
+    display: block;
+    max-width: none;
+    color: var(--text-dim);
+    font-size: 11px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
+
+  .card td[data-label="Version"] .mono {
+    max-width: none;
+    text-align: right;
+  }
+
+  .badge {
+    max-width: 100%;
+  }
+
+  .actionGroup {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -370,11 +370,11 @@ export default function ResultsPage() {
                       className={styles.patientRow}
                       onClick={() => handleViewPatient(patient)}
                     >
-                      <td><span className={styles.mono}>{patient.patient_id || patient.id || '--'}</span></td>
-                      <td className={styles.patientName}>{patient.patient_name || patient.name || '--'}</td>
-                      <td className={styles.popCell}>{patient.populations?.denominator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
-                      <td className={styles.popCell}>{patient.populations?.numerator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
-                      <td className={styles.popCell}>{patient.populations?.denominator_exclusion ? <CheckIcon className={styles.iconWarn} /> : <XIcon className={styles.iconDim} />}</td>
+                      <td data-label="Patient ID"><span className={styles.mono}>{patient.patient_id || patient.id || '--'}</span></td>
+                      <td data-label="Name" className={styles.patientName}>{patient.patient_name || patient.name || '--'}</td>
+                      <td data-label="Denom" className={styles.popCell}>{patient.populations?.denominator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
+                      <td data-label="Numer" className={styles.popCell}>{patient.populations?.numerator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
+                      <td data-label="Excl." className={styles.popCell}>{patient.populations?.denominator_exclusion ? <CheckIcon className={styles.iconWarn} /> : <XIcon className={styles.iconDim} />}</td>
                     </tr>
                   ))
                 )}

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -308,3 +308,79 @@
   color: var(--text-muted);
   background: transparent;
 }
+
+@media (max-width: 820px) {
+  .page {
+    max-width: none;
+    padding: 16px calc(16px + env(safe-area-inset-right)) 24px calc(16px + env(safe-area-inset-left));
+  }
+
+  .pageHeader {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .headerActions,
+  .jobSelect {
+    width: 100%;
+  }
+
+  .cardsRow {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .card {
+    padding: 16px;
+  }
+
+  .card:has(table) {
+    overflow: visible;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .cardTopRow,
+  .tableHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .sparklineWrap {
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .rateNum {
+    font-size: 48px;
+  }
+
+  .tableActions,
+  .btnGhost {
+    width: 100%;
+  }
+
+  .btnGhost {
+    justify-content: center;
+  }
+
+  .patientRow:hover td {
+    background: transparent;
+  }
+
+  .patientName,
+  .mono {
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
+
+  .popCell {
+    text-align: left;
+  }
+}

--- a/frontend/src/pages/SettingsPage.module.css
+++ b/frontend/src/pages/SettingsPage.module.css
@@ -291,3 +291,54 @@
   color: var(--text-dim);
   font-family: var(--font-mono);
 }
+
+@media (max-width: 820px) {
+  .page {
+    max-width: none;
+    padding: 16px calc(16px + env(safe-area-inset-right)) 24px calc(16px + env(safe-area-inset-left));
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .subNav {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .subNavItem {
+    white-space: nowrap;
+  }
+
+  .card {
+    overflow: visible;
+  }
+
+  .cardHeader,
+  .connRow,
+  .statusRow {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .connActions,
+  .btnPrimary,
+  .btnGhost,
+  .btnLink {
+    width: 100%;
+  }
+
+  .connActions {
+    flex-direction: column;
+  }
+
+  .btnPrimary,
+  .btnGhost,
+  .btnLink {
+    justify-content: center;
+    min-height: 40px;
+  }
+}

--- a/frontend/src/pages/ValidationPage.js
+++ b/frontend/src/pages/ValidationPage.js
@@ -7,7 +7,7 @@ import {
 import { useToast } from '../components/Toast';
 import KebabMenu from '../components/KebabMenu';
 import ConfirmDialog from '../components/ConfirmDialog';
-import { TrashIcon, SparkIcon, PlusIcon } from '../components/Icons';
+import { TrashIcon, SparkIcon, ViewIcon, XIcon, ChevronIcon } from '../components/Icons';
 import { useSearch } from '../contexts/SearchContext';
 
 function StatusBadge({ status }) {
@@ -75,13 +75,6 @@ export default function ValidationPage() {
     loadDetail();
   }, [selectedRunId]);
 
-  useEffect(() => {
-    if (!selectedRunId && runs.length > 0) {
-      const completed = runs.find(r => r.status === 'complete');
-      if (completed) setSelectedRunId(String(completed.id));
-    }
-  }, [runs, selectedRunId]);
-
   const handleUpload = async () => {
     const file = fileInputRef.current?.files[0];
     if (!file) return;
@@ -134,6 +127,7 @@ export default function ValidationPage() {
   };
 
   const hasExpected = expected && expected.total_measures > 0;
+  const expectedMeasures = expected?.measures || [];
 
   const q = query.trim().toLowerCase();
   const filteredRuns = runs.filter(r => {
@@ -142,10 +136,34 @@ export default function ValidationPage() {
   });
 
   // KPI values
-  const totalRuns = runs.length;
-  const passedRuns = runs.filter(r => r.status === 'complete').length;
-  const passRate = totalRuns > 0 ? `${Math.round((passedRuns / totalRuns) * 100)}%` : '--';
-  const lastRun = runs[0];
+  const bundlesLoaded = uploads.length;
+  const uploadPatients = uploads.reduce((sum, u) => sum + (u.patients_loaded || 0), 0);
+  const totalPatients = runs.reduce((sum, r) => sum + (r.patients_tested || 0), 0) || uploadPatients;
+  const totalPassedPatients = runs.reduce((sum, r) => sum + (r.patients_passed || 0), 0);
+  const passRate = totalPatients > 0 ? `${((totalPassedPatients / totalPatients) * 100).toFixed(1)}%` : '--';
+
+  const measureLabel = (measureUrl) => {
+    if (!measureUrl) return '--';
+    return measureUrl.split('/').pop() || measureUrl;
+  };
+
+  const runBundleName = (run, index) => (
+    run.bundle_filename
+    || run.filename
+    || uploads[index]?.filename
+    || uploads[0]?.filename
+    || `Run #${run.id}`
+  );
+
+  const runMeasureName = (run) => {
+    const measureUrl = run.measure_urls?.[0] || expectedMeasures[0]?.measure_url;
+    if (measureUrl) return measureLabel(measureUrl);
+    if (run.measures_tested) return `${run.measures_tested} measure${run.measures_tested === 1 ? '' : 's'}`;
+    return '--';
+  };
+
+  const selectedRunSummary = runs.find(r => String(r.id) === String(selectedRunId));
+  const selectedRunIndex = selectedRunSummary ? runs.findIndex(r => String(r.id) === String(selectedRunId)) : -1;
 
   return (
     <div className={styles.page}>
@@ -153,7 +171,7 @@ export default function ValidationPage() {
         <div>
           <div className={styles.eyebrow}>Testing</div>
           <h1 className={styles.title}>Validation</h1>
-          <div className={styles.sub}>Run measures against known test bundles and compare to expected results.</div>
+          <div className={styles.sub}>Run measures against known test bundles and compare to expected population membership.</div>
         </div>
         <div className={styles.headerActions}>
           <label className={styles.btnGhost}>
@@ -177,8 +195,8 @@ export default function ValidationPage() {
       {/* KPI cards */}
       <div className={styles.kpiRow}>
         {[
-          ['Total runs', String(totalRuns), 'text'],
-          ['Completed', String(passedRuns), 'text'],
+          ['Bundles loaded', String(bundlesLoaded || expected?.total_measures || 0), 'text'],
+          ['Test patients', totalPatients ? String(totalPatients) : '--', 'text'],
           ['Pass rate', passRate, 'accent'],
         ].map(([label, val, tone]) => (
           <div key={label} className={styles.kpiCard}>
@@ -191,44 +209,63 @@ export default function ValidationPage() {
       {/* Runs table */}
       <div className={styles.card}>
         <div className={styles.cardHeader}>
-          <span className={styles.cardTitle}>Validation runs</span>
+          <span className={styles.cardTitle}>Recent validation runs</span>
         </div>
         <table aria-label="Validation runs">
           <thead>
             <tr>
-              <th>Run</th>
+              <th>Bundle</th>
+              <th>Measure</th>
+              <th>Pass</th>
+              <th>Fail</th>
+              <th>Error</th>
+              <th>When</th>
               <th>Status</th>
-              <th>Patients tested</th>
-              <th>Started</th>
               <th style={{ width: 40 }}></th>
             </tr>
           </thead>
           <tbody>
             {filteredRuns.length === 0 ? (
-              <tr><td colSpan={5} className={styles.emptyRow}>
+              <tr><td colSpan={8} className={styles.emptyRow}>
                 {q ? `No runs match "${q}".` : 'No validation runs yet. Upload a test bundle and click "New run".'}
               </td></tr>
             ) : (
-              filteredRuns.map(r => {
+              filteredRuns.map((r, i) => {
                 const deleting = r.delete_requested || deletingRunIds.includes(String(r.id));
                 return (
-                  <tr key={r.id} className={`${styles.row} ${styles.rowClickable}`}
-                    onClick={() => setSelectedRunId(String(r.id))}>
-                    <td><span className={styles.mono}>#{r.id}</span></td>
-                    <td><StatusBadge status={deleting ? 'deleting' : r.status} /></td>
-                    <td>{r.patients_tested != null ? r.patients_tested : '--'}</td>
-                    <td className={styles.dateCell}>{r.created_at ? new Date(r.created_at).toLocaleString() : '--'}</td>
-                    <td>
-                      <KebabMenu items={[
-                        { divider: true },
-                        {
-                          label: 'Delete run',
-                          icon: <TrashIcon />,
-                          tone: 'destructive',
-                          disabled: deleting,
-                          onClick: () => setConfirmRun(r),
-                        },
-                      ]} />
+                  <tr key={r.id} className={styles.row}>
+                    <td data-label="Bundle" className={styles.bundleCell}>{runBundleName(r, i)}</td>
+                    <td data-label="Measure" className={styles.measureCell}>{runMeasureName(r)}</td>
+                    <td data-label="Pass" className={styles.passCount}>{r.patients_passed ?? '--'}</td>
+                    <td data-label="Fail" className={styles.failCount}>{r.patients_failed ?? '--'}</td>
+                    <td data-label="Error" className={styles.errorCount}>{r.patients_error ?? r.errors ?? 0}</td>
+                    <td data-label="When" className={styles.dateCell}>{r.created_at ? new Date(r.created_at).toLocaleString() : '--'}</td>
+                    <td data-label="Status"><StatusBadge status={deleting ? 'deleting' : r.status} /></td>
+                    <td data-label="Actions">
+                      <div className={styles.rowActions}>
+                        <button
+                          type="button"
+                          className={styles.viewDetailsBtn}
+                          onClick={() => setSelectedRunId(String(r.id))}
+                        >
+                          View details
+                        </button>
+                        <KebabMenu items={[
+                          {
+                            label: 'View details',
+                            icon: <ViewIcon />,
+                            onClick: () => setSelectedRunId(String(r.id)),
+                          },
+                          { divider: true },
+                          {
+                            label: 'Delete run',
+                            icon: <TrashIcon />,
+                            tone: 'destructive',
+                            disabled: deleting,
+                            onClick: () => setConfirmRun(r),
+                          },
+                        ]} />
+                      </div>
                     </td>
                   </tr>
                 );
@@ -238,88 +275,15 @@ export default function ValidationPage() {
         </table>
       </div>
 
-      {/* Run detail */}
       {runDetail && (
-        <div className={styles.card} style={{ marginTop: 16 }}>
-          <div className={styles.cardHeader}>
-            <span className={styles.cardTitle}>Run #{runDetail.id}</span>
-            <StatusBadge status={runDetail.status} />
-          </div>
-          {(runDetail.status === 'running' || runDetail.status === 'queued') ? (
-            <div className={styles.runningBanner}>
-              Validation {runDetail.status}… ({runDetail.patients_tested || 0} patients tested)
-            </div>
-          ) : runDetail.status === 'failed' ? (
-            <div className={styles.errorBanner}>Validation failed: {runDetail.error_message || 'Unknown error'}</div>
-          ) : (
-            <>
-              <div className={styles.detailKpiRow}>
-                {[
-                  ['Total patients', runDetail.patients_tested],
-                  ['Passing', runDetail.patients_passed],
-                  ['Failing', runDetail.patients_failed],
-                  ['Measures', runDetail.measures_tested],
-                ].map(([label, val]) => (
-                  <div key={label} className={styles.detailKpi}>
-                    <div className={styles.detailKpiLabel}>{label}</div>
-                    <div className={styles.detailKpiVal}>{val ?? '--'}</div>
-                  </div>
-                ))}
-              </div>
-              {(runDetail.measures || []).map((measure, mi) => (
-                <div key={mi} className={styles.measureSection}>
-                  <div className={styles.measureSectionHeader}>
-                    <span className={styles.measureUrl}>{measure.measure_url.split('/').pop()}</span>
-                    <span className={`${styles.badge} ${measure.failed + measure.errors > 0 ? styles.badgeErr : styles.badgeOk}`}>
-                      {measure.passed}/{measure.patients.length} PASS
-                    </span>
-                  </div>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th style={{ width: 30 }}></th>
-                        <th>Patient</th>
-                        <th className={styles.popCell}>Init Pop</th>
-                        <th className={styles.popCell}>Denom</th>
-                        <th className={styles.popCell}>Excl.</th>
-                        <th className={styles.popCell}>Numer</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {measure.patients.map((p, pi) => (
-                        <tr key={pi} className={p.status === 'fail' ? styles.failRow : p.status === 'error' ? styles.errorRow : ''}>
-                          <td>
-                            {p.status === 'pass' && <span className={styles.passIcon}>✓</span>}
-                            {p.status === 'fail' && <span className={styles.failIcon}>✗</span>}
-                            {p.status === 'error' && <span className={styles.warnIcon}>!</span>}
-                          </td>
-                          <td>
-                            <div>{p.patient_name || p.patient_ref}</div>
-                            {p.status === 'error' && <div className={styles.errorText}>{p.error_message}</div>}
-                          </td>
-                          {['initial-population', 'denominator', 'denominator-exclusion', 'numerator'].map(code => {
-                            const exp = p.expected_populations?.[code];
-                            const act = p.actual_populations?.[code];
-                            const mismatch = (p.mismatches || []).includes(code);
-                            return (
-                              <td key={code} className={styles.popCell}>
-                                <span className={mismatch ? styles.mismatch : styles.match}>
-                                  {act !== undefined ? String(act) : '--'}
-                                </span>
-                                <br />
-                                <span className={styles.expected}>exp: {exp !== undefined ? String(exp) : '--'}</span>
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              ))}
-            </>
-          )}
-        </div>
+        <ValidationDetailsDrawer
+          run={runDetail}
+          bundle={runBundleName(selectedRunSummary || runDetail, selectedRunIndex >= 0 ? selectedRunIndex : 0)}
+          measure={runMeasureName(selectedRunSummary || runDetail)}
+          onRerun={handleRunValidation}
+          rerunning={runStarting}
+          onClose={() => setSelectedRunId('')}
+        />
       )}
 
       <ConfirmDialog
@@ -331,6 +295,239 @@ export default function ValidationPage() {
         onCancel={() => setConfirmRun(null)}
         onConfirm={handleDeleteConfirmed}
       />
+    </div>
+  );
+}
+
+const POPULATION_LABELS = {
+  'initial-population': 'IP',
+  denominator: 'DENOM',
+  'denominator-exclusion': 'EXCL',
+  numerator: 'NUMER',
+  'numerator-exclusion': 'NUMEX',
+};
+
+function populationList(populations) {
+  if (!populations) return [];
+  return Object.entries(POPULATION_LABELS)
+    .filter(([code]) => Boolean(populations[code]))
+    .map(([, label]) => label);
+}
+
+function measureNameFromUrl(url) {
+  if (!url) return '--';
+  return url.split('/').pop() || url;
+}
+
+function toCaseId(patient, measureIndex, patientIndex) {
+  if (patient.patient_ref) return patient.patient_ref.split('/').pop() || patient.patient_ref;
+  return `case-${measureIndex + 1}-${patientIndex + 1}`;
+}
+
+function flattenValidationCases(run) {
+  return (run.measures || []).flatMap((measure, measureIndex) => (
+    (measure.patients || []).map((patient, patientIndex) => {
+      const expected = populationList(patient.expected_populations);
+      const actual = populationList(patient.actual_populations);
+      const mismatches = patient.mismatches || [];
+      return {
+        id: toCaseId(patient, measureIndex, patientIndex),
+        name: patient.patient_name || patient.patient_ref || 'Unknown patient',
+        measure: measureNameFromUrl(measure.measure_url),
+        status: (patient.status || 'unknown').toLowerCase(),
+        expected,
+        actual,
+        error: patient.error_message,
+        mismatches: mismatches.map(code => POPULATION_LABELS[code] || code),
+      };
+    })
+  ));
+}
+
+function downloadValidationReport(run, bundle, measure, cases) {
+  const report = {
+    id: run.id,
+    status: run.status,
+    bundle,
+    measure,
+    created_at: run.created_at,
+    completed_at: run.completed_at,
+    patients_tested: run.patients_tested,
+    patients_passed: run.patients_passed,
+    patients_failed: run.patients_failed,
+    measures_tested: run.measures_tested,
+    cases,
+  };
+  const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `validation-run-${run.id || 'report'}.json`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function ValidationDetailsDrawer({ run, bundle, measure, onClose, onRerun, rerunning }) {
+  const [tab, setTab] = useState('all');
+  const cases = flattenValidationCases(run);
+  const pass = run.patients_passed ?? (run.measures || []).reduce((sum, m) => sum + (m.passed || 0), 0);
+  const errorCount = (run.measures || []).reduce((sum, m) => sum + (m.errors || 0), 0);
+  const fail = (run.measures || []).reduce((sum, m) => sum + (m.failed || 0), 0);
+  const total = cases.length || run.patients_tested || pass + fail + errorCount || 0;
+  const passPct = total > 0 ? Math.round((pass / total) * 100) : 0;
+  const when = run.created_at ? new Date(run.created_at).toLocaleString() : `Run #${run.id}`;
+  const isActive = run.status === 'queued' || run.status === 'running';
+  const filteredCases = cases.filter(c => tab === 'all' || c.status === tab);
+  const passRateClass = passPct >= 90 ? styles.drawerStatOk : passPct >= 70 ? styles.drawerStatWarn : styles.drawerStatErr;
+
+  return (
+    <div className={styles.drawerOverlay} onClick={onClose} role="presentation">
+      <aside className={styles.drawer} aria-label={`Validation run ${run.id} details`} onClick={event => event.stopPropagation()}>
+        <div className={styles.drawerHeader}>
+          <div className={styles.drawerHeaderTop}>
+            <div className={styles.drawerTitleBlock}>
+              <div className={styles.drawerEyebrow}>Validation run · {when}</div>
+              <h2 className={styles.drawerTitle}>{bundle}</h2>
+              <div className={styles.drawerMeta}>{measure} · {total} test cases</div>
+            </div>
+            <button type="button" className={styles.drawerClose} onClick={onClose} aria-label="Close validation details">
+              <XIcon />
+            </button>
+          </div>
+          <div className={styles.drawerSummary}>
+            <div>
+              <div className={styles.drawerStatLabel}>Pass rate</div>
+              <div className={`${styles.drawerPassRate} ${passRateClass}`}>
+                {total > 0 ? passPct : '--'}{total > 0 && <span>%</span>}
+              </div>
+            </div>
+            <div className={styles.drawerCounts}>
+              <div>
+                <div className={styles.drawerStatLabel}>Pass</div>
+                <div className={`${styles.drawerCount} ${styles.drawerStatOk}`}>{pass}</div>
+              </div>
+              <div>
+                <div className={styles.drawerStatLabel}>Fail</div>
+                <div className={`${styles.drawerCount} ${fail ? styles.drawerStatErr : ''}`}>{fail}</div>
+              </div>
+              <div>
+                <div className={styles.drawerStatLabel}>Error</div>
+                <div className={`${styles.drawerCount} ${errorCount ? styles.drawerStatWarn : ''}`}>{errorCount}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.drawerTabs} role="tablist" aria-label="Validation case filters">
+          {[
+            ['all', `All ${total}`],
+            ['fail', `Failures ${fail}`],
+            ['error', `Errors ${errorCount}`],
+            ['pass', `Passing ${pass}`],
+          ].map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={tab === key}
+              className={`${styles.drawerTab} ${tab === key ? styles.drawerTabActive : ''}`}
+              onClick={() => setTab(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.drawerBody}>
+          {isActive && (
+            <div className={styles.drawerNotice}>
+              Validation {run.status} ({run.patients_tested || 0} patients tested)
+            </div>
+          )}
+          {run.status === 'failed' && (
+            <div className={styles.drawerError}>
+              Validation failed: {run.error_message || 'Unknown error'}
+            </div>
+          )}
+          {!isActive && run.status !== 'failed' && filteredCases.length === 0 && (
+            <div className={styles.drawerEmpty}>No {tab === 'all' ? '' : tab} cases in this run.</div>
+          )}
+          {filteredCases.map(c => (
+            <ValidationCaseRow key={`${c.measure}-${c.id}`} c={c} />
+          ))}
+        </div>
+
+        <div className={styles.drawerFooter}>
+          <button type="button" className={styles.drawerButton} onClick={() => downloadValidationReport(run, bundle, measure, cases)}>
+            Download report
+          </button>
+          <button
+            type="button"
+            className={`${styles.drawerButton} ${styles.drawerButtonPrimary}`}
+            onClick={onRerun}
+            disabled={rerunning}
+          >
+            <SparkIcon /> {rerunning ? 'Starting...' : 'Re-run'}
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function ValidationCaseRow({ c }) {
+  const [open, setOpen] = useState(false);
+  const hasDetail = c.status === 'fail' || c.status === 'error' || c.mismatches.length > 0;
+  const statusClass = c.status === 'pass'
+    ? styles.caseDotPass
+    : c.status === 'fail'
+      ? styles.caseDotFail
+      : styles.caseDotError;
+
+  return (
+    <div
+      className={`${styles.caseRow} ${hasDetail ? styles.caseRowInteractive : ''}`}
+      onClick={() => hasDetail && setOpen(value => !value)}
+      role={hasDetail ? 'button' : undefined}
+      tabIndex={hasDetail ? 0 : undefined}
+      onKeyDown={(event) => {
+        if (!hasDetail) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          setOpen(value => !value);
+        }
+      }}
+    >
+      <div className={styles.caseMain}>
+        <span className={`${styles.caseDot} ${statusClass}`} aria-hidden="true" />
+        <span className={styles.caseId}>{c.id}</span>
+        <span className={styles.caseName}>{c.name}</span>
+        {c.status === 'error' ? (
+          <span className={styles.caseErrorLabel}>error</span>
+        ) : (
+          <span className={`${styles.caseResult} ${c.status === 'fail' ? styles.caseResultMismatch : ''}`}>
+            {c.expected.join(', ') || 'none'}
+            <span> &rarr; </span>
+            <strong>{c.actual.join(', ') || 'none'}</strong>
+          </span>
+        )}
+        {hasDetail && (
+          <ChevronIcon className={`${styles.caseChevron} ${open ? styles.caseChevronOpen : ''}`} />
+        )}
+      </div>
+      {open && c.status === 'error' && (
+        <div className={styles.caseError}>{c.error || 'Unexpected validation error.'}</div>
+      )}
+      {open && c.status !== 'error' && (
+        <div className={styles.caseDetail}>
+          <div>Measure: <span>{c.measure}</span></div>
+          <div>Expected: <span>{c.expected.join(', ') || 'none'}</span></div>
+          <div>Calculated: <span>{c.actual.join(', ') || 'none'}</span></div>
+          {c.mismatches.length > 0 && <div>Mismatch: <span>{c.mismatches.join(', ')}</span></div>}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ValidationPage.module.css
+++ b/frontend/src/pages/ValidationPage.module.css
@@ -145,9 +145,40 @@
 
 .mono { font-family: var(--font-mono); font-size: 12px; }
 .dateCell { font-size: 12px; color: var(--text-dim); }
+.bundleCell,
+.measureCell {
+  font-size: 13px;
+  color: var(--text);
+}
+.bundleCell {
+  font-weight: 500;
+}
+.passCount { color: var(--ok); }
+.failCount { color: var(--err); }
+.errorCount { color: var(--warn); }
 
 .row:hover td { background: var(--bg-sunken); }
-.rowClickable { cursor: pointer; }
+
+.rowActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.viewDetailsBtn {
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: transparent;
+  font-size: 12px;
+}
+
+.viewDetailsBtn:hover {
+  background: var(--bg-sunken);
+  color: var(--text);
+}
 
 .emptyRow {
   text-align: center;
@@ -250,3 +281,556 @@
 .failIcon { color: var(--err); font-size: 14px; }
 .warnIcon { color: var(--warn); font-size: 14px; font-weight: 700; }
 .errorText { font-size: 11px; color: var(--err); margin-top: 2px; }
+
+.drawerOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: flex;
+  justify-content: flex-end;
+  background: oklch(0 0 0 / 0.3);
+}
+
+.drawer {
+  width: 620px;
+  max-width: 100vw;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-elevated);
+  border-left: 1px solid var(--line);
+  box-shadow: -20px 0 44px oklch(0 0 0 / 0.16);
+}
+
+.drawerHeader {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.drawerHeaderTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.drawerTitleBlock {
+  min-width: 0;
+  flex: 1;
+}
+
+.drawerEyebrow,
+.drawerStatLabel {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+
+.drawerEyebrow {
+  margin-bottom: 4px;
+}
+
+.drawerTitle {
+  overflow: hidden;
+  margin: 0;
+  color: var(--text);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawerMeta {
+  overflow: hidden;
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawerClose {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.drawerClose:hover {
+  background: var(--bg-sunken);
+  color: var(--text);
+}
+
+.drawerSummary {
+  display: flex;
+  gap: 16px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.drawerPassRate {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.drawerPassRate span {
+  margin-left: 1px;
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+.drawerCounts {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  margin-left: auto;
+  text-align: right;
+}
+
+.drawerCount {
+  color: var(--text-dim);
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.drawerStatOk { color: var(--ok); }
+.drawerStatWarn { color: var(--warn); }
+.drawerStatErr { color: var(--err); }
+
+.drawerTabs {
+  display: flex;
+  align-items: flex-end;
+  flex-shrink: 0;
+  gap: 4px;
+  overflow-x: auto;
+  min-height: 44px;
+  padding: 8px 24px 6px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--line);
+}
+
+.drawerTab {
+  min-height: 30px;
+  padding: 6px 10px 5px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.drawerTabActive {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 500;
+}
+
+.drawerBody {
+  flex: 1;
+  overflow: auto;
+}
+
+.drawerNotice,
+.drawerError,
+.drawerEmpty {
+  margin: 16px 24px;
+  padding: 12px;
+  border-radius: var(--radius);
+  font-size: 13px;
+}
+
+.drawerNotice {
+  color: var(--accent-ink);
+  background: var(--accent-wash);
+}
+
+.drawerError {
+  color: var(--err);
+  background: var(--err-wash);
+}
+
+.drawerEmpty {
+  margin-top: 48px;
+  color: var(--text-dim);
+  text-align: center;
+  background: transparent;
+}
+
+.caseRow {
+  padding: 8px 24px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 12px;
+}
+
+.caseRowInteractive {
+  cursor: pointer;
+}
+
+.caseRowInteractive:hover {
+  background: var(--bg-sunken);
+}
+
+.caseMain {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.caseDot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.caseDotPass { background: var(--ok); }
+.caseDotFail { background: var(--err); }
+.caseDotError { background: var(--warn); }
+
+.caseId {
+  width: 74px;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.caseName {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.caseResult,
+.caseErrorLabel {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.caseResult strong {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.caseResultMismatch strong {
+  color: var(--err);
+  font-weight: 500;
+}
+
+.caseErrorLabel {
+  color: var(--warn);
+}
+
+.caseChevron {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  color: var(--text-dim);
+  transition: transform 150ms ease;
+}
+
+.caseChevronOpen {
+  transform: rotate(90deg);
+}
+
+.caseDetail,
+.caseError {
+  margin-top: 8px;
+  margin-left: 22px;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.caseDetail {
+  color: var(--text-muted);
+  background: var(--bg-sunken);
+}
+
+.caseDetail span {
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+
+.caseError {
+  color: var(--warn);
+  background: var(--warn-wash);
+  font-family: var(--font-mono);
+}
+
+.drawerFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 24px;
+  border-top: 1px solid var(--line);
+}
+
+.drawerButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 6px 12px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.drawerButton:hover {
+  background: var(--bg-sunken);
+  color: var(--text);
+}
+
+.drawerButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.drawerButtonPrimary {
+  color: oklch(0.99 0 0);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.drawerButtonPrimary:hover {
+  color: oklch(0.99 0 0);
+  background: var(--accent-ink);
+}
+
+@media (max-width: 820px) {
+  .page {
+    max-width: none;
+    padding: 16px calc(16px + env(safe-area-inset-right)) 24px calc(16px + env(safe-area-inset-left));
+  }
+
+  .pageHeader,
+  .headerActions,
+  .errorBanner {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .kpiRow {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .btnPrimary,
+  .btnGhost {
+    justify-content: center;
+    width: 100%;
+    min-height: 40px;
+  }
+
+  .headerActions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .btnGhost,
+  .btnPrimary {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .kpiCard {
+    padding: 16px;
+  }
+
+  .kpiLabel {
+    min-height: 30px;
+  }
+
+  .card {
+    overflow: hidden;
+    border: 1px solid var(--line);
+    background: var(--bg-elevated);
+    box-shadow: none;
+  }
+
+  .cardHeader {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .card table,
+  .card tbody {
+    display: block;
+  }
+
+  .card tr {
+    display: block;
+    border: none;
+    border-radius: 0;
+    margin: 0;
+    padding: 14px;
+  }
+
+  .card tr + tr {
+    border-top: 1px solid var(--line-soft);
+  }
+
+  .card td {
+    grid-template-columns: 88px minmax(0, 1fr);
+    text-align: right;
+  }
+
+  .row:hover td {
+    background: transparent;
+  }
+
+  .bundleCell,
+  .measureCell,
+  .dateCell {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .card td[data-label="Status"] .badge,
+  .card td[data-label="Actions"] > * {
+    justify-self: end;
+  }
+
+  .rowActions {
+    flex-direction: row;
+  }
+
+  .card td[data-label="Status"] .badge {
+    max-width: max-content;
+  }
+
+  .detailKpiRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    margin-bottom: 8px;
+    overflow: hidden;
+  }
+
+  .measureSection {
+    border-top: none;
+    margin-top: 12px;
+  }
+
+  .measureSectionHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 0 0 10px;
+    border-bottom: none;
+    background: transparent;
+  }
+
+  .measureUrl {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .dateCell {
+    white-space: normal;
+  }
+
+  .popCell {
+    text-align: left;
+  }
+
+  .drawerOverlay {
+    align-items: flex-end;
+    justify-content: center;
+  }
+
+  .drawer {
+    width: 100%;
+    height: auto;
+    min-height: 60dvh;
+    max-height: 92dvh;
+    border-top: 1px solid var(--line);
+    border-left: 0;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  }
+
+  .drawerHeader,
+  .drawerTabs,
+  .drawerFooter,
+  .caseRow {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .drawerTitle {
+    white-space: normal;
+  }
+
+  .drawerSummary {
+    gap: 12px;
+  }
+
+  .drawerNotice,
+  .drawerError,
+  .drawerEmpty {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .caseMain {
+    align-items: flex-start;
+  }
+
+  .caseId {
+    width: 52px;
+  }
+
+  .caseName {
+    white-space: normal;
+  }
+
+  .caseResult {
+    max-width: 34%;
+    overflow-wrap: anywhere;
+    text-align: right;
+    white-space: normal;
+  }
+
+  .drawerFooter {
+    justify-content: stretch;
+  }
+
+  .drawerButton {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- applies the updated responsive clinical UI treatment across the main frontend surfaces
- restructures Measures, Jobs, Results, and Validation mobile layouts for clearer row/value pairing
- replaces the inline validation result detail with the Lenny validation drawer, including filters, case rows, report download, and re-run action

## Validation
- pulled latest `main` before branching: `ca2f7fe fix: expose batch counts in job API and add Results page actions (#150)`
- `npm run build`
- browser smoke on `http://localhost:3000/validation`: opened a validation run drawer and confirmed tabs plus footer actions render

## Notes
- This is a draft PR for visual review of the responsive UI changes.
