### PR TITLE
fix: wait for current validation patients after reindex

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -373,12 +373,28 @@ _REINDEX_POLL_INTERVAL = 5
 _VALUESET_EXPANSION_POLL_INTERVAL = 10
 
 
-def trigger_reindex_and_wait(base_url: str, probe_patient_id: str | None = None, timeout_s: int = 300) -> None:
-    """Trigger HAPI Encounter reindexing and wait until patient reference search works."""
+def _normalize_patient_id(patient_ref: str) -> str:
+    return patient_ref.removeprefix("Patient/")
+
+
+def trigger_reindex_and_wait_for_patients(
+    base_url: str,
+    probe_patient_ids: list[str],
+    timeout_s: int = 300,
+) -> None:
+    """Trigger HAPI Encounter reindexing and wait until current-run patient searches work."""
     headers = {"Content-Type": "application/fhir+json"}
     params = {"resourceType": "Parameters", "parameter": [{"name": "type", "valueString": "Encounter"}]}
     started_at = time.monotonic()
     polls = 0
+    pending = sorted({_normalize_patient_id(pid) for pid in probe_patient_ids if pid})
+
+    if not pending:
+        logger.warning(
+            "HAPI reindex wait skipped because no probe patients were provided",
+            extra={"base_url": base_url},
+        )
+        return
 
     with httpx.Client(timeout=30.0) as client:
         resp = client.post(f"{base_url}/$reindex", json=params, headers=headers)
@@ -388,44 +404,64 @@ def trigger_reindex_and_wait(base_url: str, probe_patient_id: str | None = None,
                 extra={"base_url": base_url, "status_code": resp.status_code, "body": resp.text[:200]},
             )
 
-        if not probe_patient_id:
-            try:
-                probe_resp = client.get(f"{base_url}/Patient?_count=1", timeout=10.0)
-                probe_resp.raise_for_status()
-                entries = probe_resp.json().get("entry", [])
-                if entries:
-                    probe_patient_id = entries[0].get("resource", {}).get("id")
-            except Exception as exc:
-                logger.warning(
-                    "Unable to select HAPI reindex probe patient",
-                    extra={"base_url": base_url, "error": str(exc)},
-                )
-
-        if not probe_patient_id:
-            logger.warning(
-                "HAPI reindex wait skipped because no probe patient was available",
-                extra={"base_url": base_url},
-            )
-            return
-
         deadline = started_at + timeout_s
-        while time.monotonic() < deadline:
+        while pending and time.monotonic() < deadline:
             polls += 1
-            try:
-                probe_resp = client.get(f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10.0)
-                if probe_resp.status_code == 200 and probe_resp.json().get("entry"):
-                    duration_s = round(time.monotonic() - started_at, 3)
-                    logger.info("HAPI reindex complete", extra={"duration_s": duration_s, "polls": polls})
-                    return
-            except Exception:
-                pass
-            time.sleep(_REINDEX_POLL_INTERVAL)
+            newly_done: set[str] = set()
+            for patient_id in pending:
+                try:
+                    probe_resp = client.get(f"{base_url}/Encounter?patient={patient_id}&_count=1", timeout=10.0)
+                    if probe_resp.status_code == 200 and probe_resp.json().get("entry"):
+                        newly_done.add(patient_id)
+                except Exception:
+                    pass
+            if newly_done:
+                pending = [patient_id for patient_id in pending if patient_id not in newly_done]
+            if pending:
+                time.sleep(_REINDEX_POLL_INTERVAL)
+
+    if not pending:
+        duration_s = round(time.monotonic() - started_at, 3)
+        logger.info(
+            "HAPI reindex complete",
+            extra={"duration_s": duration_s, "polls": polls, "probe_patient_count": len(probe_patient_ids)},
+        )
+        return
 
     duration_s = round(time.monotonic() - started_at, 3)
     logger.warning(
         "HAPI reindex timed out",
-        extra={"duration_s": duration_s, "polls": polls, "probe_patient_id": probe_patient_id},
+        extra={"duration_s": duration_s, "polls": polls, "pending_patient_count": len(pending)},
     )
