### PR TITLE
fix: set network + aliases atomically at create time (Phase 1 reset)

### DIFF
--- a/backend/app/services/measure_engine_reset.py
+++ b/backend/app/services/measure_engine_reset.py
@@ -122,33 +122,48 @@ def _reset_measure_engine_sync(timeout_s: int) -> ResetTimings:
     remove_ms = (time.monotonic() - t_remove_start) * 1000.0
 
     t_create_start = time.monotonic()
+
+    # Set network + aliases atomically at create time via the low-level API.
+    # Earlier attempt used `network_mode="none"` + post-create `network.connect()`,
+    # but Docker rejects connecting an additional network to a container in
+    # "none" mode (400: "container cannot be connected to multiple networks
+    # with one of the networks in private (none) mode"). The networking_config
+    # path is the canonical pattern for create-with-aliases.
+    networking_config = None
+    if primary_network:
+        endpoint_config = client.api.create_endpoint_config(aliases=primary_aliases or [])
+        networking_config = client.api.create_networking_config({primary_network: endpoint_config})
+
+    host_config_kwargs: dict = {}
+    if mem_limit:
+        host_config_kwargs["mem_limit"] = mem_limit
+    if nano_cpus:
+        host_config_kwargs["nano_cpus"] = nano_cpus
+    if restart_policy:
+        host_config_kwargs["restart_policy"] = restart_policy
+    host_config = client.api.create_host_config(**host_config_kwargs) if host_config_kwargs else None
+
+    create_kwargs = dict(
+        image=image,
+        name=name or None,
+        environment=env,
+        labels=labels,
+        user=user,
+    )
+    if host_config is not None:
+        create_kwargs["host_config"] = host_config
+    if networking_config is not None:
+        create_kwargs["networking_config"] = networking_config
+
     try:
-        # Use create+connect+start (not run) so we can pass network aliases,
-        # which Docker only accepts at network-attach time, not at run().
-        new_container = client.containers.create(
-            image=image,
-            name=name or None,
-            environment=env,
-            labels=labels,
-            user=user,
-            mem_limit=mem_limit if mem_limit else None,
-            nano_cpus=nano_cpus if nano_cpus else None,
-            restart_policy=restart_policy or None,
-            # Don't auto-attach to the default bridge — we'll connect to the
-            # captured network with aliases below.
-            network_mode="none" if primary_network else None,
-            detach=True,
-        )
+        resp = client.api.create_container(**create_kwargs)
+        new_container = client.containers.get(resp["Id"])
     except docker.errors.APIError as exc:
         raise MeasureEngineResetError(f"Failed to recreate measure-engine container: {exc}") from exc
 
-    # Connect + start happen AFTER create. If either fails, the just-created
-    # container holds the original name — leaving it stranded would 409 the
-    # next reset. Force-remove on failure before re-raising.
+    # Start happens AFTER create. If start fails, the just-created container
+    # holds the original name and would 409 the next reset; force-remove first.
     try:
-        if primary_network:
-            net = client.networks.get(primary_network)
-            net.connect(new_container, aliases=primary_aliases or None)
         new_container.start()
     except docker.errors.APIError as exc:
         try:

--- a/backend/tests/test_services_measure_engine_reset.py
+++ b/backend/tests/test_services_measure_engine_reset.py
@@ -59,11 +59,15 @@ def _fake_container(
 
 
 def _fake_client_with_network(target_container: MagicMock) -> tuple[MagicMock, MagicMock, MagicMock]:
-    """Wire a fake docker client where create→connect→start is observable."""
+    """Wire a fake docker client where api.create_container → containers.get → start is observable."""
     fake_client = MagicMock()
     fake_client.containers.list.return_value = [target_container]
+    fake_client.api.create_container.return_value = {"Id": "newcontainerid"}
+    fake_client.api.create_endpoint_config.side_effect = lambda **kw: {"_endpoint": kw}
+    fake_client.api.create_networking_config.side_effect = lambda mapping: {"_net": mapping}
+    fake_client.api.create_host_config.side_effect = lambda **kw: {"_host": kw}
     new_container = MagicMock()
-    fake_client.containers.create.return_value = new_container
+    fake_client.containers.get.return_value = new_container
     network = MagicMock()
     fake_client.networks.get.return_value = network
     return fake_client, new_container, network
@@ -96,17 +100,19 @@ def test_reset_happy_path_recreates_container_with_network_aliases():
     )
     container.remove.assert_called_once_with(force=True, v=True)
 
-    create_kwargs = fake_client.containers.create.call_args.kwargs
+    # Aliases must be set at create time via networking_config — Docker rejects
+    # post-create connect on a "none"-mode container.
+    endpoint_call = fake_client.api.create_endpoint_config.call_args
+    assert endpoint_call.kwargs["aliases"] == ["hapi-fhir-measure", "9b8c7d6e5f4a"]
+    netcfg_call = fake_client.api.create_networking_config.call_args
+    assert "mct2_default" in netcfg_call.args[0]
+
+    create_kwargs = fake_client.api.create_container.call_args.kwargs
     assert create_kwargs["image"] == "ghcr.io/bellese/mct2-hapi-measure:latest"
     assert create_kwargs["name"] == "mct2-hapi-fhir-measure-1"
