### PR TITLE
chore: drop redundant unit + frontend builds from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Test and Deploy
+name: Deploy
 
 on:
   push:
@@ -21,22 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        with:
-          python-version: "3.10"
-
-      - name: Run backend unit tests
-        working-directory: backend
-        run: |
-          pip install -r requirements.txt -r requirements-test.txt
-          python -m pytest tests/ --ignore=tests/integration --cov=app --cov-fail-under=70 -v
-
-      - name: Check frontend build
-        working-directory: frontend
-        run: |
-          npm ci
-          npm run build
+      # Tests + frontend build run on every PR via .github/workflows/pr-checks.yml.
+      # Branch protection requires "branch up-to-date with main" before merge, so
+      # the squashed commit on main is byte-identical to the PR tip and re-running
+      # the same tests here adds ~5 min and zero marginal safety. The post-deploy
+      # `Health check` step is the real production smoke test.
 
       # Break-glass: SSH secrets (EC2_HOST, EC2_USER, EC2_SSH_KEY) retained for
       # manual access — not used in automated deploy.


### PR DESCRIPTION
## Summary

- Removes `Run backend unit tests` + `Check frontend build` (and the now-unused `Set up Python` step) from `.github/workflows/deploy.yml`. Same tests already run on every PR via `pr-checks.yml`.
- Renames the workflow `Test and Deploy` → `Deploy` so the Actions UI matches what it does.
- Cuts deploy latency by ~5 min per push to main with zero loss of safety (branch protection requires up-to-date-with-main before merge → squashed commit on main is byte-identical to PR tip).

## Why this is safe

| Concern | Mitigation |
|---|---|
| Squash merge could differ from PR tip | Branch protection requires "branch up-to-date with main" before merge — squash is byte-identical |
| Public-fork PR runs with restricted secrets | Bellese/mct2 is private. Trusted contributors only. N/A |
| Catch flaky test that passed on PR | Retest on push doesn't run in a different env — same runner, same code, same flake distribution |
| Catch breakage from dep drift between PR run and deploy run | Possible but extremely rare, and the post-deploy `Health check` against `https://api.98-89-219-217.nip.io/health` catches stack failure |

## What still gates deploy
- All tests on the PR (Unit Tests + Coverage, Frontend Build, Lint, Script Security Lint, Integration Tests).
- Branch protection on main requires PR Checks to pass + up-to-date with main.
- Post-deploy `Health check` confirms the live API is healthy before declaring success.

## Type of change
- [x] Infrastructure / CI/CD

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge, the next deploy on main runs in ~3-4 min instead of ~8-10 min, with `Health check` still gating success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)