### PR TITLE
fix: reindex before validation run evaluation

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -1139,8 +1139,22 @@ async def run_validation(validation_run_id: int) -> None:
                     extra={"failed": failed_gathers, "total": len(all_patient_refs), "run_id": validation_run_id},
                 )
 
-            # Wait for HAPI indexing (configurable via HAPI_INDEX_WAIT_SECONDS env var)
-            await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
+            if settings.HAPI_SYNC_AFTER_UPLOAD:
+                logger.info(
+                    "Waiting for HAPI reindex before validation evaluation",
+                    extra={"run_id": validation_run_id, "patient_count": len(all_patient_refs)},
+                )
+                try:
+                    await asyncio.to_thread(trigger_reindex_and_wait, settings.MEASURE_ENGINE_URL)
+                except Exception as exc:
+                    logger.warning(
+                        "HAPI reindex failed during validation — falling back to sleep",
+                        extra={"run_id": validation_run_id, "error": sanitize_error(exc)},
+                    )
+                    await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
+            else:
+                # Rollback path: old sleep-based wait
+                await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
             if await _stop_or_delete_validation_run(validation_run_id):
                 return
 

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -930,6 +930,113 @@ class TestRunValidation:
         ctx.__aexit__ = AsyncMock(return_value=False)
         return ctx
 
