### PR TITLE
fix(validation): classify CDR gather failures as errors, not test failures

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -1140,6 +1140,11 @@ async def run_validation(validation_run_id: int) -> None:
                 return_exceptions=True,
             )
             failed_gathers = sum(1 for r in gather_results if isinstance(r, BaseException))
+            failed_patient_refs: dict[str, str] = {
+                pr: sanitize_error(r) if isinstance(r, Exception) else repr(r)
+                for pr, r in zip(all_patient_refs, gather_results)
+                if isinstance(r, BaseException)
+            }
             reindex_probe_patient_ids = sorted(
                 {
                     patient_id
@@ -1227,6 +1232,18 @@ async def run_validation(validation_run_id: int) -> None:
 
             # Phase 2: Evaluate and compare (shared client avoids N connection pools)
             async def evaluate_and_compare(er: ExpectedResult, http_client: httpx.AsyncClient) -> ValidationResult:
+                if er.patient_ref in failed_patient_refs:
+                    return ValidationResult(
+                        validation_run_id=validation_run_id,
+                        measure_url=er.measure_url,
+                        patient_ref=er.patient_ref,
+                        patient_name=None,
+                        expected_populations=er.expected_populations,
+                        actual_populations=None,
+                        status="error",
+                        error_message=f"Patient data gather failed: {failed_patient_refs[er.patient_ref]}",
+                        mismatches=[],
+                    )
                 info = measure_info[er.measure_url]
                 try:
                     if await _stop_or_delete_validation_run(validation_run_id):

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -1265,6 +1265,97 @@ class TestRunValidation:
         # Concurrent batch should have 2x measure-1, 1x measure-2 (3 patients total)
         assert sorted(concurrent_measure_ids) == ["measure-1", "measure-1", "measure-2"]
 
+    async def test_cdr_gather_failure_records_error_not_fail(self, test_session):
+        """CDR gather exception → status='error', evaluation skipped; other patients unaffected."""
+        run = ValidationRun(status=ValidationStatus.queued)
+        test_session.add(run)
+        test_session.add_all(
+            [
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/CMS124",
+                    patient_ref="patient-1",
+                    test_description="gather succeeds",
+                    expected_populations={"numerator": 1},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="cms124.json",
+                ),
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/CMS124",
+                    patient_ref="patient-2",
+                    test_description="gather fails",
+                    expected_populations={"numerator": 1},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="cms124.json",
+                ),
+            ]
+        )
+        await test_session.commit()
+        await test_session.refresh(run)
+
+        async def gather_side_effect(cdr_url, patient_ref, auth_headers):
+            if patient_ref == "patient-2":
+                raise RuntimeError("CDR connection refused")
+            return [{"resourceType": "Patient", "id": patient_ref}]
+
+        strategy = MagicMock()
+        strategy.gather_patient_data = AsyncMock(side_effect=gather_side_effect)
+
+        def make_ctx():
+            return self._make_session_ctx(test_session)
+
+        with (
+            patch("app.services.validation.async_session", side_effect=lambda: make_ctx()),
+            patch("app.services.validation._resolve_measure_id", new_callable=AsyncMock, return_value="measure-1"),
+            patch(
+                "app.services.validation._reload_measures_from_seed_bundles",
+                new_callable=AsyncMock,
+                return_value={"measures_loaded": 0, "libraries_loaded": 0, "failed": 0},
+            ),
+            patch("app.services.validation.BatchQueryStrategy", return_value=strategy),
+            patch("app.services.validation.push_resources", new_callable=AsyncMock),
+            patch("app.services.validation.wipe_patient_data", new_callable=AsyncMock),
+            patch(
+                "app.services.validation.evaluate_measure",
+                new_callable=AsyncMock,
+                return_value={
+                    "group": [{"population": [{"code": {"coding": [{"code": "numerator"}]}, "count": 1}]}],
+                    "evaluatedResource": [],
+                },
+            ) as mock_evaluate,
+            patch("app.services.validation.settings.HAPI_INDEX_WAIT_SECONDS", 0),
+        ):
+            await run_validation(run.id)
+
+        await test_session.refresh(run)
+        rows = (
+            (
+                await test_session.execute(
+                    select(ValidationResult)
+                    .where(ValidationResult.validation_run_id == run.id)
+                    .order_by(ValidationResult.patient_ref)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert run.status == ValidationStatus.complete
+        assert len(rows) == 2
+
+        p1 = next(r for r in rows if r.patient_ref == "patient-1")
+        assert p1.status == "pass"
+
+        p2 = next(r for r in rows if r.patient_ref == "patient-2")
+        assert p2.status == "error"
+        assert "Patient data gather failed" in p2.error_message
+        assert "CDR connection refused" in p2.error_message
+
+        # Warmup (patient-1) + main eval (patient-1) = 2 calls; patient-2 skipped.
+        called_patient_refs = [call.args[1] for call in mock_evaluate.call_args_list]
+        assert "patient-2" not in called_patient_refs
+
     async def test_warmup_failure_does_not_stop_main_evaluation(self, test_session, monkeypatch):
         """Even if warmup fails (e.g., 409 CONFLICT), main evaluation should continue."""
         run = ValidationRun(status=ValidationStatus.queued)


### PR DESCRIPTION
## Summary

- CDR gather failures (network errors, timeouts, auth failures) were previously passed through to the measure engine, which evaluated against empty data and returned `status="fail"` — misrepresenting an infrastructure problem as a measure logic failure
- Now: if `asyncio.gather` raises for a patient ref during the CDR gather phase, that patient's result is immediately set to `status="error"` with a message like `"Patient data gather failed: <exception>"`, and measure evaluation is skipped for that patient
- Regression test added: `test_cdr_gather_failure_records_error_not_fail` verifies the exact behavior for a two-patient run where one gather raises

## Related issue

Closes #66

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (N/A for docs/infra/chore)
- [x] docs/ updated (if architecture or API changed)
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered (N/A for pure refactor/docs)

## Test plan

- [x] `python -m pytest tests/test_services_validation.py::TestRunValidation::test_cdr_gather_failure_records_error_not_fail -v` — new test passes
- [x] Full unit suite: `321 passed, 0 failed`, coverage 84.93% (floor 70%) — no regressions
- [x] Lint: `ruff check` and `ruff format --check` both clean