### PR TITLE
fix: bake measure HAPI image with IGs only, no measure or patient seed

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -107,8 +107,13 @@ jobs:
           docker run -d --name hapi-measure -p 8181:8080 --user root mct2-hapi-measure-config
 
       - name: Seed Measure container
+        # SEED_TYPE=igs bakes ONLY the IGs (qicore/uscore/cql) into the image —
+        # no measure-bundle.json, no patient-bundle.json. Per-measure isolation
+        # (PR #167) requires that reset+reload gives an empty HAPI with just
+        # IGs; baking in CMS122 + seed patients would defeat isolation because
+        # they'd persist across container recreate and contaminate every measure.
         run: |
-          HAPI_PORT=8181 SEED_TYPE=measure bash docker/seed-hapi.sh
+          HAPI_PORT=8181 SEED_TYPE=igs bash docker/seed-hapi.sh
 
       - name: Dump Measure container state on failure
         if: failure()

--- a/docker/seed-hapi.sh
+++ b/docker/seed-hapi.sh
@@ -7,10 +7,12 @@
 #
 # Environment variables:
 #   HAPI_PORT   Port on localhost that maps to the container's 8080 (default: 8080)
-#   SEED_TYPE   "cdr" (default) or "measure"
-#               cdr     → POST patient-bundle.json only
-#               measure → POST measure-bundle.json then patient-bundle.json,
-#                         and wait for ValueSet pre-expansion
+#   SEED_TYPE   "cdr" (default), "measure", or "igs"
+#               cdr     → POST patient-bundle.json only, $reindex, no ValueSet expansion poll
+#               measure → POST measure-bundle.json + patient-bundle.json, $reindex, ValueSet expansion poll
+#               igs     → wait for IGs to install via Spring env vars; no bundle posts, no $reindex.
+#                         Use for the per-measure-isolation HAPI image (no measure or patient
+#                         data baked in, so reset gives a truly empty engine).
 set -euo pipefail
 
 HAPI_PORT="${HAPI_PORT:-8080}"
@@ -41,6 +43,18 @@ until curl -sf "${HAPI_BASE}/metadata" -o /dev/null; do
     sleep "${METADATA_POLL}"
 done
 log "HAPI is up."
+
+# ---------------------------------------------------------------------------
+# IGs-only short-circuit
+# ---------------------------------------------------------------------------
+# Spring auto-installs IGs from the env vars set in the image's Dockerfile
+# during HAPI startup. The /metadata 200 above means startup completed and
+# IGs are loaded. No data to seed, no reindex needed (no Encounters).
+if [ "${SEED_TYPE}" = "igs" ]; then
+    log "SEED_TYPE=igs: IGs installed by HAPI on startup. No bundles posted, no \$reindex."
+    log "Seed complete."
+    exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Load seed bundles


### PR DESCRIPTION
## Summary

Phase 1 D6 prod verification found /jobs CMS124 completes 33/33 with **all-zero populations** despite no errors. Diagnosis: the prebaked measure image bakes \`seed/measure-bundle.json\` (CMS122) into the H2 layer. After reset+reload, HAPI ends up with **both** the requested measure AND CMS122 — exactly the cross-bundle terminology contamination Phase 1 was meant to defeat, with a baked-in copy that survives container recreate.

Confirmed in prod after job 11:
\`\`\`
GET /Measure → CMS122FHIRDiabetesAssessGT9Pct, CMS124FHIRCervicalCancerScreening
               (total: 2 — CMS122 should not be there after reset+CMS124-only load)
\`\`\`

Fix: bake the measure image with only the IGs (qicore/uscore/cql) in \`JpaPackageCache\`. No measure data, no patient data. Reset gives a truly empty engine; \`load_measure_support_to_engine\` puts in exactly one measure; true per-measure isolation.

## Related issue
Unblocks #166 D6 prod gate (substantive correctness signal).

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI/CD

## What changed
- \`docker/seed-hapi.sh\` — new \`SEED_TYPE=igs\` short-circuits after \`/metadata\` is reachable. Skips bundle posts, \`\$reindex\`, and ValueSet expansion poll (none meaningful without seed data).
- \`.github/workflows/bake-hapi-image.yml\` — measure container uses \`SEED_TYPE=igs\`. CDR container unchanged (\`SEED_TYPE=cdr\` — patient seed is fine for CDR; no terminology concern there).

## Local validation
Built the modified config image locally and ran the new IGs-only seed path. Verified:
- \`/metadata\` reachable in ~17s (vs ~5 min for full seed cycle)
- HAPI logs show IG packages (\`hl7.fhir.uv.cql\`, \`hl7.fhir.us.qicore\`, \`hl7.fhir.us.core\`) indexed into \`JpaPackageCache\`
- \`/Measure\`, \`/Library\`, \`/Patient\` all return \`total=0\`
- Quick exit, no \`\$reindex\`, no ValueSet expansion poll

## Test plan
- [x] Local: verified empty FHIR store + IGs indexed
- [ ] Bake workflow runs successfully and publishes \`ghcr.io/bellese/mct2-hapi-measure:latest\` (~20-30 min)
- [ ] Redeploy succeeds (~3-4 min thanks to PR #169 trim)
- [ ] Re-run \`/jobs CMS124\` with \`group_id\` filter on the 33 test patients — expect non-zero populations

🤖 Generated with [Claude Code](https://claude.com/claude-code)