### PR TITLE
fix(push_resources): sort Patient resources first to defeat HAPI forward-ref index miss

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -547,8 +547,21 @@ async def push_resources(
     Uses batch (not transaction) so HAPI does not validate cross-references
     between entries — avoids HAPI-2001 when clinical subjects are absent from
     the measure engine.
+
+    Patient resources are placed first in the batch. HAPI's bundle import
+    skips writing reference index entries for forward-references (e.g. an
+    Encounter whose `subject` points at a Patient that hasn't been written
+    yet in the same bundle). The Encounter is durably persisted but
+    `Encounter?patient=Patient/{id}` returns 0 forever afterwards. Sorting
+    Patients-first makes every Patient reference resolvable at index time.
+    Verified empirically 2026-04-25: same bundle, original order = 20/33
+    indexed; Patients-first = 33/33 at t=0. See issue #177.
     """
     base = target_url or settings.MEASURE_ENGINE_URL
+    valid = [r for r in resources if "resourceType" in r and "id" in r]
+    ordered = [r for r in valid if r.get("resourceType") == "Patient"] + [
+        r for r in valid if r.get("resourceType") != "Patient"
+    ]
     bundle = {
         "resourceType": "Bundle",
         "type": "batch",
@@ -560,8 +573,7 @@ async def push_resources(
                     "url": f"{r['resourceType']}/{r['id']}",
                 },
             }
-            for r in resources
-            if "resourceType" in r and "id" in r
+            for r in ordered
         ],
     }
     if not bundle["entry"]:

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -249,6 +249,53 @@ async def test_push_resources_empty():
     mock_ctx.post.assert_not_called()
 
 
+async def test_push_resources_sorts_patients_first():
+    """push_resources MUST place Patient entries before any resource that
+    references them. HAPI's bundle import skips writing reference index
+    entries for forward-references, so an Encounter appearing in the bundle
+    before its referenced Patient persists the Encounter but never indexes
+    `Encounter.subject → Patient/{id}`. `Encounter?patient=` then returns 0
+    forever. Verified empirically 2026-04-25 (issue #177): same bundle,
+    original order = 20/33 indexed; Patients-first = 33/33 at t=0.
+
+    This test pins the sort behavior so we don't regress.
+    """
+    # Caller passes resources in a "bad" order: Encounter before Patient.
+    resources = [
+        {"resourceType": "Encounter", "id": "e1", "subject": {"reference": "Patient/p1"}},
+        {"resourceType": "Condition", "id": "c1", "subject": {"reference": "Patient/p1"}},
+        {"resourceType": "Patient", "id": "p1"},
+        {"resourceType": "Encounter", "id": "e2", "subject": {"reference": "Patient/p2"}},
+        {"resourceType": "Patient", "id": "p2"},
+    ]
+    mock_response = _make_response(200, {"resourceType": "Bundle"})
+
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+        mock_ctx.post = AsyncMock(return_value=mock_response)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await push_resources(resources)
+
+    posted_bundle = mock_ctx.post.call_args.kwargs.get("json") or mock_ctx.post.call_args[1].get("json")
+    types_in_order = [e["resource"]["resourceType"] for e in posted_bundle["entry"]]
+
+    # All Patients come first.
+    first_non_patient_idx = next(i for i, t in enumerate(types_in_order) if t != "Patient")
+    assert all(t == "Patient" for t in types_in_order[:first_non_patient_idx]), (
+        f"Patients must lead; got order: {types_in_order}"
+    )
+    assert "Patient" not in types_in_order[first_non_patient_idx:], (
+        f"No Patient may appear after a non-Patient; got order: {types_in_order}"
+    )
+    # Stable order is preserved within each group.
+    non_patient_types = [t for t in types_in_order if t != "Patient"]
+    assert non_patient_types == ["Encounter", "Condition", "Encounter"], (
+        f"Non-Patient relative order should be preserved; got: {non_patient_types}"
+    )
+
+
 async def test_push_resources_with_auth_headers():
     """push_resources forwards auth_headers alongside Content-Type."""
     resources = [{"resourceType": "Patient", "id": "p1"}]


### PR DESCRIPTION
## Summary

Closes #177.

HAPI's bundle import doesn't write reference index entries when an Encounter (or any resource with `subject: Patient/{id}`) appears in the bundle BEFORE the Patient it references. The Encounter persists, but `Encounter?patient=` returns 0 forever afterwards. This breaks `$everything`, which breaks `/jobs` Phase 1 gather, which makes `$evaluate-measure` return IPP=False.

The fix is one block: `push_resources` sorts Patient resources to the front of the batch Bundle before sending. All 6 callers (validation.py, orchestrator.py, measure_engine_reset.py) get the fix automatically.

## Empirical proof (local, 2026-04-25)

Three runs on identical fresh stacks, only bundle entry order varied:

| variant | t=0 | t=60s | t=300s |
|---|---|---|---|
| Original CMS124 bundle, no warmup | 20/33 | 20/33 | 20/33 |
| Original CMS124 bundle, with warmup | 20/33 | 20/33 | 20/33 |
| Same bundle, Patients-first reordered | **33/33** | **33/33** | **33/33** |

Warmup is irrelevant; bundle order is the cause.

## Validation

- Local stack with this PR's code, original (un-modified) CMS124 bundle uploaded:
  - CDR `Encounter?patient=` count: **33/33 immediately**.
  - `/jobs CMS124` populations: **IPP=29, denom=29, numer=4, denom-exclusion=16** — exact match to the bundle's 33 expected MeasureReports.
- Unit tests: **320/320 pass**.
- Lint clean.
- New test `test_push_resources_sorts_patients_first` pins the sort behavior.

## Type of change
- [x] Bug fix

## Test plan
- [x] Unit tests pass locally
- [x] Lint
- [x] Local end-to-end: upload + /jobs CMS124 returns expected populations
- [ ] After merge: prod deploy + `/jobs CMS124` returns the same populations

## Out of scope
- Phase 1 reset architecture revert (#167 + #170 + #171). Tracked separately. The architecture is currently inert in prod — doesn't break anything new, but solves a problem we don't actually have.
- `seed-hapi.sh` bake-time bundle posts (deferred per Step 3 direction).