### PR TITLE
fix(validation): clear stale expected results across bundles and fix session commit atomicity

### DIFF
--- a/backend/app/services/bundle_loader.py
+++ b/backend/app/services/bundle_loader.py
@@ -86,6 +86,7 @@ async def load_connectathon_bundles(
             bundle_json = json.loads(bundle_path.read_bytes())
             async with async_session() as session:
                 summary = await triage_test_bundle(bundle_json, bundle_path.name, session)
+                await session.commit()
             loaded += 1
             details.append({"file": bundle_path.name, "status": "loaded", **summary})
             logger.info(

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import httpx
-from sqlalchemy import delete, select, tuple_
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -720,41 +720,33 @@ async def triage_test_bundle(
                 f"Details: {str(exc)}"
             ) from exc
 
-    # Fully replace expected results owned by this source bundle before loading the
-    # current bundle contents. This removes stale rows when a bundle shrinks or when
-    # MADiE changes the canonical URL for the same filename.
+    # Delete stale expected results in two passes:
+    # 1. Remove all rows owned by this exact filename so a re-upload of the same file
+    #    with fewer patients or a renamed measure URL leaves nothing behind.
+    # 2. Remove any rows from OTHER bundles that cover the same measures so uploading
+    #    bundle_v2.json after bundle_v1.json for measure M doesn't leave v1's patients
+    #    mixed in with v2's patients.  (Fixes issue #64.)
     await session.execute(delete(ExpectedResult).where(ExpectedResult.source_bundle == filename))
-
-    existing_by_key: dict[tuple[str, str], ExpectedResult] = {}
     if test_cases:
-        key_tuples = [(tc["measure_url"], tc["patient_ref"]) for tc in test_cases]
-        existing_result = await session.execute(
-            select(ExpectedResult).where(tuple_(ExpectedResult.measure_url, ExpectedResult.patient_ref).in_(key_tuples))
-        )
-        existing_by_key = {(er.measure_url, er.patient_ref): er for er in existing_result.scalars().all()}
+        covered_measure_urls = list({tc["measure_url"] for tc in test_cases})
+        await session.execute(delete(ExpectedResult).where(ExpectedResult.measure_url.in_(covered_measure_urls)))
 
     for tc in test_cases:
-        key = (tc["measure_url"], tc["patient_ref"])
-        existing = existing_by_key.get(key)
-        if existing:
-            existing.test_description = tc["test_description"]
-            existing.expected_populations = tc["expected_populations"]
-            existing.period_start = tc["period_start"]
-            existing.period_end = tc["period_end"]
-            existing.source_bundle = filename
-        else:
-            session.add(
-                ExpectedResult(
-                    measure_url=tc["measure_url"],
-                    patient_ref=tc["patient_ref"],
-                    test_description=tc["test_description"],
-                    expected_populations=tc["expected_populations"],
-                    period_start=tc["period_start"],
-                    period_end=tc["period_end"],
-                    source_bundle=filename,
-                )
+        session.add(
+            ExpectedResult(
+                measure_url=tc["measure_url"],
+                patient_ref=tc["patient_ref"],
+                test_description=tc["test_description"],
+                expected_populations=tc["expected_populations"],
+                period_start=tc["period_start"],
+                period_end=tc["period_end"],
+                source_bundle=filename,
             )
-    await session.commit()
+        )
+    # Intentionally no session.commit() here — the commit is deferred to
+    # process_bundle_upload so that DB changes and clinical push succeed or fail
+    # atomically.  If push_resources raises below, the session context manager in
+    # process_bundle_upload rolls back both the delete and these inserts.  (Fixes #65.)
 
     # Push clinical data to active CDR (default or external)
     patients_loaded = 0

--- a/backend/tests/test_services_bundle_loader.py
+++ b/backend/tests/test_services_bundle_loader.py
@@ -105,3 +105,50 @@ async def test_load_connectathon_bundles_includes_patients_loaded(tmp_path):
     assert summary["failed"] == 0
     loaded_detail = summary["details"][0]
     assert loaded_detail["patients_loaded"] == 5
+
+
+async def test_load_connectathon_bundles_commits_after_triage(tmp_path):
+    """load_connectathon_bundles commits the session after triage_test_bundle returns (#65).
+
+    triage_test_bundle no longer calls session.commit() internally (deferred to caller
+    for atomicity). bundle_loader must call commit() or ExpectedResult rows are silently
+    discarded when the session closes.
+    """
+    from app.services.bundle_loader import load_connectathon_bundles
+
+    (tmp_path / "bundle.json").write_text(json.dumps({"resourceType": "Bundle", "entry": []}))
+
+    with patch("app.services.bundle_loader.triage_test_bundle") as mock_triage:
+        mock_triage.return_value = {"measures_loaded": 0, "patients_loaded": 0, "expected_results_loaded": 0}
+        mock_session = AsyncMock()
+        mock_session_factory = MagicMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.bundle_loader.async_session", mock_session_factory):
+            await load_connectathon_bundles(directory=tmp_path)
+
+    mock_session.commit.assert_called_once()
+
+
+async def test_load_connectathon_bundles_no_commit_on_triage_error(tmp_path):
+    """load_connectathon_bundles does not commit when triage_test_bundle raises (#65).
+
+    Errors are caught, logged, and counted as failures — not committed.
+    """
+    from app.services.bundle_loader import load_connectathon_bundles
+
+    (tmp_path / "bundle.json").write_text(json.dumps({"resourceType": "Bundle", "entry": []}))
+
+    with patch("app.services.bundle_loader.triage_test_bundle") as mock_triage:
+        mock_triage.side_effect = RuntimeError("triage failed")
+        mock_session = AsyncMock()
+        mock_session_factory = MagicMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.bundle_loader.async_session", mock_session_factory):
+            summary = await load_connectathon_bundles(directory=tmp_path)
+
+    assert summary["failed"] == 1
+    mock_session.commit.assert_not_called()

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -741,6 +741,75 @@ class TestTriageTestBundle:
         assert result["expected_results_loaded"] == 1
         assert refreshed_count == 1
 
+    async def test_reupload_different_filename_replaces_stale_expected_results(
+        self, test_session, mock_test_bundle_with_expected
+    ):
+        """Re-uploading a different filename that covers the same measure clears stale rows (issue #64).
+
+        If bundle_v1.json loaded patients A, B, C for CMS124 and bundle_v2.json
+        loads only patients A, B for the same measure, C must not survive.
+        """
+        test_session.add_all(
+            [
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/CMS124",
+                    patient_ref="stale-patient-from-v1",
+                    test_description="v1 patient no longer in new bundle",
+                    expected_populations={"numerator": 0},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="bundle_v1.json",
+                ),
+                ExpectedResult(
+                    measure_url="https://example.com/Measure/OTHER",
+                    patient_ref="other-measure-patient",
+                    test_description="different measure — must survive",
+                    expected_populations={"numerator": 1},
+                    period_start="2026-01-01",
+                    period_end="2026-12-31",
+                    source_bundle="bundle_v1.json",
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock):
+            await triage_test_bundle(mock_test_bundle_with_expected, "bundle_v2.json", test_session)
+
+        all_rows = (
+            (await test_session.execute(select(ExpectedResult).order_by(ExpectedResult.patient_ref))).scalars().all()
+        )
+        patient_refs = [r.patient_ref for r in all_rows]
+
+        assert "stale-patient-from-v1" not in patient_refs, "stale v1 patient for CMS124 must be evicted"
+        assert "test-patient-1" in patient_refs, "new bundle's patient must be present"
+        assert "other-measure-patient" in patient_refs, "unrelated measure's patient must be untouched"
+
+    async def test_clinical_push_failure_rolls_back_expected_results(
+        self, test_session, mock_test_bundle_with_expected
+    ):
+        """If clinical data push fails, expected results must not be committed to DB (issue #65).
+
+        The DB delete + insert happen in the same transaction as the clinical push.
+        When push_resources raises, process_bundle_upload's session context manager
+        rolls back the transaction.  This test mimics that rollback explicitly.
+        """
+
+        async def fail_on_clinical(resources, *, target_url=None, auth_headers=None):
+            if target_url is not None:
+                raise ValueError("CDR unreachable — simulated failure")
+
+        with patch("app.services.validation.push_resources", side_effect=fail_on_clinical):
+            with pytest.raises(ValueError, match="CDR unreachable"):
+                await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        # Roll back the session — this is what process_bundle_upload's `async with async_session()`
+        # block does when triage_test_bundle raises.
+        await test_session.rollback()
+
+        row_count = await test_session.scalar(select(func.count()).select_from(ExpectedResult))
+        assert row_count == 0, "expected results must not be committed when clinical push fails"
+
     async def test_hapi_sync_after_upload_calls_reindex_and_valueset_wait(
         self, test_session, mock_test_bundle_with_expected, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- **Fixes #64**: Re-uploading a bundle under a different filename no longer leaves stale `ExpectedResult` rows behind. `triage_test_bundle()` now performs a double-delete: first by `source_bundle == filename`, then by `measure_url IN covered_urls`, ensuring all prior rows for the same measure are wiped regardless of which filename they came from.
- **Fixes #65**: Failed clinical pushes no longer leave a partial committed state. `triage_test_bundle()` no longer calls `session.commit()` internally — the commit is deferred to the caller (`process_bundle_upload`) which commits only after the clinical push succeeds. If the push fails, SQLAlchemy rolls back all DB changes atomically.
- **Regression fix**: `load_connectathon_bundles()` (startup loader) was left without a commit after the #65 fix removed it from `triage_test_bundle()`. Added `await session.commit()` in `bundle_loader.py` to restore correct startup behavior.

## Related issue

Closes #64
Closes #65

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (N/A for docs/infra/chore)
- [x] docs/ updated (if architecture or API changed)
- [ ] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered (N/A for pure refactor/docs)

## Test plan

**Unit tests** (311 passing):
```bash
cd backend && python3 -m pytest tests/ --ignore=tests/integration -q
```

New tests covering the contract:
- `test_reupload_different_filename_replaces_stale_expected_results` — verifies double-delete clears cross-filename stale rows (#64)
- `test_clinical_push_failure_rolls_back_expected_results` — verifies DB rolls back when clinical push raises (#65)
- `test_load_connectathon_bundles_commits_after_triage` — pins that `load_connectathon_bundles()` commits after triage (#65 regression)
- `test_load_connectathon_bundles_no_commit_on_triage_error` — pins that no commit happens when triage raises

**Integration tests** (35 CI-equivalent tests passing):
```bash
./scripts/run-integration-tests.sh
```
The `test_smart_load` module (which validates `ExpectedResult` row counts per measure) is skipped in pre-baked CI mode and runs nightly — it exercises the exact code path this PR fixes.

**Manual smoke test**:
1. Upload a bundle containing `ExpectedResult` rows for measure X
2. Re-upload the same measure content under a different filename — confirm old rows are gone, new rows present
3. Upload a bundle that will fail the clinical push — confirm no `ExpectedResult` rows are committed