+
+
+def trigger_reindex_and_wait(base_url: str, probe_patient_id: str | None = None, timeout_s: int = 300) -> None:
+    """Trigger HAPI Encounter reindexing and wait until patient reference search works."""
+    if probe_patient_id:
+        trigger_reindex_and_wait_for_patients(base_url, [probe_patient_id], timeout_s=timeout_s)
+        return
+
+    with httpx.Client(timeout=30.0) as client:
+        try:
+            probe_resp = client.get(f"{base_url}/Patient?_count=1", timeout=10.0)
+            probe_resp.raise_for_status()
+            entries = probe_resp.json().get("entry", [])
+            if entries:
+                probe_patient_id = entries[0].get("resource", {}).get("id")
+        except Exception as exc:
+            logger.warning(
+                "Unable to select HAPI reindex probe patient",
+                extra={"base_url": base_url, "error": str(exc)},
+            )
+
+    if not probe_patient_id:
+        logger.warning(
+            "HAPI reindex wait skipped because no probe patient was available",
+            extra={"base_url": base_url},
+        )
+        return
+
+    trigger_reindex_and_wait_for_patients(base_url, [probe_patient_id], timeout_s=timeout_s)
 
 
 def wait_for_valueset_expansion(base_url: str, valueset_urls: list[str], timeout_s: int = 600) -> dict[str, int]:

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -35,6 +35,7 @@ from app.services.fhir_client import (
     evaluate_measure,
     push_resources,
     trigger_reindex_and_wait,
+    trigger_reindex_and_wait_for_patients,
     wait_for_valueset_expansion,
     wipe_patient_data,
 )
@@ -1119,13 +1120,19 @@ async def run_validation(validation_run_id: int) -> None:
             strategy = BatchQueryStrategy()
             semaphore = asyncio.Semaphore(settings.MAX_WORKERS)
 
-            async def gather_and_push(patient_ref: str) -> None:
+            async def gather_and_push(patient_ref: str) -> set[str]:
                 async with semaphore:
                     if await _stop_or_delete_validation_run(validation_run_id):
-                        return
+                        return set()
                     resources = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
                     if resources:
                         await push_resources(resources)
+                    return {
+                        resource.get("subject", {}).get("reference", "").removeprefix("Patient/")
+                        for resource in resources
+                        if resource.get("resourceType") == "Encounter"
+                        and resource.get("subject", {}).get("reference", "").startswith("Patient/")
+                    }
 
             all_patient_refs = [er.patient_ref for er in resolved_expected_results]
             gather_results = await asyncio.gather(
@@ -1133,6 +1140,14 @@ async def run_validation(validation_run_id: int) -> None:
                 return_exceptions=True,
             )
             failed_gathers = sum(1 for r in gather_results if isinstance(r, BaseException))
+            reindex_probe_patient_ids = sorted(
+                {
+                    patient_id
+                    for result in gather_results
+                    if not isinstance(result, BaseException)
+                    for patient_id in result
+                }
+            )
             if failed_gathers:
                 logger.warning(
                     "Patient data gather partial failure — validation may reflect incomplete data",
@@ -1145,7 +1160,14 @@ async def run_validation(validation_run_id: int) -> None:
                     extra={"run_id": validation_run_id, "patient_count": len(all_patient_refs)},
                 )
                 try:
