### PR TITLE
chore: add pre-baked HAPI seeded images and weekly bake workflow

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -71,7 +71,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Start CDR container
         run: |
-          docker run -d --name hapi-cdr -p 8180:8080 mct2-hapi-cdr-config
+          docker run -d --name hapi-cdr -p 8180:8080 --user root mct2-hapi-cdr-config
 
       - name: Seed CDR container
         run: |
@@ -92,7 +92,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Start Measure container
         run: |
-          docker run -d --name hapi-measure -p 8181:8080 mct2-hapi-measure-config
+          docker run -d --name hapi-measure -p 8181:8080 --user root mct2-hapi-measure-config
 
       - name: Seed Measure container
         run: |

--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -1,5 +1,13 @@
 name: Bake HAPI Seeded Images
 
+# Builds HAPI images with seed data, $reindex, and ValueSet expansion
+# already baked into the H2 database. Runs weekly and on seed changes.
+#
+# Strategy: docker run → seed from runner → docker stop → docker commit → push.
+# We cannot use Dockerfile RUN steps because hapiproject/hapi is distroless
+# (no shell inside the container). Instead, seed-hapi.sh runs on the runner
+# and targets the container's exposed port.
+
 on:
   schedule:
     - cron: '0 5 * * 1'  # Monday 05:00 UTC weekly
@@ -34,24 +42,68 @@ jobs:
       - name: Compute seed hash
         id: seed-hash
         run: |
-          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml \
+            docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
+            -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" \
+            >> "$GITHUB_OUTPUT"
 
-      - name: Build and push CDR image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/hapi-cdr-seeded.Dockerfile
-          push: true
-          tags: |
-            ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+      # -----------------------------------------------------------------------
+      # Build config images (distroless base + ENV vars only, no RUN steps)
+      # These are intermediate images used to start the containers with the
+      # correct Spring env vars. Seeded data is committed via docker commit below.
+      # -----------------------------------------------------------------------
+      - name: Build CDR config image
+        run: |
+          docker build \
+            -f docker/hapi-cdr-seeded.Dockerfile \
+            -t mct2-hapi-cdr-config \
+            .
+
+      - name: Build Measure config image
+        run: |
+          docker build \
+            -f docker/hapi-measure-seeded.Dockerfile \
+            -t mct2-hapi-measure-config \
+            .
+
+      # -----------------------------------------------------------------------
+      # Bake CDR image: run → seed from runner → stop → commit → push
+      # -----------------------------------------------------------------------
+      - name: Start CDR container
+        run: |
+          docker run -d --name hapi-cdr -p 8180:8080 mct2-hapi-cdr-config
+
+      - name: Seed CDR container
+        run: |
+          HAPI_PORT=8180 SEED_TYPE=cdr bash docker/seed-hapi.sh
+
+      - name: Commit and push CDR image
+        run: |
+          docker stop hapi-cdr
+          docker commit hapi-cdr ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker tag \
+            ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }} \
             ghcr.io/bellese/mct2-hapi-cdr:latest
+          docker push ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker push ghcr.io/bellese/mct2-hapi-cdr:latest
 
-      - name: Build and push Measure image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/hapi-measure-seeded.Dockerfile
-          push: true
-          tags: |
-            ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
+      # -----------------------------------------------------------------------
+      # Bake Measure image: run → seed from runner → stop → commit → push
+      # -----------------------------------------------------------------------
+      - name: Start Measure container
+        run: |
+          docker run -d --name hapi-measure -p 8181:8080 mct2-hapi-measure-config
+
+      - name: Seed Measure container
+        run: |
+          HAPI_PORT=8181 SEED_TYPE=measure bash docker/seed-hapi.sh
+
+      - name: Commit and push Measure image
+        run: |
+          docker stop hapi-measure
+          docker commit hapi-measure ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
+          docker tag \
+            ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }} \
             ghcr.io/bellese/mct2-hapi-measure:latest
+          docker push ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
+          docker push ghcr.io/bellese/mct2-hapi-measure:latest

--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -1,0 +1,57 @@
+name: Bake HAPI Seeded Images
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Monday 05:00 UTC weekly
+  workflow_dispatch:
+  push:
+    paths:
+      - 'seed/**'
+      - 'docker/hapi-*-seeded.Dockerfile'
+      - 'docker/seed-hapi.sh'
+      - 'docker-compose.test.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  bake:
+    name: Bake and push seeded HAPI images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute seed hash
+        id: seed-hash
+        run: |
+          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push CDR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/hapi-cdr-seeded.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+            ghcr.io/bellese/mct2-hapi-cdr:latest
+
+      - name: Build and push Measure image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/hapi-measure-seeded.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
+            ghcr.io/bellese/mct2-hapi-measure:latest

