### PR TITLE
revert: "bake measure HAPI image with IGs only" (#172)

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -107,13 +107,8 @@ jobs:
           docker run -d --name hapi-measure -p 8181:8080 --user root mct2-hapi-measure-config
 
       - name: Seed Measure container
-        # SEED_TYPE=igs bakes ONLY the IGs (qicore/uscore/cql) into the image —
-        # no measure-bundle.json, no patient-bundle.json. Per-measure isolation
-        # (PR #167) requires that reset+reload gives an empty HAPI with just
-        # IGs; baking in CMS122 + seed patients would defeat isolation because
-        # they'd persist across container recreate and contaminate every measure.
         run: |
-          HAPI_PORT=8181 SEED_TYPE=igs bash docker/seed-hapi.sh
+          HAPI_PORT=8181 SEED_TYPE=measure bash docker/seed-hapi.sh
 
       - name: Dump Measure container state on failure
         if: failure()

--- a/docker/seed-hapi.sh
+++ b/docker/seed-hapi.sh
@@ -7,12 +7,10 @@
 #
 # Environment variables:
 #   HAPI_PORT   Port on localhost that maps to the container's 8080 (default: 8080)
-#   SEED_TYPE   "cdr" (default), "measure", or "igs"
-#               cdr     → POST patient-bundle.json only, $reindex, no ValueSet expansion poll
-#               measure → POST measure-bundle.json + patient-bundle.json, $reindex, ValueSet expansion poll
-#               igs     → wait for IGs to install via Spring env vars; no bundle posts, no $reindex.
-#                         Use for the per-measure-isolation HAPI image (no measure or patient
-#                         data baked in, so reset gives a truly empty engine).
+#   SEED_TYPE   "cdr" (default) or "measure"
+#               cdr     → POST patient-bundle.json only
+#               measure → POST measure-bundle.json then patient-bundle.json,
+#                         and wait for ValueSet pre-expansion
 set -euo pipefail
 
 HAPI_PORT="${HAPI_PORT:-8080}"
@@ -43,18 +41,6 @@ until curl -sf "${HAPI_BASE}/metadata" -o /dev/null; do
     sleep "${METADATA_POLL}"
 done
 log "HAPI is up."
-
-# ---------------------------------------------------------------------------
-# IGs-only short-circuit
-# ---------------------------------------------------------------------------
-# Spring auto-installs IGs from the env vars set in the image's Dockerfile
-# during HAPI startup. The /metadata 200 above means startup completed and
-# IGs are loaded. No data to seed, no reindex needed (no Encounters).
-if [ "${SEED_TYPE}" = "igs" ]; then
-    log "SEED_TYPE=igs: IGs installed by HAPI on startup. No bundles posted, no \$reindex."
-    log "Seed complete."
-    exit 0
-fi
 
 # ---------------------------------------------------------------------------
 # Load seed bundles


### PR DESCRIPTION
## Summary

Reverts #172. Two-step rationale:

1. **CI is broken for the team.** #172's IGs-only measure bake means `ghcr.io/bellese/mct2-hapi-measure:latest` has zero Patient resources. The integration-test fixture's `HAPI_PREBAKED=1` smoke probe asserts `Patient count > 0`, so every PR's Integration Tests fails. The forward-fix attempt (#175) couldn't unblock CI cleanly.
2. **The architectural premise of #172 was wrong.** Local validation (full stack, sync strategy enabled, #172's IGs-only image in place) showed `/jobs CMS124` still produces wrong populations: 20/33 patients have no searchable Encounter even after $reindex + 60s waits. The contamination from a baked-in CMS122 was not the root cause of the bug. Removing CMS122 from the prebaked image gave us nothing in exchange for breaking CI.

The Phase 1 reset architecture (#167) stays in prod. It's inert without #172 — reset+reload still happens, the new prebaked image just has CMS122 baked back in. Cross-bundle contamination is back, but evidence today says contamination wasn't the bug, so this is fine.

## Related issue
Refs #166. The real bug is documented in `~/.gstack/projects/Bellese-mct2/2026-04-25-hapi-consistency-model.md` v2 — HAPI's reference index deterministically misses ~40% of Encounters during bundle import for reasons not yet identified. Investigation continues from a healthy CI baseline.

## Type of change
- [x] Revert
- [x] Infrastructure / CI/CD

## What this restores
- `docker/seed-hapi.sh` — drops the `SEED_TYPE=igs` short-circuit, back to `cdr` / `measure` modes only.
- `.github/workflows/bake-hapi-image.yml` — measure container uses `SEED_TYPE=measure` again, baking measure-bundle.json + patient-bundle.json into the image.

## Followup after merge
- The bake workflow will re-trigger on this merge (matches its `paths` filter) and republish `ghcr.io/bellese/mct2-hapi-{cdr,measure}:latest` with seed data baked back in. ETA ~3-5 min.
- After bake completes, integration tests on subsequent PRs will pass against the new image.
- PR #175 (forward-fix attempt) is now redundant — close it after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)