-                    await asyncio.to_thread(trigger_reindex_and_wait, settings.MEASURE_ENGINE_URL)
+                    if reindex_probe_patient_ids:
+                        await asyncio.to_thread(
+                            trigger_reindex_and_wait_for_patients,
+                            settings.MEASURE_ENGINE_URL,
+                            reindex_probe_patient_ids,
+                        )
+                    else:
+                        await asyncio.to_thread(trigger_reindex_and_wait, settings.MEASURE_ENGINE_URL)
                 except Exception as exc:
                     logger.warning(
                         "HAPI reindex failed during validation — falling back to sleep",

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -15,6 +15,7 @@ from app.services.fhir_client import (
     push_resources,
     resolve_evaluated_resource,
     trigger_reindex_and_wait,
+    trigger_reindex_and_wait_for_patients,
     upload_measure_bundle,
     wait_for_valueset_expansion,
     wipe_patient_data,
@@ -1262,6 +1263,31 @@ def test_trigger_reindex_and_wait_posts_202_and_polls_success(monkeypatch, caplo
     assert client.get_calls == [
         "http://hapi/fhir/Patient?_count=1",
         "http://hapi/fhir/Encounter?patient=p1&_count=1",
+    ]
+    assert "HAPI reindex complete" in caplog.text
+
+
+def test_trigger_reindex_and_wait_for_patients_polls_until_all_patients_index(monkeypatch, caplog):
+    client = FakeSyncClient(
+        get_responses=[
+            FakeSyncResponse(200, {"entry": [{"resource": {"id": "e1"}}]}),
+            FakeSyncResponse(200, {"entry": []}),
+            FakeSyncResponse(200, {"entry": [{"resource": {"id": "e2"}}]}),
+        ],
+        post_responses=[FakeSyncResponse(202)],
+    )
+
+    monkeypatch.setattr("app.services.fhir_client.httpx.Client", lambda **kwargs: client)
+    monkeypatch.setattr("app.services.fhir_client.time.sleep", lambda seconds: None)
+
+    with caplog.at_level("INFO"):
+        trigger_reindex_and_wait_for_patients("http://hapi/fhir", ["Patient/p1", "p2"])
+
+    assert client.post_calls[0][0] == "http://hapi/fhir/$reindex"
+    assert client.get_calls == [
+        "http://hapi/fhir/Encounter?patient=p1&_count=1",
+        "http://hapi/fhir/Encounter?patient=p2&_count=1",
+        "http://hapi/fhir/Encounter?patient=p2&_count=1",
     ]
     assert "HAPI reindex complete" in caplog.text
 

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -959,7 +959,16 @@ class TestRunValidation:
         monkeypatch.setattr("app.services.validation.settings.MEASURE_ENGINE_URL", "http://measure/fhir")
 
         strategy = MagicMock()
-        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
+        strategy.gather_patient_data = AsyncMock(
+            return_value=[
+                {"resourceType": "Patient", "id": "patient-1"},
+                {
+                    "resourceType": "Encounter",
+                    "id": "encounter-1",
+                    "subject": {"reference": "Patient/patient-1"},
+                },
+            ]
+        )
 
         def make_ctx():
             return self._make_session_ctx(test_session)
@@ -1009,8 +1018,9 @@ class TestRunValidation:
         )
 
         mock_to_thread.assert_awaited_once()
-        assert mock_to_thread.await_args.args[0].__name__ == "trigger_reindex_and_wait"
+        assert mock_to_thread.await_args.args[0].__name__ == "trigger_reindex_and_wait_for_patients"
         assert mock_to_thread.await_args.args[1] == "http://measure/fhir"
+        assert mock_to_thread.await_args.args[2] == ["patient-1"]
         mock_sleep.assert_not_awaited()
 
     async def test_hapi_sync_disabled_uses_sleep_fallback(self, test_session, monkeypatch):


### PR DESCRIPTION
## Summary
- Tightens the validation-run reindex wait introduced in #155 so it probes the Encounter patient indexes for the actual patients pushed by that validation run.
- Keeps the existing trigger_reindex_and_wait behavior for upload/jobs callers, but routes explicit patient probes through the same all-patients wait helper.
- Adds unit coverage for the current-patient wait helper and updates the validation worker test to assert it passes the pushed patient IDs.

## Why
#155 deployed correctly and the validation worker logged the reindex wait, but prod validation still returned the old baseline numbers. The wait helper used one arbitrary Patient as the readiness probe, so it could complete while most of the newly pushed validation patients still were not searchable via Encounter?patient=... indexes.

## Verification
- cd backend && ruff check app/ tests/
- cd backend && ruff format --check app/ tests/
- cd backend && python3 -m pytest tests/ --ignore=tests/integration -v
- After rebasing onto current origin/main: targeted ruff + current-patient tests passed.

## Related
- #155
- #156

## Check caveat
The seeded HAPI image bake workflow failure is unrelated to this validation worker fix and is being handled separately.