### PR TITLE
feat(ci): hard-fail on silent prebake fallback when REQUIRE_PREBAKED=1

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,6 +63,7 @@ jobs:
       # Soft default: STRICT_STU6=0 for rollout week. Flip to 1 once all connectathon measures pass in CI.
       STRICT_STU6: "0"
       USE_PREBAKED: "1"
+      REQUIRE_PREBAKED: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -38,6 +38,7 @@ POLL_INTERVAL=5
 # full seed + reindex + ValueSet expansion on every test run.
 # ---------------------------------------------------------------------------
 USE_PREBAKED="${USE_PREBAKED:-0}"
+REQUIRE_PREBAKED="${REQUIRE_PREBAKED:-0}"
 _using_prebaked=false
 
 if [ "$USE_PREBAKED" = "1" ]; then
@@ -72,6 +73,20 @@ if [ "$USE_PREBAKED" = "1" ]; then
         echo "  WARNING: hash-tagged images not found; falling back to :latest prebaked images."
         _using_prebaked=true
     else
+        if [ "$REQUIRE_PREBAKED" = "1" ]; then
+            echo ""
+            echo "ERROR: REQUIRE_PREBAKED=1 but no prebaked GHCR image was reachable."
+            echo "       Tried: $CDR_HASH_IMAGE"
+            echo "              $CDR_LATEST_IMAGE"
+            echo "       This usually means a GHCR auth failure or the image has not been built yet."
+            echo "       Fix options:"
+            echo "         1. Log in to GHCR: docker login ghcr.io -u <user> -p <token>"
+            echo "         2. Trigger a bake: gh workflow run bake-hapi-image.yml"
+            echo "         3. Allow vanilla fallback: unset REQUIRE_PREBAKED (CI correctness not guaranteed)"
+            echo ""
+            echo "USED PREBAKED: no — EXITING (REQUIRE_PREBAKED=1)"
+            exit 1
+        fi
         echo "  WARNING: prebaked images unavailable; falling back to vanilla $VANILLA_IMAGE + full seed."
         _cdr_image="$VANILLA_IMAGE"
         _measure_image="$VANILLA_IMAGE"
@@ -84,6 +99,9 @@ if [ "$USE_PREBAKED" = "1" ]; then
 
     if $_using_prebaked; then
         export HAPI_PREBAKED=1
+        echo "USED PREBAKED: yes"
+    else
+        echo "USED PREBAKED: no (vanilla fallback — seed will run in-container)"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds `REQUIRE_PREBAKED` env-var to `scripts/run-integration-tests.sh`. When set to `1`, any GHCR pull failure that would silently fall back to vanilla HAPI instead exits non-zero with a clear diagnostic and `USED PREBAKED: no — EXITING (REQUIRE_PREBAKED=1)` banner.
- Adds `USED PREBAKED: yes/no` banner at the end of the prebake resolution block so every run's cache status is visible in logs at a glance.
- Sets `REQUIRE_PREBAKED: "1"` in `.github/workflows/pr-checks.yml` so CI integration tests always fail loudly on GHCR auth failure rather than silently running on vanilla images.

**Before:** if GHCR auth failed in CI, integration tests fell back to vanilla `hapiproject/hapi:v8.8.0-1` and ran to completion. Results looked identical to a real prebake run. CI could have been running vanilla for weeks undetected.

**After:** `REQUIRE_PREBAKED=1` makes CI fail loudly with a diagnostic pointing to the exact fix needed. Every passing CI run now asserts `USED PREBAKED: yes` in the logs — verifiable, not hoped.

Closes one of the three gaps documented in issue #191 (Phase 1 of the pre-bake slow-start fix plan).

## Test plan

- [x] Lint: `ruff check` + `ruff format --check` — clean
- [x] Unit tests: 308 passed
- [ ] Integration tests run in CI with `USE_PREBAKED=1 REQUIRE_PREBAKED=1` — will pass on green GHCR path; will exit non-zero with diagnostic on auth failure

## Notes

Phase 1 only — two files, 19 lines. Phase 2 (bake Connectathon bundles) is gated on #188 (wipe-races-push fix) landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)