### PR TITLE
chore: wire PR gate to pre-baked HAPI images

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,6 +62,7 @@ jobs:
     env:
       # Soft default: STRICT_STU6=0 for rollout week. Flip to 1 once all connectathon measures pass in CI.
       STRICT_STU6: "0"
+      USE_PREBAKED: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
@@ -78,27 +79,12 @@ jobs:
         working-directory: backend
         run: pip install -r requirements.txt -r requirements-test.txt
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4  # v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          install: true
-
-      - name: Cache Docker images
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: docker-hapi-${{ hashFiles('docker-compose.test.yml') }}
-          restore-keys: docker-hapi-
-
-      - name: Load cached Docker images or pull
-        run: |
-          if [ -d /tmp/docker-cache ] && ls /tmp/docker-cache/*.tar 2>/dev/null; then
-            for f in /tmp/docker-cache/*.tar; do docker load -i "$f"; done
-          else
-            mkdir -p /tmp/docker-cache
-            docker pull hapiproject/hapi:v8.8.0-1
-            docker save hapiproject/hapi:v8.8.0-1 -o /tmp/docker-cache/hapi.tar
-          fi
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run integration tests
         run: |

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -208,7 +208,25 @@ def _load_seed_data(_require_infrastructure):
     REINDEX that prevents patient-reference searches from working until the reindex
     settles.
     """
+    import os
+
     import httpx as _httpx
+
+    if os.environ.get("HAPI_PREBAKED") == "1":
+        # Images are pre-seeded; skip loading + reindex + ValueSet expansion.
+        # Smoke probe: if Patient count is 0 the baked image is corrupt — fail fast.
+        for base_url, label in [(TEST_CDR_URL, "CDR"), (TEST_MEASURE_URL, "measure")]:
+            try:
+                resp = _httpx.get(f"{base_url}/Patient?_summary=count", timeout=15)
+                total = resp.json().get("total", 0) if resp.status_code == 200 else 0
+            except Exception:
+                total = 0
+            if total == 0:
+                raise RuntimeError(
+                    f"HAPI_PREBAKED=1 but {label} HAPI at {base_url} has no Patient resources. "
+                    f"The pre-baked image may be corrupt or the wrong image was pulled."
+                )
+        return
 
     measure_bundle_path = SEED_DIR / "measure-bundle.json"
     patient_bundle_path = SEED_DIR / "patient-bundle.json"

--- a/docker-compose.prebaked.yml
+++ b/docker-compose.prebaked.yml
@@ -1,0 +1,12 @@
+# docker-compose.prebaked.yml — override when using pre-baked HAPI images.
+#
+# Volume mounts at /data/hapi would shadow the baked H2/Lucene data, so
+# this overlay removes them.  Use with:
+#   docker compose -f docker-compose.test.yml -f docker-compose.prebaked.yml up -d
+
+services:
+  hapi-fhir-cdr:
+    volumes: []
+
+  hapi-fhir-measure:
+    volumes: []

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,7 +22,7 @@ services:
       retries: 5
 
   hapi-fhir-cdr:
-    image: hapiproject/hapi:v8.8.0-1
+    image: ${HAPI_CDR_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
     ports: ["8180:8080"]
     volumes: ["test_cdrdata:/data/hapi"]
@@ -47,7 +47,7 @@ services:
       - spring.datasource.driverClassName=org.h2.Driver
 
   hapi-fhir-measure:
-    image: hapiproject/hapi:v8.8.0-1
+    image: ${HAPI_MEASURE_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
     ports: ["8181:8080"]
     volumes: ["test_measuredata:/data/hapi"]

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -24,12 +24,69 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.test.yml"
+PREBAKED_OVERLAY="$PROJECT_ROOT/docker-compose.prebaked.yml"
 
 CDR_METADATA="http://localhost:8180/fhir/metadata"
 MEASURE_METADATA="http://localhost:8181/fhir/metadata"
 
 MAX_WAIT=300  # seconds
 POLL_INTERVAL=5
+
+# ---------------------------------------------------------------------------
+# Pre-baked image resolution (CI fast path)
+# Set USE_PREBAKED=1 to pull pre-seeded GHCR images instead of running the
+# full seed + reindex + ValueSet expansion on every test run.
+# ---------------------------------------------------------------------------
+USE_PREBAKED="${USE_PREBAKED:-0}"
+_using_prebaked=false
+
+if [ "$USE_PREBAKED" = "1" ]; then
+    echo "==> USE_PREBAKED=1 — resolving pre-baked HAPI images from GHCR..."
+    SEED_HASH=$(find "$PROJECT_ROOT/seed/" \
+        "$PROJECT_ROOT/docker/seed-hapi.sh" \
+        "$PROJECT_ROOT/docker-compose.test.yml" \
+        "$PROJECT_ROOT/docker/hapi-cdr-seeded.Dockerfile" \
+        "$PROJECT_ROOT/docker/hapi-measure-seeded.Dockerfile" \
+        -type f 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | cut -c1-12)
+    echo "  Seed hash: ${SEED_HASH}"
+
+    _try_pull() {
+        local image="$1"
+        if docker pull "$image" > /dev/null 2>&1; then
+            echo "$image"
+            return 0
+        fi
+        return 1
+    }
+
+    CDR_HASH_IMAGE="ghcr.io/bellese/mct2-hapi-cdr:${SEED_HASH}"
+    CDR_LATEST_IMAGE="ghcr.io/bellese/mct2-hapi-cdr:latest"
+    MEASURE_HASH_IMAGE="ghcr.io/bellese/mct2-hapi-measure:${SEED_HASH}"
+    MEASURE_LATEST_IMAGE="ghcr.io/bellese/mct2-hapi-measure:latest"
+    VANILLA_IMAGE="hapiproject/hapi:v8.8.0-1"
+
+    if _cdr_image=$(_try_pull "$CDR_HASH_IMAGE") && _measure_image=$(_try_pull "$MEASURE_HASH_IMAGE"); then
+        echo "  Using hash-tagged prebaked images."
+        _using_prebaked=true
+    elif _cdr_image=$(_try_pull "$CDR_LATEST_IMAGE") && _measure_image=$(_try_pull "$MEASURE_LATEST_IMAGE"); then
+        echo "  WARNING: hash-tagged images not found; falling back to :latest prebaked images."
+        _using_prebaked=true
+    else
+        echo "  WARNING: prebaked images unavailable; falling back to vanilla $VANILLA_IMAGE + full seed."
+        _cdr_image="$VANILLA_IMAGE"
+        _measure_image="$VANILLA_IMAGE"
+    fi
+
+    export HAPI_CDR_IMAGE="$_cdr_image"
+    export HAPI_MEASURE_IMAGE="$_measure_image"
+    echo "  CDR image:     $HAPI_CDR_IMAGE"
+    echo "  Measure image: $HAPI_MEASURE_IMAGE"
+
+    if $_using_prebaked; then
+        export HAPI_PREBAKED=1
+        export HAPI_REUSE_SEARCH_CACHE_MS=60000
+    fi
+fi
 
 # Phase timing
 _ts() { date +%s; }
@@ -45,10 +102,26 @@ _phase_done() {
     _t_prev=$_now
 }
 
+_compose_up() {
+    if $_using_prebaked; then
+        docker compose -f "$COMPOSE_FILE" -f "$PREBAKED_OVERLAY" up -d
+    else
+        docker compose -f "$COMPOSE_FILE" up -d
+    fi
+}
+
+_compose_down() {
+    if $_using_prebaked; then
+        docker compose -f "$COMPOSE_FILE" -f "$PREBAKED_OVERLAY" down -v 2>/dev/null || true
+    else
+        docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    fi
+}
+
 cleanup() {
     echo ""
     echo "==> Stopping test containers..."
-    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    _compose_down
 
     local _t_end
     _t_end=$(_ts)
@@ -79,13 +152,15 @@ has_explicit_pytest_target() {
     return 1
 }
 
-echo "==> Pulling HAPI FHIR image (avoids compose startup timeout on cold pull)..."
-docker pull hapiproject/hapi:v8.8.0-1
+if ! $_using_prebaked; then
+    echo "==> Pulling HAPI FHIR image (avoids compose startup timeout on cold pull)..."
+    docker pull hapiproject/hapi:v8.8.0-1
+fi
 _elapsed_pull=$(( $(_ts) - _t_start ))
 _phase_done "docker pull"
 
 echo "==> Starting test infrastructure..."
-docker compose -f "$COMPOSE_FILE" up -d
+_compose_up
 _elapsed_compose_up=$(( $(_ts) - _t_start ))
 _phase_done "docker compose up -d"
 


### PR DESCRIPTION
## Summary
- Sets `USE_PREBAKED=1` in the `integration-tests` CI job so the PR gate pulls pre-seeded `ghcr.io/bellese/mct2-hapi-{cdr,measure}` images from GHCR instead of running the full 8-12 min seed + reindex + ValueSet expansion on every PR
- Adds `docker-compose.prebaked.yml` overlay that removes `/data/hapi` volume mounts (which would otherwise shadow the baked H2/Lucene data)
- Parameterizes image refs in `docker-compose.test.yml` via `HAPI_CDR_IMAGE` / `HAPI_MEASURE_IMAGE` (default: vanilla upstream, preserving local dev parity)
- Short-circuits `_load_seed_data` fixture in conftest when `HAPI_PREBAKED=1`, with a smoke probe that fails fast if Patient count = 0
- Replaces Docker tar cache + vanilla pull steps in `pr-checks.yml` with a single GHCR login step; image resolution + pull lives entirely in `run-integration-tests.sh`
- Graceful fallback: if GHCR images are unavailable (e.g. bake not yet run), script falls back to `:latest` then to vanilla upstream + full seed

## Expected impact
- PR gate integration tests: **20 min → 5-7 min** on warm GHCR cache
- Fallback path (vanilla + full seed): unchanged behavior, still works, just slow

## Test plan
- [ ] Bake workflow (`bake-hapi-image.yml`) completes and images appear in GHCR (`ghcr.io/bellese/mct2-hapi-cdr:latest`)
- [ ] PR gate CI shows "Using hash-tagged prebaked images" in logs
- [ ] Integration tests pass and finish in < 10 min
- [ ] `$GITHUB_STEP_SUMMARY` shows test durations (confirming seed is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)