### PR TITLE
docs(runbooks): measure engine H2 recovery procedure (issue #189)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,17 @@ Design doc with full evidence and option analysis: `~/.gstack/projects/Bellese-m
    - The data flow (`fhir_client.py`, `validation.py`, `orchestrator.py`)
    - HAPI behavior or configuration
    - Bundle import / `$everything` / `$evaluate-measure` paths
+   - After any wipe+push cycle in the smoke run, probe `$everything` on at least one patient to confirm the full clinical bundle comes back (not just the Patient resource). Use Python — the shell strips `$` from these URLs:
+     ```bash
+     docker exec leonard-backend-1 python3 -c "
+     import httpx, sys
+     pid = sys.argv[1]
+     r = httpx.get(f'http://hapi-fhir-measure:8080/fhir/Patient/{pid}/\$everything', timeout=30)
+     types = {e['resource']['resourceType'] for e in r.json().get('entry', [])}
+     print('resource types in bundle:', types)
+     assert 'Encounter' in types, 'FAIL: $everything returned only Patient — HAPI index not ready'
+     " <a-patient-id-in-scope>
+     ```
 5. The "ship-or-not" gate: if step 1, 2, 3, or 4 didn't run successfully, **do not push**. Tell Sutton what's blocking instead.
 
 If the change is documentation-only (`*.md`, no code), steps 1–4 are not required, but step 5 still applies — confirm in the PR description that no code changed.

--- a/docs/runbooks/measure-engine-h2-recovery.md
+++ b/docs/runbooks/measure-engine-h2-recovery.md
@@ -1,0 +1,115 @@
+# Runbook: Measure Engine H2 Recovery
+
+## Symptoms
+
+Use this runbook when ALL of the following are true:
+
+- `/jobs <any-measure>` returns IPP=0 / denom=0 / numer=0 for every in-scope patient
+- `$evaluate-measure` directly on the measure engine returns zero populations
+- **Container restart alone does NOT fix it** (state persists in the `leonard_measuredata` Docker volume)
+- CDR data is intact: `Patient/{id}/$everything` returns full clinical bundles from the CDR
+
+This pattern indicates the measure engine's H2 store (`/data/hapi/h2.mv.db`) has
+accumulated bad Library/ValueSet/CodeSystem state. The most common cause is
+Library/ValueSet rows accumulating across many `wipe_patient_data` + `push_resources`
+cycles until canonical resolution returns the wrong (or no) version, causing
+`$evaluate-measure` to return zeros.
+
+**Do NOT use this runbook** for:
+- IPP > 0 but wrong count (wrong populations, not zero populations) — that is likely
+  a data or CQL logic issue
+- CDR returning empty `$everything` — that is a CDR indexing issue, not an H2 issue
+- A single measure returning zero while others return non-zero
+
+## Why restart doesn't help
+
+`docker restart` reloads the container but keeps the same volume. The H2 file at
+`/data/hapi/h2.mv.db` persists across restarts. Only removing the volume forces a
+fresh import.
+
+The `leonard_measuredata` volume is **separate from `leonard_cdrdata`**. Wiping the
+measure engine volume does NOT affect clinical patient data on the CDR.
+
+## Procedure
+
+Run from the EC2 instance (SSH or via AWS SSM session) as root or with sudo:
+
+```bash
+cd /opt/leonard
+
+# 1. Bring down the stack
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+
+# 2. Wipe ONLY the measure engine volume — cdrdata is untouched
+docker volume rm leonard_measuredata
+
+# 3. Bring everything back up
+#    The `seed` service runs once on startup and repopulates ME from the
+#    connectathon bundles at /opt/leonard/seed/connectathon-bundles
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+# 4. Wait for the seed service to finish
+docker logs -f leonard-seed-1 | grep -E "MCT2 seed data loaded successfully|ERROR"
+# Ctrl-C once you see "MCT2 seed data loaded successfully"
+```
+
+Total downtime: ~5 min (seed completes in ~5 min on a t3.medium with the
+prebaked CDR image; the measure engine is already in the same image, no IG
+load required).
+
+## Verification
+
+### Step 1: Check resource counts on the measure engine
+
+```bash
+docker exec leonard-backend-1 python3 - <<'EOF'
+import httpx
+for rt in ("Patient", "Encounter", "Observation", "Condition",
+           "Measure", "Library", "ValueSet"):
+    r = httpx.get(f"http://hapi-fhir-measure:8080/fhir/{rt}?_summary=count", timeout=10)
+    print(f"{rt}: {r.json().get('total')}")
+EOF
+```
+
+Expected baseline (connectathon seed data):
+
+| Resource | Expected |
+|----------|----------|
+| Patient | 568 |
+| Encounter | 793 |
+| Observation | 234 |
+| Condition | 382 |
+| Measure | ≥ 12 |
+| Library | 24 |
+| ValueSet | ≈ 123 |
+
+If any count is 0, the seed did not complete. Re-check `docker logs leonard-seed-1`.
+
+### Step 2: Run a /jobs cycle and verify populations
+
+```bash
+curl -s -X POST https://api.98-89-219-217.nip.io/jobs \
+  -H "Content-Type: application/json" \
+  -d '{"measure_id":"CMS124FHIRCervicalCancerScreening",
+       "period_start":"2026-01-01","period_end":"2026-12-31",
+       "group_id":"CMS124FHIRCervicalCancerScreening"}' \
+  | jq .id
+```
+
+Wait for the job to complete, then check populations:
+
+```bash
+JOB_ID=<id-from-above>
+curl -s "https://api.98-89-219-217.nip.io/jobs/$JOB_ID" | jq '{status,total_patients}'
+curl -s "https://api.98-89-219-217.nip.io/jobs/$JOB_ID/comparison" | jq .
+```
+
+Expected CMS124 with connectathon group filter: `matched=33/33  IPP=29  denom=29  numer=4  denom-excl=16`.
+
+If IPP is still 0 after a successful seed, the issue is not H2 corruption — see
+the HAPI async-indexing notes in `CLAUDE.md` for next steps.
+
+## Related issues
+
+- [#187](https://github.com/Bellese/mct2/issues/187) — root cause investigation (H2 corruption, RESOLVED via this procedure)
+- [#188](https://github.com/Bellese/mct2/issues/188) — orchestrator wipe-races-push (separate issue; fixing #188 reduces the frequency of H2 drift)


### PR DESCRIPTION
## Summary

- Adds `docs/runbooks/measure-engine-h2-recovery.md`: step-by-step procedure for recovering when `leonard_measuredata` accumulates corrupted H2 state and `/jobs` returns IPP=0 across the board
- Adds `$everything` probe to CLAUDE.md's pre-push checklist: after any wipe+push smoke run, verify the full clinical bundle comes back (not just Patient) via an inline Python one-liner that avoids the shell `$`-stripping pitfall

## Related issue

Closes #189

## Type of change

- [x] Documentation

## Checklist

- [x] Tests added or updated (N/A for docs)
- [x] docs/ updated (if architecture or API changed) — this PR IS the docs update
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered (N/A for docs)

## Test plan

Documentation-only PR — no code changes. Verified:

- [ ] Runbook procedure matches empirical recovery from issue #187
- [ ] Expected resource counts match the connectathon seed baseline (`Patient=568`, `Encounter=793`, etc.)
- [ ] CMS124 verification command matches acceptance criteria in issue #188
- [ ] `$everything` probe uses Python to avoid shell `$`-stripping (see `CLAUDE.md` pitfall note)
- [ ] No code changed — `git diff HEAD~1 --stat` shows only `CLAUDE.md` and `docs/runbooks/measure-engine-h2-recovery.md`