### PR TITLE
fix: reset module ignores CONNECTATHON_BUNDLES_DIR env var

### DIFF
--- a/backend/app/services/measure_engine_reset.py
+++ b/backend/app/services/measure_engine_reset.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import pathlib
 import time
 from dataclasses import dataclass
@@ -37,8 +36,11 @@ SERVICE_LABEL = "com.docker.compose.service"
 HAPI_MEASURE_SERVICE = "hapi-fhir-measure"
 DEFAULT_RESET_TIMEOUT_S = 300
 HEALTH_POLL_INTERVAL_S = 1.0
-_DEFAULT_SEED_DIR = pathlib.Path(__file__).resolve().parents[3] / "seed" / "connectathon-bundles"
-SEED_BUNDLES_DIR = pathlib.Path(os.getenv("CONNECTATHON_BUNDLES_DIR", str(_DEFAULT_SEED_DIR)))
+# Resolves to /seed/connectathon-bundles in the backend container (bind-mounted
+# from ./seed/connectathon-bundles on the host). NOT CONNECTATHON_BUNDLES_DIR —
+# that env var is the operator-facing toggle to skip startup bundle replay in
+# bundle_loader.py and points at a non-existent path in prod.
+SEED_BUNDLES_DIR = pathlib.Path(__file__).resolve().parents[3] / "seed" / "connectathon-bundles"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Prod D6 surfaced this. After PR #170 landed, the network-alias fix worked but the CMS124 /jobs run failed at the bundle-load step:

\`\`\`
No connectathon bundle found for measure_id='CMS124FHIRCervicalCancerScreening'.
\`\`\`

\`docker-compose.yml\` deliberately sets \`CONNECTATHON_BUNDLES_DIR=/seed/disabled-connectathon-bundles\` (a non-existent path) so \`bundle_loader.py\` skips the startup bundle replay. PR #168 made \`measure_engine_reset.py\` honor the same env var "for consistency" — but those two modules have different needs for the same env var:

| Module | Use of \`CONNECTATHON_BUNDLES_DIR\` |
|---|---|
| \`bundle_loader.py\` | Operator toggle: pointing at a missing path skips the startup replay |
| \`measure_engine_reset.py\` | Needs the actual on-disk bundle source (the bind mount) regardless of operator toggle |

Reset module now hardcodes \`SEED_BUNDLES_DIR\` to the bind-mount path (\`/seed/connectathon-bundles\` in the backend container, resolved via \`__file__\`'s parents). The bind mount is identical in dev, CI, and prod compose files. Code comment names the asymmetry.

## Related issue
Unblocks #166 D6 prod gate.

## Type of change
- [x] Bug fix

## Test plan
- [x] Reset unit tests pass (\`SEED_BUNDLES_DIR\` is patched per-test, so tests already used the constant — no test change needed)
- [x] Lint clean
- [ ] After merge: deploy succeeds, /jobs CMS124 returns 33/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)