+    async def _run_one_patient_validation(
+        self,
+        test_session,
+        monkeypatch,
+        *,
+        hapi_sync_after_upload: bool,
+        to_thread_side_effect=None,
+    ):
+        run = ValidationRun(status=ValidationStatus.queued)
+        test_session.add(run)
+        test_session.add(
+            ExpectedResult(
+                measure_url="https://example.com/Measure/CMS124",
+                patient_ref="patient-1",
+                test_description="resolved",
+                expected_populations={"numerator": 1},
+                period_start="2026-01-01",
+                period_end="2026-12-31",
+                source_bundle="cms124.json",
+            )
+        )
+        await test_session.commit()
+        await test_session.refresh(run)
+
+        monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", hapi_sync_after_upload)
+        monkeypatch.setattr("app.services.validation.settings.HAPI_INDEX_WAIT_SECONDS", 7)
+        monkeypatch.setattr("app.services.validation.settings.MEASURE_ENGINE_URL", "http://measure/fhir")
+
+        strategy = MagicMock()
+        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
+
+        def make_ctx():
+            return self._make_session_ctx(test_session)
+
+        with (
+            patch("app.services.validation.async_session", side_effect=lambda: make_ctx()),
+            patch("app.services.validation._resolve_measure_id", new_callable=AsyncMock, return_value="measure-1"),
+            patch(
+                "app.services.validation._reload_measures_from_seed_bundles",
+                new_callable=AsyncMock,
+                return_value={"measures_loaded": 0, "libraries_loaded": 0, "failed": 0},
+            ),
+            patch("app.services.validation.BatchQueryStrategy", return_value=strategy),
+            patch("app.services.validation.push_resources", new_callable=AsyncMock),
+            patch("app.services.validation.wipe_patient_data", new_callable=AsyncMock),
+            patch(
+                "app.services.validation.evaluate_measure",
+                new_callable=AsyncMock,
+                return_value={
+                    "group": [
+                        {
+                            "population": [
+                                {
+                                    "code": {"coding": [{"code": "numerator"}]},
+                                    "count": 1,
+                                }
+                            ]
+                        }
+                    ],
+                    "evaluatedResource": [],
+                },
+            ),
+            patch("app.services.validation.asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread,
+            patch("app.services.validation.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            if to_thread_side_effect is not None:
+                mock_to_thread.side_effect = to_thread_side_effect
+            await run_validation(run.id)
+
+        return run, mock_to_thread, mock_sleep
+
+    async def test_reindexes_after_patient_push_when_hapi_sync_enabled(self, test_session, monkeypatch):
+        _, mock_to_thread, mock_sleep = await self._run_one_patient_validation(
+            test_session,
+            monkeypatch,
+            hapi_sync_after_upload=True,
+        )
+
+        mock_to_thread.assert_awaited_once()
+        assert mock_to_thread.await_args.args[0].__name__ == "trigger_reindex_and_wait"
+        assert mock_to_thread.await_args.args[1] == "http://measure/fhir"
+        mock_sleep.assert_not_awaited()
+
+    async def test_hapi_sync_disabled_uses_sleep_fallback(self, test_session, monkeypatch):
+        _, mock_to_thread, mock_sleep = await self._run_one_patient_validation(
+            test_session,
+            monkeypatch,
+            hapi_sync_after_upload=False,
+        )
+
+        mock_to_thread.assert_not_awaited()
+        mock_sleep.assert_awaited_once_with(7)
+
+    async def test_reindex_failure_logs_warning_and_uses_sleep_fallback(self, test_session, monkeypatch, caplog):
+        caplog.set_level("WARNING", logger="app.services.validation")
+
+        _, mock_to_thread, mock_sleep = await self._run_one_patient_validation(
+            test_session,
+            monkeypatch,
+            hapi_sync_after_upload=True,
+            to_thread_side_effect=RuntimeError("unreachable"),
+        )
+
+        mock_to_thread.assert_awaited_once()
+        mock_sleep.assert_awaited_once_with(7)
+        assert "HAPI reindex failed during validation" in caplog.text
+
     async def test_missing_measure_creates_error_results_and_resolved_measure_still_runs(self, test_session):
         run = ValidationRun(status=ValidationStatus.queued)
         test_session.add(run)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,6 +93,8 @@ The nightly `connectathon-measures.yml` workflow still runs once per night, but 
 
 If `/jobs` reports lower initial population counts than the direct-HAPI integration harness, check `HAPI_SYNC_AFTER_UPLOAD`, `PATIENT_DATA_STRATEGY`, and `VALUESET_RELOAD_MODE` first. HAPI indexes Encounter patient references and expands large ValueSets asynchronously after bundle upload, so MCT2 waits for reindex and `$expand` readiness before jobs can run against freshly uploaded Connectathon bundles. To isolate a regression, temporarily set `HAPI_SYNC_AFTER_UPLOAD=False`, `PATIENT_DATA_STRATEGY=data_requirements`, or `VALUESET_RELOAD_MODE=remap` and restart the backend.
 
+The validation dashboard path uses the same `HAPI_SYNC_AFTER_UPLOAD` reindex wait after the validation worker pushes patient data to the measure engine. Upload-bundle and `/jobs` still wait for both reindex and ValueSet expansion readiness; validation runs only need the reindex wait because they do not load new ValueSets.
+
 ---
 
 ## Connectathon Measure Tests (manifest-driven)


### PR DESCRIPTION
## Summary
- Ports the reindex-and-wait pattern from PR #142 into the validation worker's run_validation. The validation run path was missed in #142 — upload-bundle and /jobs got the fix, but the /validation/runs worker still used the pre-#142 asyncio.sleep(HAPI_INDEX_WAIT_SECONDS) shortcut after pushing patient data.
- Adds a reindex call gated behind the existing HAPI_SYNC_AFTER_UPLOAD flag, with a sleep-based fallback if the reindex call fails or the flag is off.
- Three new unit tests cover both flag paths plus the exception fallback.

## Why
Prod validation run #1 on 2026-04-24 returned 119/568 overall; CMS124 specifically 4/33. Same code, same measure-engine state, different result from /jobs (which was 33/33 on the same patients). Root cause: asyncio.sleep(5) is not enough time for HAPI to index 568 freshly-pushed patients on t3.medium, so the subsequent $evaluate-measure calls read stale indexes and patients miss IP. Same root-cause class as #142.

## Impact
Expected improvement on the Validation dashboard:
- CMS124: 4/33 → 33/33
- CMS506: 29/38 → 38/38
- CMS816: 1/9 → 9/9
- CMS130: 7/64 → ~63/64
- CMS125: 6/66 → ~56/66 (still partial because of HAPI-0831, tracked in #141)
- CMS122: 4/56 → ~50/56 (still partial because of Type D anomaly in #140)
- CMS529: 53/53 (already green; smaller patient set happened to clear the sleep window)
- Type A / Type B measures (CMS1218, CMS2, CMS71, CMS165, CMS1017) stay failing — separate bundle/HAPI issues.

## Rollback
Set HAPI_SYNC_AFTER_UPLOAD=False and restart backend. Restores the pre-fix asyncio.sleep behavior on the validation path without a redeploy.

## Related
- #142 — original reindex-timing fix (upload-bundle and /jobs). This PR extends that coverage to /validation/runs.
- #149 — wipe_patient_data accumulated-state bug. Independent.
- #140, #141 — residual per-measure issues, not addressed here.

## Validation
- `cd backend && ruff check app/ tests/`
- `cd backend && ruff format --check app/ tests/`
- `cd backend && python3 -m pytest tests/ --ignore=tests/integration -v` (302 passed)
- Local cold stack: uploaded CMS124 via `/validation/upload-bundle`; upload completed with 1 measure, 33 patients, 33 expected results.
- Validation worker logs showed `Waiting for HAPI reindex before validation evaluation` and `HAPI reindex complete` once for each HAPI_SYNC_AFTER_UPLOAD=True validation run.
- CMS124 validation run #2 completed `patients_tested=33`, `patients_passed=33`, `patients_failed=0`. Note: the first cold run hit three HAPI SearchParameter 409 conflicts during concurrent first-time `$evaluate-measure`; the immediately following run passed 33/33 after that HAPI initialization path completed.
- Rollback check: restarted backend with `HAPI_SYNC_AFTER_UPLOAD=False`, confirmed `settings.HAPI_SYNC_AFTER_UPLOAD == False`, reran CMS124 validation, and confirmed the validation-worker reindex log did not appear. Restored backend to `HAPI_SYNC_AFTER_UPLOAD=True` afterward.
