### PR TITLE
fix: GHCR pull auth on prod via ephemeral GITHUB_TOKEN relay

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   id-token: write
   contents: read
+  packages: read  # required for GHCR pull on EC2 (token relayed via SSM SecureString)
 
 jobs:
   test-and-deploy:
@@ -46,6 +47,23 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::439475769170:role/leonard-github-deploy
           aws-region: us-east-1
+
+      - name: Stage GHCR pull token in SSM
+        # Writes the workflow's GITHUB_TOKEN to SSM as a SecureString so the
+        # EC2 deploy script can `docker login ghcr.io` to pull pre-baked HAPI
+        # images. The token is short-lived (workflow run TTL, ~1h) and removed
+        # by the cleanup step below regardless of deploy outcome.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          aws ssm put-parameter \
+            --name "/leonard/prod/GHCR_TOKEN" \
+            --value "$GH_TOKEN" \
+            --type "SecureString" \
+            --overwrite \
+            --region us-east-1 >/dev/null
+          echo "Staged ephemeral GHCR pull token in /leonard/prod/GHCR_TOKEN"
 
       - name: Deploy via SSM Run Command
         if: success()
@@ -91,6 +109,17 @@ jobs:
             echo "Deploy timed out waiting for SSM command $COMMAND_ID (final status: $STATUS)" >&2
             exit 1
           fi
+
+      - name: Remove staged GHCR pull token from SSM
+        # Always-run cleanup. Token is unusable after workflow ends anyway
+        # (~1h TTL), but we remove it so a static read of SSM never reveals
+        # an active credential between deploys.
+        if: always()
+        run: |
+          aws ssm delete-parameter \
+            --name "/leonard/prod/GHCR_TOKEN" \
+            --region us-east-1 2>/dev/null || true
+          echo "Cleared /leonard/prod/GHCR_TOKEN"
 
       - name: Health check
         if: success()

