### PR TITLE
fix: wire HAPI_SYNC_AFTER_UPLOAD gate into /jobs orchestrator path (#140)

### DIFF
--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -19,6 +19,7 @@ from app.services.fhir_client import (
     evaluate_measure,
     get_group_members,
     push_resources,
+    trigger_reindex_and_wait,
     wipe_patient_data,
 )
 from app.services.validation import sanitize_error
@@ -338,11 +339,25 @@ async def _process_single_batch(
             # Wait for HAPI FHIR search indexes to catch up.
             # CQL evaluation relies on FHIR search internally; HAPI
             # indexes transactions asynchronously.
-            logger.info(
-                "All patient data pushed — waiting for HAPI indexing",
-                extra={"job_id": job_id, "batch_id": batch_id},
-            )
-            await asyncio.sleep(5.0)
+            if settings.HAPI_SYNC_AFTER_UPLOAD:
+                logger.info(
+                    "All patient data pushed — waiting for HAPI reindex",
+                    extra={"job_id": job_id, "batch_id": batch_id},
+                )
+                try:
+                    await asyncio.to_thread(trigger_reindex_and_wait, settings.MEASURE_ENGINE_URL)
+                except Exception as exc:
+                    logger.warning(
+                        "HAPI reindex failed during job — falling back to sleep",
+                        extra={"job_id": job_id, "batch_id": batch_id, "error": str(exc)},
+                    )
+                    await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
+            else:
+                logger.info(
+                    "All patient data pushed — waiting for HAPI indexing",
+                    extra={"job_id": job_id, "batch_id": batch_id},
+                )
+                await asyncio.sleep(settings.HAPI_INDEX_WAIT_SECONDS)
             if await _stop_or_delete_job(job_id):
                 return
 

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -147,6 +147,8 @@ async def test_run_job_happy_path(test_session, session_factory, mock_measure_re
             new_callable=AsyncMock,
             return_value=mock_measure_report,
         ),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
     ):
         await run_job(job_id)
 
@@ -279,6 +281,8 @@ async def test_run_job_partial_patient_failure(test_session, session_factory, mo
             new_callable=AsyncMock,
             side_effect=mock_evaluate,
         ),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
     ):
         await run_job(job_id)
 
@@ -331,6 +335,8 @@ async def test_run_job_all_patient_failures_marks_job_failed(test_session, sessi
             new_callable=AsyncMock,
             side_effect=Exception("HAPI returned 400"),
         ),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
     ):
         await run_job(job_id)
 