-    # Must NOT auto-attach to default bridge — we attach with aliases below.
-    assert create_kwargs["network_mode"] == "none"
+    assert "networking_config" in create_kwargs
+    assert "host_config" in create_kwargs
 
-    fake_client.networks.get.assert_called_once_with("mct2_default")
-    connect_kwargs = network.connect.call_args.kwargs
-    # CRITICAL: the service-name alias ("hapi-fhir-measure") must be forwarded
-    # so http://hapi-fhir-measure:8080/fhir keeps resolving from the backend.
-    assert connect_kwargs["aliases"] == ["hapi-fhir-measure", "9b8c7d6e5f4a"]
     new_container.start.assert_called_once()
 
 
@@ -133,31 +139,19 @@ def test_reset_remove_failure_wraps_api_error():
 def test_reset_recreate_failure_wraps_api_error():
     container = _fake_container()
     fake_client, _, _ = _fake_client_with_network(container)
-    fake_client.containers.create.side_effect = docker.errors.APIError("can't bind port")
+    fake_client.api.create_container.side_effect = docker.errors.APIError("can't bind port")
 
     with patch.object(measure_engine_reset.docker, "from_env", return_value=fake_client):
         with pytest.raises(MeasureEngineResetError, match="Failed to recreate"):
             _reset_measure_engine_sync(timeout_s=10)
-
-
-def test_reset_connect_failure_removes_stranded_container():
-    """If create() succeeds but network.connect() fails, the just-created
-    container would otherwise hold the original name and 409 the next reset.
-    Force-remove + re-raise is required to keep reset retries idempotent."""
-    container = _fake_container()
-    fake_client, new_container, network = _fake_client_with_network(container)
-    network.connect.side_effect = docker.errors.APIError("network busy")
-
-    with patch.object(measure_engine_reset.docker, "from_env", return_value=fake_client):
-        with pytest.raises(MeasureEngineResetError, match="Failed to recreate"):
-            _reset_measure_engine_sync(timeout_s=10)
-    new_container.remove.assert_called_once_with(force=True)
 
 
 def test_reset_start_failure_removes_stranded_container():
-    """Same contract as connect failure — start() failure must clean up."""
+    """If create() succeeds but start() fails, the just-created container holds
+    the original name and would 409 the next reset; force-remove + re-raise
+    keeps the reset retry idempotent."""
     container = _fake_container()
-    fake_client, new_container, network = _fake_client_with_network(container)
+    fake_client, new_container, _ = _fake_client_with_network(container)
     new_container.start.side_effect = docker.errors.APIError("OOM at start")
 
     with patch.object(measure_engine_reset.docker, "from_env", return_value=fake_client):


### PR DESCRIPTION
## Summary

Surfaced by the prod D6 CMS124 verification run. First /jobs CMS124 against the new architecture failed with:

\`\`\`
Failed to recreate measure-engine container: 400 Client Error: Bad Request
("container cannot be connected to multiple networks with one of the
networks in private (none) mode")
\`\`\`

The Phase 1 design used \`containers.create(network_mode=\"none\")\` followed by a separate \`network.connect(aliases=...)\` call, because the high-level docker-py SDK's \`containers.create(network=name)\` parameter doesn't accept aliases. Docker engine rejects connecting an additional network to a container in \"none\" mode — that constraint isn't documented in the SDK and the unit tests mocked it away (the \`network.connect()\` mock didn't enforce the engine-side constraint).

Fix: use the low-level docker-py API (\`api.create_container\` + \`create_networking_config\` + \`create_endpoint_config\`) to set network + aliases atomically at create time. No \"none\" mode, no separate connect, alias bound at create time. This is the canonical pattern for create-with-aliases per docker-py docs.

## Related issue
Unblocks #166 Phase 1 D6 prod gate.

## Type of change
- [x] Bug fix

## What changed
- \`backend/app/services/measure_engine_reset.py\` — replaced create-with-none-mode + post-create connect with low-level \`api.create_container(networking_config=...)\`. Aliases bound at create time.
- \`backend/tests/test_services_measure_engine_reset.py\` — 11 tests updated to patch the low-level API surface (\`api.create_container\`, \`api.create_endpoint_config\`, \`api.create_networking_config\`, \`api.create_host_config\`) instead of \`containers.create\`. Removed \`test_reset_connect_failure_*\` (no separate connect call to fail anymore). Kept the start-failure cleanup test — that path is still real.

## Test plan
- [x] 319 unit tests pass (run locally; same suite that ran on #167 + #168)
- [x] Lint clean
- [ ] After merge: deploy succeeds, /jobs CMS124 runs without the 400 error, returns 33/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)