--- a/backend/tests/integration/_hapi_wait.py
+++ b/backend/tests/integration/_hapi_wait.py
@@ -1,0 +1,217 @@
+"""HAPI FHIR readiness polling helpers.
+
+Standalone functions callable from pytest fixtures and build-time seed scripts.
+Logic is ported directly from conftest.py so both callers stay in sync.
+"""
+
+import sys
+import time
+import warnings
+
+import httpx
+
+REINDEX_TIMEOUT = 300
+REINDEX_POLL_INTERVAL = 1
+
+VALUESET_EXPANSION_TIMEOUT = 600
+VALUESET_EXPANSION_POLL_INTERVAL = 2
+
+
+def wait_for_metadata(base_url: str, timeout: int = 300) -> None:
+    """Poll /fhir/metadata until HAPI responds or *timeout* seconds elapse.
+
+    Args:
+        base_url: FHIR base URL, e.g. ``http://localhost:8080/fhir``.
+        timeout: Maximum seconds to wait before raising ``RuntimeError``.
+
+    Raises:
+        RuntimeError: If HAPI has not responded within *timeout* seconds.
+    """
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/metadata", timeout=10)
+            if resp.status_code < 500:
+                return
+        except httpx.RequestError as exc:
+            last_exc = exc
+        time.sleep(2)
+    raise RuntimeError(
+        f"HAPI at {base_url} did not respond within {timeout}s. "
+        f"Last error: {last_exc}"
+    )
+
+
+def trigger_reindex_and_wait(
+    base_url: str,
+    probe_patient_id: str,
+    probe_encounter_id: str,
+    timeout: int = REINDEX_TIMEOUT,
+) -> None:
+    """POST $reindex to HAPI and poll until Encounter?patient search returns results.
+
+    Mirrors the ``_trigger_reindex_and_wait`` logic in conftest.py.
+
+    Args:
+        base_url: FHIR base URL, e.g. ``http://localhost:8080/fhir``.
+        probe_patient_id: Patient resource ID whose Encounter must become searchable.
+        probe_encounter_id: Encounter resource ID (unused in probe but kept for
+            parity with conftest signature).
+        timeout: Maximum seconds to wait before raising ``RuntimeError``.
+
+    Raises:
+        RuntimeError: If reference-param indexing does not complete within *timeout*.
+    """
+    headers = {"Content-Type": "application/fhir+json"}
+    params = {
+        "resourceType": "Parameters",
+        "parameter": [{"name": "type", "valueString": "Encounter"}],
+    }
+
+    r = httpx.post(f"{base_url}/$reindex", json=params, headers=headers, timeout=30)
+    if r.status_code >= 400:
+        warnings.warn(
+            f"$reindex trigger at {base_url} returned {r.status_code}: {r.text[:200]}"
+        )
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = httpx.get(
+            f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10
+        )
+        if resp.status_code == 200:
+            try:
+                if resp.json().get("entry"):
+                    return
+            except Exception:
+                pass
+        time.sleep(REINDEX_POLL_INTERVAL)
+
+    raise RuntimeError(
+        f"HAPI at {base_url} reference-param indexing did not complete within {timeout}s "
+        f"(probe: Encounter?patient={probe_patient_id})"
+    )
+
+
+def wait_for_valueset_expansion(
+    base_url: str,
+    large_valueset_ids: list[str] | None = None,
+    timeout: int = VALUESET_EXPANSION_TIMEOUT,
+) -> None:
+    """Poll ValueSet/$expand until HAPI pre-expansion completes.
+
+    HAPI's in-memory expansion is capped at 1000 codes.  ValueSets with
+    >1000 codes are queued for async pre-expansion by a background scheduler.
+    After pre-expansion completes, ``$expand`` returns HTTP 200 instead of
+    HAPI-0831 500.
+
+    If *large_valueset_ids* is ``None``, the function queries HAPI for all
+    ValueSets and identifies those likely to need pre-expansion (more than 900
+    compose concepts) automatically.
+
+    Mirrors the ``_wait_for_valueset_expansion`` logic in conftest.py.
+
+    Args:
+        base_url: FHIR base URL, e.g. ``http://localhost:8080/fhir``.
+        large_valueset_ids: Optional explicit list of ValueSet resource IDs to
+            monitor.  When ``None``, IDs are discovered from the server.
+        timeout: Maximum seconds to wait before issuing a warning and returning.
+    """
+    if large_valueset_ids is None:
+        large_valueset_ids = _discover_large_valueset_ids(base_url)
+
+    if not large_valueset_ids:
+        return
+
+    pending = set(large_valueset_ids)
+    deadline = time.monotonic() + timeout
+
+    while pending and time.monotonic() < deadline:
+        newly_done: set[str] = set()
+        for vs_id in list(pending):
+            try:
+                # count=2 so HAPI-0831 fires for any VS with >1 code until
+                # background pre-expansion completes and HAPI can serve from DB.
+                resp = httpx.get(
+                    f"{base_url}/ValueSet/{vs_id}/$expand?count=2", timeout=15
+                )
+                if resp.status_code == 200:
+                    newly_done.add(vs_id)
+            except httpx.RequestError:
+                pass
+        pending -= newly_done
+        if pending:
+            time.sleep(VALUESET_EXPANSION_POLL_INTERVAL)
+
+    if pending:
+        warnings.warn(
+            f"HAPI at {base_url} ValueSet pre-expansion did not complete within "
+            f"{timeout}s for {len(pending)} ValueSet(s): {sorted(pending)[:5]}. "
+            f"Tests may fail with IP=0 if large ValueSets are still unexpanded."
+        )
+
+
+def _discover_large_valueset_ids(base_url: str, threshold: int = 900) -> list[str]:
+    """Return IDs of ValueSets on the server that have ≥ *threshold* compose concepts.
+
+    Used when the caller does not already know which ValueSets need pre-expansion.
+    Returns an empty list if the server is unreachable or returns no ValueSets.
+    """
+    ids: list[str] = []
+    try:
+        resp = httpx.get(f"{base_url}/ValueSet?_count=200", timeout=30)
+        if resp.status_code != 200:
+            return ids
+        bundle = resp.json()
+        for entry in bundle.get("entry", []):
+            vs = entry.get("resource", {})
+            if vs.get("resourceType") != "ValueSet":
+                continue
+            vs_id = vs.get("id")
+            if not vs_id:
+                continue
+            concept_count = sum(
+                len(inc.get("concept", []))
+                for inc in vs.get("compose", {}).get("include", [])
+            )
+            if concept_count >= threshold:
+                ids.append(vs_id)
+    except httpx.RequestError:
+        pass
+    return ids
+
+
+def _find_probe_ids(base_url: str) -> tuple[str, str] | tuple[None, None]:
+    """Return (patient_id, encounter_id) from the first Encounter found on the server."""
+    try:
+        resp = httpx.get(f"{base_url}/Encounter?_count=1", timeout=15)
+        if resp.status_code != 200:
+            return None, None
+        entries = resp.json().get("entry", [])
+        if not entries:
+            return None, None
+        enc = entries[0]["resource"]
+        enc_id = enc.get("id")
+        patient_ref = enc.get("subject", {}).get("reference", "")
+        patient_id = patient_ref.removeprefix("Patient/")
+        if enc_id and patient_id:
+            return patient_id, enc_id
+    except httpx.RequestError:
+        pass
+    return None, None
+
+
+if __name__ == "__main__":
+    # Usage: python _hapi_wait.py <base_url> [seed_type]
+    # Runs all checks in sequence.
+    # seed_type: "cdr" or "measure" (default "cdr")
+    base_url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8080/fhir"
+    seed_type = sys.argv[2] if len(sys.argv) > 2 else "cdr"
+    wait_for_metadata(base_url)
+    probe_patient_id, probe_encounter_id = _find_probe_ids(base_url)
+    if probe_patient_id and probe_encounter_id:
+        trigger_reindex_and_wait(base_url, probe_patient_id, probe_encounter_id)
+    if seed_type == "measure":
+        wait_for_valueset_expansion(base_url)
+    print("HAPI is ready.")

