### PR TITLE
fix: pull pre-built images before compose up in deploy-prod.sh

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -182,14 +182,26 @@ done
 printf '[+] Reconciling DB password...\n'
 LEONARD_DIR="$LEONARD_DIR" "$RECONCILE_SCRIPT"
 
-# ── step 7: build and bring up remaining services ────────────────────────────
+# ── step 7: pull pre-built images from registries ─────────────────────────────
+# Without an explicit pull, `up --build` uses any locally-cached image even when
+# `:latest` upstream has been republished. This bit us when the bake workflow
+# (which republishes ghcr.io/bellese/mct2-hapi-{cdr,measure}:latest) finished
+# AFTER the deploy workflow started — deploy used the stale cached image and
+# never picked up the new bake. `docker compose pull` here is best-effort
+# (--ignore-pull-failures lets us continue if a registry hiccups; the next
+# step's `--build` still uses the cached image as fallback).
+printf '[+] Pulling latest pre-built images...\n'
+"${COMPOSE[@]}" pull --ignore-pull-failures || true
+
+# ── step 8: build and bring up remaining services ────────────────────────────
 # --build ensures locally-built images (backend, frontend, seed) are rebuilt
 # from the current Dockerfile so the new entrypoint and code are picked up.
-# Services using pre-built images (hapi, postgres, caddy) are unaffected.
+# Services using pre-built images (hapi, postgres, caddy) come from the pull
+# above (or local cache if pull failed).
 printf '[+] Building and starting remaining services...\n'
 "${COMPOSE[@]}" up -d --build
 
-# ── step 8: health check ──────────────────────────────────────────────────────
+# ── step 9: health check ──────────────────────────────────────────────────────
 printf '[+] Waiting for API health check...\n'
 for i in $(seq 1 24); do
     if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Without an explicit pull, \`up --build\` uses locally-cached images even when \`:latest\` upstream has been republished. This bit us today when PR #172's IGs-only bake completed AFTER the parallel deploy workflow finished — prod ran with the stale prebaked image (CMS122 still baked in).

Adds \`docker compose pull --ignore-pull-failures\` before \`up -d --build\`. If pull succeeds, compose recreates containers with the new digest automatically. If pull fails, we fall through to the cached image.

## Related issue
Unblocks #166 D6 prod gate (need to actually deploy the IGs-only image from #172).

## What changed
- \`scripts/deploy-prod.sh\` — new step 7 \`docker compose pull\` (best-effort), renumbered downstream steps.

## Known limitation
This PR doesn't fix the underlying **bake/deploy parallel-execution race**. If a future commit changes both \`seed/**\` (triggers bake) AND \`backend/**\` (deploys), deploy can still finish before bake. The next deploy will catch up (cache miss → pull). A proper fix would sequence them via \`workflow_run\` or add a \`wait for bake\` step. Tracked as followup.

## Test plan
- [x] \`bash -n scripts/deploy-prod.sh\` passes
- [ ] After merge: deploy workflow runs, sees the post-#172 bake image, pulls it, recreates the measure container with 0 baked measures
- [ ] Followup CMS124 D6 verification with non-zero populations

🤖 Generated with [Claude Code](https://claude.com/claude-code)