@@ -440,6 +446,8 @@ async def test_process_batch_uses_everything_strategy(test_session, session_fact
         _make_session_factory_patch(session_factory),
         patch("app.services.orchestrator.BatchQueryStrategy") as mock_strategy_cls,
         patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
         patch("app.services.orchestrator.asyncio.sleep", new_callable=AsyncMock),
         patch(
             "app.services.orchestrator.evaluate_measure",
@@ -513,6 +521,8 @@ async def test_process_batch_uses_data_requirements_strategy_when_configured(
         _make_session_factory_patch(session_factory),
         patch("app.services.orchestrator.DataRequirementsStrategy") as mock_strategy_cls,
         patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
         patch("app.services.orchestrator.asyncio.sleep", new_callable=AsyncMock),
         patch(
             "app.services.orchestrator.evaluate_measure",
@@ -545,3 +555,67 @@ async def test_process_batch_uses_data_requirements_strategy_when_configured(
         )
 
     mock_strategy_cls.assert_called_once_with("CMS999")
+
+
+async def test_process_batch_hapi_sync_calls_trigger_reindex(test_session, session_factory, monkeypatch):
+    """When HAPI_SYNC_AFTER_UPLOAD=True, _process_single_batch calls trigger_reindex_and_wait."""
+    from unittest.mock import MagicMock
+
+    from app.models.job import Batch, BatchStatus
+    from app.services.orchestrator import _process_single_batch
+
+    monkeypatch.setattr("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", True)
+    monkeypatch.setattr("app.services.orchestrator.settings.MEASURE_ENGINE_URL", "http://mcs/fhir")
+
+    job = Job(
+        measure_id="CMS122",
+        period_start="2026-01-01",
+        period_end="2026-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.running,
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    batch = Batch(
+        job_id=job.id,
+        batch_number=1,
+        patient_ids=["p1"],
+        status=BatchStatus.pending,
+    )
+    test_session.add(batch)
+    await test_session.commit()
+    await test_session.refresh(batch)
+
+    patient_map = {"p1": {"resourceType": "Patient", "id": "p1"}}
+    mock_reindex = MagicMock()
+
+    with (
+        _make_session_factory_patch(session_factory),
+        patch("app.services.orchestrator.BatchQueryStrategy") as mock_strategy_cls,
+        patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.trigger_reindex_and_wait", mock_reindex),
+        patch(
+            "app.services.orchestrator.evaluate_measure",
+            new_callable=AsyncMock,
+            return_value={
+                "resourceType": "MeasureReport",
+                "status": "complete",
+                "group": [{"population": [{"code": {"coding": [{"code": "initial-population"}]}, "count": 1}]}],
+            },
+        ),
+    ):
+        mock_strategy = MagicMock()
+        mock_strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "p1"}])
+        mock_strategy_cls.return_value = mock_strategy
+
+        await _process_single_batch(
+            job_id=job.id,
+            batch_id=batch.id,
+            patient_map=patient_map,
+            cdr_url="http://cdr/fhir",
+            auth_headers={},
+        )
+
+    mock_reindex.assert_called_once_with("http://mcs/fhir")

--- a/docs/connectathon-measures-status.md
+++ b/docs/connectathon-measures-status.md
@@ -2,7 +2,7 @@
 
 **HAPI version:** v8.8.0-1
 **Target:** MADiE May 2026 Connectathon (12 measures)
-**Last updated:** 2026-04-22 (PR #112 verification — 17 Class A failures confirmed, xfail marks added, eval gate extended; EXM bundles removed, QI-Core 6 versions pending — issue #115)
+**Last updated:** 2026-04-24 (issue #140 root cause confirmed — CMS122 DE divergence is HAPI upstream CQL bug, not MCT2 defect; /jobs hardcoded sleep replaced with HAPI_SYNC_AFTER_UPLOAD gate)
 
 ---
 
@@ -186,6 +186,8 @@ Patients land in `numerator` when MADiE expects `denominator-exclusion`. The fai
 Status: Genuine HAPI vs. MADiE CQL evaluation differences — not fixable locally. All 17 marked `xfail` in `test_connectathon_measures.py::_HAPI_DE_XFAIL`. Needs HAPI upstream issue filed at hapifhir/hapi-fhir (update `_HAPI_DE_XFAIL` comment with issue number when filed).
 
 **Issue #112 verification (2026-04-22):** Fresh-container run with extended eval gate confirmed exactly 17 failures — the 69 extra failures from an earlier run were timing artifacts (IP=0 from VS expansion not complete). Root cause: the eval gate only probed CMS122 patient `9cba6cfa`; CMS125/CMS130 VSes take longer to expand on slower machines. Fix: added eval gate probes for CMS122 numerator path + CMS125 + CMS130 in `_load_connectathon_bundles_to_hapi`.
+
+**Issue #140 root cause (2026-04-24):** Separate investigation confirmed the CMS122 `denominator-exclusion` gap is a HAPI upstream CQL bug, not a MCT2 defect. Evidence: (1) the count of 19 actual vs. 25 expected exactly matches the 6 `_HAPI_DE_XFAIL` frailty patients; (2) Phase 3 testing showed adding `trigger_reindex_and_wait` to the `/jobs` path improved overall CMS122 accuracy (49/56 → 50/56) but left `denominator-exclusion` at 19 → 19, ruling out reference-index timing. The `/jobs` path hardcoded `asyncio.sleep(5.0)` was replaced with the `HAPI_SYNC_AFTER_UPLOAD` + `trigger_reindex_and_wait` gate (same pattern as the validation path) to fix the broader accuracy gap for other patients. See issue #140 for full findings.
 
 ### Class B: CMS71 — MADiE bundle export bug (strict=false)
 


### PR DESCRIPTION
## Summary

- **Root cause documented**: CMS122 `denominator_exclusion` discrepancy (issue #140) is a confirmed HAPI v8.8.0 CQL evaluation divergence for AIFrailLTCF criteria. The 6-patient gap (19 actual vs 25 expected) exactly matches `_HAPI_DE_XFAIL`. MCT2 faithfully reports what HAPI evaluates. Updated `docs/connectathon-measures-status.md` with full findings.
- **`/jobs` orchestrator fix**: Replaces the hardcoded `asyncio.sleep(5.0)` in `_process_single_batch` with the same `HAPI_SYNC_AFTER_UPLOAD` + `trigger_reindex_and_wait` gate used by the validation path since commit `e907ccb`. This fixes the accuracy gap where manually adding reindex to the jobs path recovered 1/6 mismatched CMS122 patients (Phase 3 data from issue #140 investigation).
- **Test cleanup**: Adds `HAPI_SYNC_AFTER_UPLOAD=False` + `HAPI_INDEX_WAIT_SECONDS=0` patches to `run_job` unit tests — cuts orchestrator test suite from 15.75s to 0.46s. Adds a new test asserting `trigger_reindex_and_wait` is called with the correct URL when `HAPI_SYNC_AFTER_UPLOAD=True`.

## What does NOT change

The 6 CMS122 frailty patients in `_HAPI_DE_XFAIL` remain xfailed. Adding reindex to the jobs path does not fix them — Phase 3 testing confirmed `denominator_exclusion` stayed at 19→19 with reindex. That is a HAPI upstream CQL bug. Next action: file hapifhir/hapi-fhir issue (see `docs/connectathon-measures-status.md` Next Steps #1).

## Test plan

- [ ] `python3 -m pytest tests/test_services_orchestrator.py -v` — 20 passed, ~0.5s
- [ ] `python3 -m pytest tests/ --ignore=tests/integration -q` — all passing
- [ ] Review `docs/connectathon-measures-status.md` Class A section for accuracy

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)