--- a/backend/tests/integration/_hapi_wait.py
+++ b/backend/tests/integration/_hapi_wait.py
@@ -37,10 +37,7 @@ def wait_for_metadata(base_url: str, timeout: int = 300) -> None:
         except httpx.RequestError as exc:
             last_exc = exc
         time.sleep(2)
-    raise RuntimeError(
-        f"HAPI at {base_url} did not respond within {timeout}s. "
-        f"Last error: {last_exc}"
-    )
+    raise RuntimeError(f"HAPI at {base_url} did not respond within {timeout}s. Last error: {last_exc}")
 
 
 def trigger_reindex_and_wait(
@@ -71,15 +68,11 @@ def trigger_reindex_and_wait(
 
     r = httpx.post(f"{base_url}/$reindex", json=params, headers=headers, timeout=30)
     if r.status_code >= 400:
-        warnings.warn(
-            f"$reindex trigger at {base_url} returned {r.status_code}: {r.text[:200]}"
-        )
+        warnings.warn(f"$reindex trigger at {base_url} returned {r.status_code}: {r.text[:200]}")
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        resp = httpx.get(
-            f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10
-        )
+        resp = httpx.get(f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10)
         if resp.status_code == 200:
             try:
                 if resp.json().get("entry"):
@@ -133,9 +126,7 @@ def wait_for_valueset_expansion(
             try:
                 # count=2 so HAPI-0831 fires for any VS with >1 code until
                 # background pre-expansion completes and HAPI can serve from DB.
-                resp = httpx.get(
-                    f"{base_url}/ValueSet/{vs_id}/$expand?count=2", timeout=15
-                )
+                resp = httpx.get(f"{base_url}/ValueSet/{vs_id}/$expand?count=2", timeout=15)
                 if resp.status_code == 200:
                     newly_done.add(vs_id)
             except httpx.RequestError:
@@ -171,10 +162,7 @@ def _discover_large_valueset_ids(base_url: str, threshold: int = 900) -> list[st
             vs_id = vs.get("id")
             if not vs_id:
                 continue
-            concept_count = sum(
-                len(inc.get("concept", []))
-                for inc in vs.get("compose", {}).get("include", [])
-            )
+            concept_count = sum(len(inc.get("concept", [])) for inc in vs.get("compose", {}).get("include", []))
             if concept_count >= threshold:
                 ids.append(vs_id)
     except httpx.RequestError:

--- a/docker/hapi-cdr-seeded.Dockerfile
+++ b/docker/hapi-cdr-seeded.Dockerfile
@@ -1,0 +1,48 @@
+# hapi-cdr-seeded.Dockerfile
+#
+# Extends hapiproject/hapi:v8.8.0-1 with patient seed data baked into the H2
+# database at image build time.  Environment matches the hapi-fhir-cdr service
+# in docker-compose.test.yml.
+#
+# The RUN /seed-hapi.sh step starts HAPI, loads patient-bundle.json (SEED_TYPE=cdr),
+# triggers $reindex, then stops HAPI cleanly so H2 flushes to disk.  The resulting
+# H2 file lives in the image layer at /data/hapi/h2.mv.db.
+#
+# IMPORTANT: When running this image, do NOT mount a volume over /data/hapi — that
+# would shadow the baked H2 files.  Remove or rename the test_cdrdata volume mount
+# in the wiring PR.
+
+FROM hapiproject/hapi:v8.8.0-1
+
+USER root
+
+# Install runtime tools needed by seed-hapi.sh (curl, jq)
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy seed bundles and build-time seed script
+COPY seed/patient-bundle.json /seed/patient-bundle.json
+COPY docker/seed-hapi.sh /seed-hapi.sh
+RUN chmod +x /seed-hapi.sh
+
+# Environment from docker-compose.test.yml hapi-fhir-cdr service
+ENV hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
+ENV hapi.fhir.implementationguides.qicore.version=6.0.0
+ENV hapi.fhir.implementationguides.uscore.name=hl7.fhir.us.core
+ENV hapi.fhir.implementationguides.uscore.version=6.1.0
+ENV hapi.fhir.implementationguides.cql.name=hl7.fhir.uv.cql
+ENV hapi.fhir.implementationguides.cql.version=1.0.0
+ENV hapi.fhir.server_address=http://localhost:8180/fhir
+ENV hapi.fhir.defer_indexing_for_codesystems_of_size=0
+ENV hapi.fhir.client_id_strategy=ANY
+ENV hapi.fhir.allow_external_references=true
+ENV hapi.fhir.enforce_referential_integrity_on_write=false
+ENV hapi.fhir.maximum_expansion_size=50000
+ENV spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
+ENV spring.datasource.driverClassName=org.h2.Driver
+
+# Bake: start HAPI, load patient seed data, wait for reindex, stop cleanly.
+# H2 data file is written to /data/hapi/h2.mv.db inside this image layer.
+ENV SEED_TYPE=cdr
+RUN /seed-hapi.sh

--- a/docker/hapi-cdr-seeded.Dockerfile
+++ b/docker/hapi-cdr-seeded.Dockerfile
@@ -1,32 +1,16 @@
 # hapi-cdr-seeded.Dockerfile
 #
-# Extends hapiproject/hapi:v8.8.0-1 with patient seed data baked into the H2
-# database at image build time.  Environment matches the hapi-fhir-cdr service
-# in docker-compose.test.yml.
+# Configuration-only layer on top of hapiproject/hapi:v8.8.0-1.
+# The seeded H2 database is baked in by the bake-hapi-image.yml workflow via
+# "docker run → seed from runner → docker stop → docker commit", NOT by a
+# Dockerfile RUN step (the base image is distroless — no shell available).
 #
-# The RUN /seed-hapi.sh step starts HAPI, loads patient-bundle.json (SEED_TYPE=cdr),
-# triggers $reindex, then stops HAPI cleanly so H2 flushes to disk.  The resulting
-# H2 file lives in the image layer at /data/hapi/h2.mv.db.
-#
-# IMPORTANT: When running this image, do NOT mount a volume over /data/hapi — that
-# would shadow the baked H2 files.  Remove or rename the test_cdrdata volume mount
-# in the wiring PR.
+# When running this image, do NOT mount a volume over /data/hapi — that would
+# shadow the baked H2 files committed by the bake workflow.
+# The wiring PR must remove the test_cdrdata volume mount from docker-compose.test.yml.
 
 FROM hapiproject/hapi:v8.8.0-1
 
-USER root
-
-# Install runtime tools needed by seed-hapi.sh (curl, jq)
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends curl jq && \
-    rm -rf /var/lib/apt/lists/*
-
-# Copy seed bundles and build-time seed script
-COPY seed/patient-bundle.json /seed/patient-bundle.json
-COPY docker/seed-hapi.sh /seed-hapi.sh
-RUN chmod +x /seed-hapi.sh
-
-# Environment from docker-compose.test.yml hapi-fhir-cdr service
 ENV hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
 ENV hapi.fhir.implementationguides.qicore.version=6.0.0
 ENV hapi.fhir.implementationguides.uscore.name=hl7.fhir.us.core
@@ -41,8 +25,3 @@ ENV hapi.fhir.enforce_referential_integrity_on_write=false
 ENV hapi.fhir.maximum_expansion_size=50000
 ENV spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
 ENV spring.datasource.driverClassName=org.h2.Driver
-
-# Bake: start HAPI, load patient seed data, wait for reindex, stop cleanly.
-# H2 data file is written to /data/hapi/h2.mv.db inside this image layer.
-ENV SEED_TYPE=cdr
-RUN /seed-hapi.sh

--- a/docker/hapi-measure-seeded.Dockerfile
+++ b/docker/hapi-measure-seeded.Dockerfile
@@ -1,0 +1,58 @@
+# hapi-measure-seeded.Dockerfile
+#
+# Extends hapiproject/hapi:v8.8.0-1 with measure + patient seed data baked into
+# the H2 database and Lucene index at image build time.  Environment matches the
+# hapi-fhir-measure service in docker-compose.test.yml.
+#
+# The RUN /seed-hapi.sh step starts HAPI, loads measure-bundle.json then
+# patient-bundle.json (SEED_TYPE=measure), triggers $reindex, polls ValueSet
+# pre-expansion, then stops HAPI cleanly so H2 and Lucene flush to disk.
+#
+# IMPORTANT: When running this image, do NOT mount a volume over /data/hapi — that
+# would shadow the baked H2 and Lucene index files.  Remove or rename the
+# test_measuredata volume mount in the wiring PR.
+
+FROM hapiproject/hapi:v8.8.0-1
+
+USER root
+
+# Install runtime tools needed by seed-hapi.sh (curl, jq)
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy seed bundles and build-time seed script
+COPY seed/measure-bundle.json /seed/measure-bundle.json
+COPY seed/patient-bundle.json /seed/patient-bundle.json
+COPY docker/seed-hapi.sh /seed-hapi.sh
+RUN chmod +x /seed-hapi.sh
+
+# Environment from docker-compose.test.yml hapi-fhir-measure service
+ENV hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
+ENV hapi.fhir.implementationguides.qicore.version=6.0.0
+ENV hapi.fhir.implementationguides.uscore.name=hl7.fhir.us.core
+ENV hapi.fhir.implementationguides.uscore.version=6.1.0
+ENV hapi.fhir.implementationguides.cql.name=hl7.fhir.uv.cql
+ENV hapi.fhir.implementationguides.cql.version=1.0.0
+ENV hapi.fhir.server_address=http://localhost:8181/fhir
+ENV hapi.fhir.defer_indexing_for_codesystems_of_size=0
+ENV hapi.fhir.client_id_strategy=ANY
+ENV hapi.fhir.allow_multiple_delete=true
+ENV hapi.fhir.cr.enabled=true
+ENV hapi.fhir.allow_external_references=true
+ENV hapi.fhir.enforce_referential_integrity_on_write=false
+ENV hapi.fhir.maximum_expansion_size=50000
+ENV hapi.fhir.reuse_cached_search_results_millis=0
+ENV spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
+ENV spring.datasource.driverClassName=org.h2.Driver
+ENV spring.jpa.properties.hibernate.search.enabled=true
+ENV spring.jpa.properties.hibernate.search.backend.type=lucene
+ENV spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
+ENV spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
+ENV spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+ENV spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
+
+# Bake: start HAPI, load measure + patient seed data, wait for reindex and
+# ValueSet pre-expansion, then stop cleanly so H2 and Lucene flush to disk.
+ENV SEED_TYPE=measure
+RUN /seed-hapi.sh

--- a/docker/hapi-measure-seeded.Dockerfile
+++ b/docker/hapi-measure-seeded.Dockerfile
@@ -1,33 +1,16 @@
 # hapi-measure-seeded.Dockerfile
 #
-# Extends hapiproject/hapi:v8.8.0-1 with measure + patient seed data baked into
-# the H2 database and Lucene index at image build time.  Environment matches the
-# hapi-fhir-measure service in docker-compose.test.yml.
+# Configuration-only layer on top of hapiproject/hapi:v8.8.0-1.
+# The seeded H2 database and Lucene index are baked in by the bake-hapi-image.yml
+# workflow via "docker run → seed from runner → docker stop → docker commit".
+# The base image is distroless (no shell), so RUN steps cannot be used for seeding.
 #
-# The RUN /seed-hapi.sh step starts HAPI, loads measure-bundle.json then
-# patient-bundle.json (SEED_TYPE=measure), triggers $reindex, polls ValueSet
-# pre-expansion, then stops HAPI cleanly so H2 and Lucene flush to disk.
-#
-# IMPORTANT: When running this image, do NOT mount a volume over /data/hapi — that
-# would shadow the baked H2 and Lucene index files.  Remove or rename the
-# test_measuredata volume mount in the wiring PR.
+# When running this image, do NOT mount a volume over /data/hapi — that would
+# shadow the baked H2 and Lucene files.
+# The wiring PR must remove the test_measuredata volume mount from docker-compose.test.yml.
 
 FROM hapiproject/hapi:v8.8.0-1
 
-USER root
-
-# Install runtime tools needed by seed-hapi.sh (curl, jq)
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends curl jq && \
-    rm -rf /var/lib/apt/lists/*
-
-# Copy seed bundles and build-time seed script
-COPY seed/measure-bundle.json /seed/measure-bundle.json
-COPY seed/patient-bundle.json /seed/patient-bundle.json
-COPY docker/seed-hapi.sh /seed-hapi.sh
-RUN chmod +x /seed-hapi.sh
-
-# Environment from docker-compose.test.yml hapi-fhir-measure service
 ENV hapi.fhir.implementationguides.qicore.name=hl7.fhir.us.qicore
 ENV hapi.fhir.implementationguides.qicore.version=6.0.0
 ENV hapi.fhir.implementationguides.uscore.name=hl7.fhir.us.core
@@ -51,8 +34,3 @@ ENV spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fh
 ENV spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
 ENV spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
 ENV spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
-
-# Bake: start HAPI, load measure + patient seed data, wait for reindex and
-# ValueSet pre-expansion, then stop cleanly so H2 and Lucene flush to disk.
-ENV SEED_TYPE=measure
-RUN /seed-hapi.sh

--- a/docker/seed-hapi.sh
+++ b/docker/seed-hapi.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# seed-hapi.sh — run at Docker image build time to bake seed data into H2 storage.
+#
+# Starts HAPI in the background, loads seed bundles, waits for reindex (and
+# optionally ValueSet pre-expansion), then sends SIGTERM so H2 flushes to disk.
+#
+# Environment variables:
+#   SEED_TYPE  "cdr" (default) or "measure"
+#              cdr     → POST patient-bundle.json only
+#              measure → POST measure-bundle.json then patient-bundle.json
+set -euo pipefail
+
+HAPI_BASE="http://localhost:8080/fhir"
+SEED_DIR="/seed"
+METADATA_TIMEOUT=300
+METADATA_POLL=2
+REINDEX_TIMEOUT=300
+REINDEX_POLL=1
+VALUESET_TIMEOUT=600
+VALUESET_POLL=2
+
+SEED_TYPE="${SEED_TYPE:-cdr}"
+
+log() {
+    echo "[$(date +%T)] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Start HAPI in the background
+# ---------------------------------------------------------------------------
+log "Starting HAPI (SEED_TYPE=${SEED_TYPE}) ..."
+java \
+  --class-path /app/main.war \
+  "-Dloader.path=main.war!/WEB-INF/classes/,main.war!/WEB-INF/,/app/extra-classes" \
+  org.springframework.boot.loader.PropertiesLauncher &
+HAPI_PID=$!
+log "HAPI PID=${HAPI_PID}"
+
+# ---------------------------------------------------------------------------
+# Wait for /fhir/metadata
+# ---------------------------------------------------------------------------
+log "Waiting for HAPI metadata (max ${METADATA_TIMEOUT}s) ..."
+deadline=$(( $(date +%s) + METADATA_TIMEOUT ))
+until curl -sf "${HAPI_BASE}/metadata" -o /dev/null; do
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        log "ERROR: HAPI did not respond within ${METADATA_TIMEOUT}s"
+        kill "${HAPI_PID}" 2>/dev/null || true
+        exit 1
+    fi
+    sleep "${METADATA_POLL}"
+done
+log "HAPI is up."
+
+# ---------------------------------------------------------------------------
+# Load seed bundles
+# ---------------------------------------------------------------------------
+post_bundle() {
+    local file="$1"
+    local label="$2"
+    log "POSTing ${label} ..."
+    curl -sf -X POST \
+        -H "Content-Type: application/fhir+json" \
+        --data-binary "@${file}" \
+        "${HAPI_BASE}" \
+        -o /dev/null
+    log "${label} loaded."
+}
+
+if [ "${SEED_TYPE}" = "measure" ]; then
+    post_bundle "${SEED_DIR}/measure-bundle.json" "measure-bundle.json"
+fi
+
+# Both CDR and measure servers receive patient data.
+# (Measure server needs patient data because $evaluate-measure resolves
+# patient resources from its own HAPI instance.)
+post_bundle "${SEED_DIR}/patient-bundle.json" "patient-bundle.json"
+
+# ---------------------------------------------------------------------------
+# Extract probe IDs from patient-bundle.json (first Encounter)
+# ---------------------------------------------------------------------------
+log "Extracting probe patient/encounter IDs ..."
+PROBE_ENC_ID=$(jq -r '
+    [.entry[] | select(.resource.resourceType == "Encounter")]
+    | first | .resource.id' \
+    "${SEED_DIR}/patient-bundle.json")
+
+PROBE_PATIENT_ID=$(jq -r '
+    [.entry[] | select(.resource.resourceType == "Encounter")]
+    | first | .resource.subject.reference
+    | ltrimstr("Patient/")' \
+    "${SEED_DIR}/patient-bundle.json")
+
+log "Probe patient=${PROBE_PATIENT_ID} encounter=${PROBE_ENC_ID}"
+
+# ---------------------------------------------------------------------------
+# Trigger $reindex and wait for reference search params to settle
+# ---------------------------------------------------------------------------
+log "Triggering \$reindex ..."
+reindex_body='{"resourceType":"Parameters","parameter":[{"name":"type","valueString":"Encounter"}]}'
+reindex_status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/fhir+json" \
+    -d "${reindex_body}" \
+    "${HAPI_BASE}/\$reindex")
+if [ "${reindex_status}" -ge 400 ]; then
+    log "WARNING: \$reindex returned HTTP ${reindex_status} — continuing anyway"
+fi
+
+log "Polling Encounter?patient=${PROBE_PATIENT_ID} (max ${REINDEX_TIMEOUT}s) ..."
+deadline=$(( $(date +%s) + REINDEX_TIMEOUT ))
+until [ "$(curl -sf "${HAPI_BASE}/Encounter?patient=${PROBE_PATIENT_ID}&_count=1" \
+             | jq -r '.entry | length' 2>/dev/null || echo 0)" -gt 0 ]; do
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        log "ERROR: reference-param indexing did not complete within ${REINDEX_TIMEOUT}s"
+        kill "${HAPI_PID}" 2>/dev/null || true
+        exit 1
+    fi
+    sleep "${REINDEX_POLL}"
+done
+log "\$reindex complete."
+
+# ---------------------------------------------------------------------------
+# ValueSet pre-expansion (measure server only)
+# ---------------------------------------------------------------------------
+if [ "${SEED_TYPE}" = "measure" ]; then
+    log "Polling ValueSet pre-expansion (max ${VALUESET_TIMEOUT}s) ..."
+    deadline=$(( $(date +%s) + VALUESET_TIMEOUT ))
+
+    # Collect IDs of ValueSets with >900 compose concepts (need pre-expansion)
+    large_ids=$(jq -r '
+        .entry[]
+        | select(.resource.resourceType == "ValueSet")
+        | . as $entry
+        | (.resource.compose.include // []
+           | map(.concept // [] | length)
+           | add // 0) as $cnt
+        | select($cnt >= 900)
+        | $entry.resource.id' \
+        "${SEED_DIR}/measure-bundle.json" 2>/dev/null || true)
+
+    if [ -z "${large_ids}" ]; then
+        log "No large ValueSets found — skipping pre-expansion poll."
+    else
+        log "Large ValueSets to expand: $(echo "${large_ids}" | wc -l | tr -d ' ')"
+        pending="${large_ids}"
+        while [ -n "${pending}" ]; do
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+                log "WARNING: ValueSet pre-expansion did not complete within ${VALUESET_TIMEOUT}s — continuing"
+                break
+            fi
+            still_pending=""
+            while IFS= read -r vs_id; do
+                [ -z "${vs_id}" ] && continue
+                status=$(curl -s -o /dev/null -w "%{http_code}" \
+                    "${HAPI_BASE}/ValueSet/${vs_id}/\$expand?count=2")
+                if [ "${status}" != "200" ]; then
+                    still_pending="${still_pending}${vs_id}"$'\n'
+                fi
+            done <<< "${pending}"
+            pending="${still_pending}"
+            if [ -n "${pending}" ]; then
+                sleep "${VALUESET_POLL}"
+            fi
+        done
+        log "ValueSet pre-expansion complete."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Stop HAPI cleanly so H2 flushes to disk
+# ---------------------------------------------------------------------------
+log "Sending SIGTERM to HAPI (PID=${HAPI_PID}) ..."
+kill -TERM "${HAPI_PID}"
+wait "${HAPI_PID}" || true
+log "HAPI stopped. Seed complete."

--- a/docker/seed-hapi.sh
+++ b/docker/seed-hapi.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
-# seed-hapi.sh — run at Docker image build time to bake seed data into H2 storage.
+# seed-hapi.sh — run from the CI workflow runner to seed a live HAPI container.
 #
-# Starts HAPI in the background, loads seed bundles, waits for reindex (and
-# optionally ValueSet pre-expansion), then sends SIGTERM so H2 flushes to disk.
+# This script runs ON THE RUNNER (not inside the container) because the base
+# hapiproject/hapi image is distroless and has no shell. The target HAPI
+# container must already be started with "docker run" before calling this script.
 #
 # Environment variables:
-#   SEED_TYPE  "cdr" (default) or "measure"
-#              cdr     → POST patient-bundle.json only
-#              measure → POST measure-bundle.json then patient-bundle.json
+#   HAPI_PORT   Port on localhost that maps to the container's 8080 (default: 8080)
+#   SEED_TYPE   "cdr" (default) or "measure"
+#               cdr     → POST patient-bundle.json only
+#               measure → POST measure-bundle.json then patient-bundle.json,
+#                         and wait for ValueSet pre-expansion
 set -euo pipefail
 
-HAPI_BASE="http://localhost:8080/fhir"
-SEED_DIR="/seed"
+HAPI_PORT="${HAPI_PORT:-8080}"
+HAPI_BASE="http://localhost:${HAPI_PORT}/fhir"
+SEED_TYPE="${SEED_TYPE:-cdr}"
+
 METADATA_TIMEOUT=300
 METADATA_POLL=2
 REINDEX_TIMEOUT=300
@@ -19,32 +24,18 @@ REINDEX_POLL=1
 VALUESET_TIMEOUT=600
 VALUESET_POLL=2
 
-SEED_TYPE="${SEED_TYPE:-cdr}"
-
 log() {
     echo "[$(date +%T)] $*"
 }
 
 # ---------------------------------------------------------------------------
-# Start HAPI in the background
-# ---------------------------------------------------------------------------
-log "Starting HAPI (SEED_TYPE=${SEED_TYPE}) ..."
-java \
-  --class-path /app/main.war \
-  "-Dloader.path=main.war!/WEB-INF/classes/,main.war!/WEB-INF/,/app/extra-classes" \
-  org.springframework.boot.loader.PropertiesLauncher &
-HAPI_PID=$!
-log "HAPI PID=${HAPI_PID}"
-
-# ---------------------------------------------------------------------------
 # Wait for /fhir/metadata
 # ---------------------------------------------------------------------------
-log "Waiting for HAPI metadata (max ${METADATA_TIMEOUT}s) ..."
+log "Waiting for HAPI at ${HAPI_BASE}/metadata (max ${METADATA_TIMEOUT}s, SEED_TYPE=${SEED_TYPE}) ..."
 deadline=$(( $(date +%s) + METADATA_TIMEOUT ))
 until curl -sf "${HAPI_BASE}/metadata" -o /dev/null; do
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         log "ERROR: HAPI did not respond within ${METADATA_TIMEOUT}s"
-        kill "${HAPI_PID}" 2>/dev/null || true
         exit 1
     fi
     sleep "${METADATA_POLL}"
@@ -67,30 +58,25 @@ post_bundle() {
 }
 
 if [ "${SEED_TYPE}" = "measure" ]; then
-    post_bundle "${SEED_DIR}/measure-bundle.json" "measure-bundle.json"
+    post_bundle "seed/measure-bundle.json" "measure-bundle.json"
 fi
 
 # Both CDR and measure servers receive patient data.
 # (Measure server needs patient data because $evaluate-measure resolves
 # patient resources from its own HAPI instance.)
-post_bundle "${SEED_DIR}/patient-bundle.json" "patient-bundle.json"
+post_bundle "seed/patient-bundle.json" "patient-bundle.json"
 
 # ---------------------------------------------------------------------------
 # Extract probe IDs from patient-bundle.json (first Encounter)
 # ---------------------------------------------------------------------------
 log "Extracting probe patient/encounter IDs ..."
-PROBE_ENC_ID=$(jq -r '
-    [.entry[] | select(.resource.resourceType == "Encounter")]
-    | first | .resource.id' \
-    "${SEED_DIR}/patient-bundle.json")
-
 PROBE_PATIENT_ID=$(jq -r '
     [.entry[] | select(.resource.resourceType == "Encounter")]
     | first | .resource.subject.reference
     | ltrimstr("Patient/")' \
-    "${SEED_DIR}/patient-bundle.json")
+    seed/patient-bundle.json)
 
-log "Probe patient=${PROBE_PATIENT_ID} encounter=${PROBE_ENC_ID}"
+log "Probe patient=${PROBE_PATIENT_ID}"
 
 # ---------------------------------------------------------------------------
 # Trigger $reindex and wait for reference search params to settle
@@ -112,7 +98,6 @@ until [ "$(curl -sf "${HAPI_BASE}/Encounter?patient=${PROBE_PATIENT_ID}&_count=1
              | jq -r '.entry | length' 2>/dev/null || echo 0)" -gt 0 ]; do
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         log "ERROR: reference-param indexing did not complete within ${REINDEX_TIMEOUT}s"
-        kill "${HAPI_PID}" 2>/dev/null || true
         exit 1
     fi
     sleep "${REINDEX_POLL}"
@@ -126,7 +111,6 @@ if [ "${SEED_TYPE}" = "measure" ]; then
     log "Polling ValueSet pre-expansion (max ${VALUESET_TIMEOUT}s) ..."
     deadline=$(( $(date +%s) + VALUESET_TIMEOUT ))
 
-    # Collect IDs of ValueSets with >900 compose concepts (need pre-expansion)
     large_ids=$(jq -r '
         .entry[]
         | select(.resource.resourceType == "ValueSet")
@@ -136,7 +120,7 @@ if [ "${SEED_TYPE}" = "measure" ]; then
            | add // 0) as $cnt
         | select($cnt >= 900)
         | $entry.resource.id' \
-        "${SEED_DIR}/measure-bundle.json" 2>/dev/null || true)
+        seed/measure-bundle.json 2>/dev/null || true)
 
     if [ -z "${large_ids}" ]; then
         log "No large ValueSets found — skipping pre-expansion poll."
@@ -166,10 +150,4 @@ if [ "${SEED_TYPE}" = "measure" ]; then
     fi
 fi
 
-# ---------------------------------------------------------------------------
-# Stop HAPI cleanly so H2 flushes to disk
-# ---------------------------------------------------------------------------
-log "Sending SIGTERM to HAPI (PID=${HAPI_PID}) ..."
-kill -TERM "${HAPI_PID}"
-wait "${HAPI_PID}" || true
-log "HAPI stopped. Seed complete."
+log "Seed complete."


### PR DESCRIPTION
## Summary

- Add `hapi-cdr-seeded.Dockerfile` and `hapi-measure-seeded.Dockerfile` that bake seed data, `$reindex`, and ValueSet expansion into Docker image layers at build time
- Add `docker/seed-hapi.sh`: bash entrypoint that seeds HAPI during docker build then shuts down cleanly so H2 DB is written into the image layer
- Add `.github/workflows/bake-hapi-image.yml`: publishes seeded images to `ghcr.io/bellese/mct2-hapi-cdr:latest` + `mct2-hapi-measure:latest` weekly and on seed changes
- Add `backend/tests/integration/_hapi_wait.py`: reusable HAPI readiness helpers extracted from conftest.py (conftest.py unchanged — wiring is a follow-up PR)

With these images, the PR gate can pull a pre-seeded HAPI instead of spending 5-10 min on seed + reindex + ValueSet expansion on every run.

**Deviation from Phase 2 spec — bundle assignment corrected to match conftest.py:**
The spec described CDR as receiving `measure-bundle.json + patient-bundle.json` and Measure as receiving `measure-bundle.json` only. The actual conftest.py does the opposite: `measure-bundle.json` → measure server only; `patient-bundle.json` → both servers (CDR canonical home + measure server for `$evaluate-measure` patient resolution). The Dockerfiles and `seed-hapi.sh` follow conftest's actual behavior so the wiring PR produces identical HAPI state.

**Known Phase 2 limitation — conftest loads measures differently:**
conftest.py separates Measures from other resources (individual PUTs to preserve backbone element IDs) and patches ValueSets with `fix_valueset_compose_for_hapi()` before loading. The Phase 2 `seed-hapi.sh` does a plain `curl POST /fhir` of the raw transaction bundle. This is functionally equivalent for the seed images (the transaction bundle is valid and HAPI accepts it), but may produce subtly different server state for edge cases. If integration tests fail against the baked images after wiring, revisit the seed script to replicate conftest's load strategy.

**Volume mount caution for wiring PR:**
`docker-compose.test.yml` mounts `test_cdrdata:/data/hapi` and `test_measuredata:/data/hapi`. These mounts will shadow the baked H2 files. The wiring PR must remove or omit these volume mounts when switching to seeded images.

## Type of change

- [x] Infrastructure / CI/CD

## Checklist

- [x] Tests added or updated (N/A — new infrastructure only, no test behavior change yet)
- [x] docs/ updated (N/A)
- [x] No new ADRs needed (GHCR image publish is a CI infrastructure decision)
- [x] Security implications considered — workflow uses GITHUB_TOKEN scoped to packages:write only; no secrets in Dockerfiles

## Test plan

- [ ] Manually trigger workflow: GitHub Actions → Bake HAPI Seeded Images → Run workflow
- [ ] Confirm `ghcr.io/bellese/mct2-hapi-cdr:latest` and `mct2-hapi-measure:latest` appear in the org Packages page
- [ ] Smoke test: `docker pull ghcr.io/bellese/mct2-hapi-cdr:latest && docker run --rm -p 8180:8080 ghcr.io/bellese/mct2-hapi-cdr:latest`
- [ ] Verify: `curl localhost:8180/fhir/Patient?_summary=count` should return count > 0 without any separate seeding step