--- a/docs/runbooks/ghcr-pull-auth.md
+++ b/docs/runbooks/ghcr-pull-auth.md
@@ -1,0 +1,105 @@
+# GHCR Pull Auth on Prod
+
+## Why this exists
+
+The Phase 1 per-measure HAPI reset architecture (PR #167, design doc
+`2026-04-24-main-design-ephemeral-hapi-per-measure.md`) requires the prod EC2
+instance to pull pre-baked HAPI images from `ghcr.io/bellese/mct2-hapi-{cdr,measure}`.
+GHCR packages owned by an org default to **private**, so an unauthenticated
+`docker compose pull` returns 401 and the deploy fails:
+
+```
+hapi-fhir-measure Error Head "https://ghcr.io/v2/bellese/mct2-hapi-measure/manifests/latest": unauthorized
+```
+
+## How auth works
+
+No long-lived credential. The deploy workflow's own ephemeral `GITHUB_TOKEN`
+(scope: `packages: read`) is relayed to the EC2 box for one deploy and then
+deleted.
+
+```
+.github/workflows/deploy.yml
+  ├─ Stage step:    aws ssm put-parameter --name /leonard/prod/GHCR_TOKEN
+  │                                       --value $GITHUB_TOKEN
+  │                                       --type SecureString --overwrite
+  ├─ Deploy step:   aws ssm send-command  (runs scripts/deploy-prod.sh on EC2)
+  │                   └─ deploy-prod.sh:  docker login ghcr.io < /run/leonard/env
+  └─ Cleanup step:  aws ssm delete-parameter (always-run, even on deploy fail)
+```
+
+The token sits in SSM only for the duration of the deploy (~3-5 min). It would
+expire on its own at workflow end (~1 h) regardless.
+
+## IAM requirements
+
+The OIDC role `arn:aws:iam::439475769170:role/leonard-github-deploy` (assumed
+by the deploy workflow) needs:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "ssm:PutParameter",
+    "ssm:DeleteParameter"
+  ],
+  "Resource": "arn:aws:ssm:us-east-1:439475769170:parameter/leonard/prod/GHCR_TOKEN"
+},
+{
+  "Effect": "Allow",
+  "Action": ["kms:Encrypt"],
+  "Resource": "arn:aws:kms:us-east-1:439475769170:alias/aws/ssm"
+}
+```
+
+The EC2 instance role needs `ssm:GetParameter*` on `/leonard/prod/*` (already
+in place for `POSTGRES_PASSWORD`). No additional IAM change.
+
+## Failure modes
+
+**`Stage GHCR pull token in SSM` step fails with AccessDenied** — IAM doesn't
+yet allow `ssm:PutParameter` on the token path. Apply the policy snippet
+above and re-run the workflow.
+
+**Deploy step fails with `docker login ghcr.io failed`** — the workflow may
+not have `packages: read` permission. Check `.github/workflows/deploy.yml`
+permissions block. The token is also `packages: read`-scoped — if a future
+change reduces the workflow's permission, GHCR returns 401.
+
+**Manual deploy via `sudo ./scripts/deploy-prod.sh` on the EC2 box** —
+deploy-prod.sh prints a warning and skips `docker login`. If
+`docker-compose.prebaked.yml` is in the compose stack, the next pull will
+401. To run a manual deploy: either push to main (auto-redeploy via workflow
+with auth), or temporarily drop `-f docker-compose.prebaked.yml` from the
+COMPOSE array in `deploy-prod.sh`.
+
+## Verification
+
+After deploy:
+
+```
+ssh leonard@98.89.219.217 -i ~/.ssh/leonard.pem  # via session manager
+sudo docker images | grep ghcr.io/bellese
+# Should list mct2-hapi-cdr:latest and mct2-hapi-measure:latest
+```
+
+In CloudWatch logs (group `/leonard/deploy`), the deploy run should contain:
+
+```
+[+] Logging in to GHCR for pre-baked HAPI image pulls...
+[+] GHCR login OK
+```
+
+## Why not a long-lived PAT
+
+Considered. Rejected because:
+- A PAT is a long-lived credential needing rotation, monitoring, and SSM hygiene.
+- The workflow `GITHUB_TOKEN` is auto-rotated, scoped per-run, and free.
+- Bake workflow already pushes images using the same `GITHUB_TOKEN` pattern;
+  symmetry between push and pull auth is operationally clean.
+
+## Related
+
+- PR that introduced this: TBD (chore/ghcr-pull-auth)
+- PR that introduced the prebaked dependency: #167
+- Bake workflow: `.github/workflows/bake-hapi-image.yml`

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -120,6 +120,29 @@ grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" \
     | cut -d= -f2- \
     | install -o root -g root -m 0600 /dev/stdin "$SECRET_FILE"
 
+# ── docker login to GHCR (if token was staged by the deploy workflow) ─────────
+# The deploy workflow writes GITHUB_TOKEN to /leonard/prod/GHCR_TOKEN as a
+# SecureString just before invoking this script and deletes it after. Manual
+# runs without that staging step skip login and will fail loudly at compose
+# pull time if the prebaked overlay references private GHCR images.
+if grep -qE '^GHCR_TOKEN=' "$ENV_FILE"; then
+    printf '[+] Logging in to GHCR for pre-baked HAPI image pulls...\n'
+    GHCR_TOKEN_VALUE=$(grep -E '^GHCR_TOKEN=' "$ENV_FILE" | cut -d= -f2- | tr -d '\r\n')
+    # Username can be any non-empty string when the password is a GitHub token;
+    # GHCR ignores it. Use a label that's recognizable in `docker logout` output.
+    if ! printf '%s' "$GHCR_TOKEN_VALUE" \
+        | docker login ghcr.io --username leonard-deploy --password-stdin >/dev/null 2>&1; then
+        unset GHCR_TOKEN_VALUE
+        die 1 "docker login ghcr.io failed — check workflow packages:read scope"
+    fi
+    unset GHCR_TOKEN_VALUE
+    printf '[+] GHCR login OK\n'
+else
+    printf '[!] GHCR_TOKEN not in %s — skipping ghcr.io login.\n' "$ENV_FILE"
+    printf '    Manual deploys cannot pull the private pre-baked HAPI images.\n'
+    printf '    Trigger via the deploy workflow or omit docker-compose.prebaked.yml.\n'
+fi
+
 # ── shared preflight done; branch on mode ─────────────────────────────────────
 if [[ "$POST_DB_RESTART" -eq 1 ]]; then
     # ── --post-db-restart: reconcile only, no compose operations ──────────────


### PR DESCRIPTION
## Summary

- Fixes the prod deploy that failed after PR #167 with `unauthorized` against `ghcr.io/v2/bellese/mct2-hapi-measure`. Pre-baked HAPI images are private GHCR packages; EC2 had no auth.
- Relays the deploy workflow's own ephemeral `GITHUB_TOKEN` to the EC2 box via SSM `SecureString`, `docker login ghcr.io`, deploys, deletes the token. No long-lived PAT, no rotation, no human in the loop.
- Symmetric with the bake workflow (which pushes the same images using the same token pattern).

## Related issue
Unblocks #166 (Phase 1 prod canary).

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI/CD

## What changed
- `.github/workflows/deploy.yml` — adds `packages: read` permission, a `Stage GHCR pull token in SSM` step before `ssm send-command`, and an always-run `Remove staged GHCR pull token from SSM` step after.
- `scripts/deploy-prod.sh` — extracts `GHCR_TOKEN` from `/run/leonard/env` and runs `docker login ghcr.io --password-stdin` before the compose `up`. Manual runs without a staged token print a warning and skip login (loud failure if prebaked overlay is still in the compose stack).
- `docs/runbooks/ghcr-pull-auth.md` — full debug runbook with IAM snippet, failure modes, verification checklist.
- No `fetch-prod-secrets.sh` changes — the existing `/leonard/prod/` path-prefix iteration picks up `GHCR_TOKEN` automatically.

## Threat model
- Token sits in SSM only for the duration of one deploy (~3-5 min), encrypted `SecureString`, IAM-restricted, deleted on workflow end.
- Workflow `GITHUB_TOKEN` itself expires within ~1h regardless.
- Token bytes don't appear in CloudTrail event bodies; `PutParameter` records the name + metadata only.
- `--password-stdin` keeps the token off the EC2 process listing.

## IAM requirement (one-time)
The OIDC role `arn:aws:iam::439475769170:role/leonard-github-deploy` needs `ssm:PutParameter` + `ssm:DeleteParameter` on `parameter/leonard/prod/GHCR_TOKEN` plus `kms:Encrypt` on `alias/aws/ssm`. Snippet in `docs/runbooks/ghcr-pull-auth.md`. If the role doesn't have it, the new `Stage GHCR pull token in SSM` step will fail with `AccessDenied` — clear signal to grant the perms.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on `deploy.yml` passes
- [x] `bash -n scripts/deploy-prod.sh` clean
- [ ] **Merge → workflow runs → deploy succeeds** (this is the test). If the OIDC role lacks SSM permissions, the staging step fails with `AccessDenied` — apply the policy snippet from the runbook and re-run.
- [ ] Verify in deploy run logs that `[+] GHCR login OK` appears and `Stage GHCR pull token in SSM` + `Remove staged GHCR pull token from SSM` both ran.
- [ ] Then run the D6 prod gate on `/jobs CMS124` — expect 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)