### PR TITLE
feat(ci): bake connectathon bundles into HAPI images (Phase 2)

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -7,6 +7,11 @@ name: Bake HAPI Seeded Images
 # We cannot use Dockerfile RUN steps because hapiproject/hapi is distroless
 # (no shell inside the container). Instead, seed-hapi.sh runs on the runner
 # and targets the container's exposed port.
+#
+# Phase 2: After the base seed, both containers are restarted from their
+# locally-committed base images, all 12 connectathon bundles are loaded via
+# load_connectathon_bundles.py, and the final images are pushed with :${seed-hash}.
+# :latest is NOT pushed here — that is gated on Phase 4 (verify-bake).
 
 on:
   schedule:
@@ -15,6 +20,7 @@ on:
   push:
     paths:
       - 'seed/**'
+      - 'seed/connectathon-bundles/**'
       - 'docker/hapi-*-seeded.Dockerfile'
       - 'docker/seed-hapi.sh'
       - 'docker-compose.test.yml'
@@ -42,7 +48,7 @@ jobs:
       - name: Compute seed hash
         id: seed-hash
         run: |
-          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml \
+          echo "hash=$(find seed/ seed/connectathon-bundles/ docker/seed-hapi.sh docker-compose.test.yml \
             docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
             -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" \
             >> "$GITHUB_OUTPUT"
@@ -67,7 +73,8 @@ jobs:
             .
 
       # -----------------------------------------------------------------------
-      # Bake CDR image: run → seed from runner → stop → commit → push
+      # Bake CDR base image: run → seed from runner → stop → commit locally
+      # (No push yet — connectathon bundles are loaded in Phase 2 below)
       # -----------------------------------------------------------------------
       - name: Start CDR container
         run: |
@@ -87,20 +94,16 @@ jobs:
           echo "=== docker logs hapi-cdr (last 300 lines) ==="
           docker logs --tail 300 hapi-cdr 2>&1 || true
 
-      - name: Commit and push CDR image
+      - name: Commit CDR base image locally
         run: |
           docker stop hapi-cdr
-          docker commit hapi-cdr ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
-          docker tag \
-            ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }} \
-            ghcr.io/bellese/mct2-hapi-cdr:latest
-          docker push ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
-          docker push ghcr.io/bellese/mct2-hapi-cdr:latest
+          docker commit hapi-cdr mct2-hapi-cdr-base
           # Free runner memory before starting the Measure container
           docker rm hapi-cdr
 
       # -----------------------------------------------------------------------
-      # Bake Measure image: run → seed from runner → stop → commit → push
+      # Bake Measure base image: run → seed from runner → stop → commit locally
+      # (No push yet — connectathon bundles are loaded in Phase 2 below)
       # -----------------------------------------------------------------------
       - name: Start Measure container
         run: |
@@ -120,12 +123,81 @@ jobs:
           echo "=== docker logs hapi-measure (last 300 lines) ==="
           docker logs --tail 300 hapi-measure 2>&1 || true
 
-      - name: Commit and push Measure image
+      - name: Commit Measure base image locally
         run: |
           docker stop hapi-measure
-          docker commit hapi-measure ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
-          docker tag \
-            ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }} \
-            ghcr.io/bellese/mct2-hapi-measure:latest
+          docker commit hapi-measure mct2-hapi-measure-base
+          docker rm hapi-measure
+
+      # -----------------------------------------------------------------------
+      # Phase 2: Load connectathon bundles into both base images simultaneously
+      # Both containers start from their locally-committed base images (IGs and
+      # ValueSets already expanded, so startup is fast and memory is settled).
+      # -----------------------------------------------------------------------
+      - name: Start CDR container for connectathon seed
+        run: |
+          docker run -d --name hapi-cdr-conn -p 8180:8080 --user root mct2-hapi-cdr-base
+
+      - name: Start Measure container for connectathon seed
+        run: |
+          docker run -d --name hapi-measure-conn -p 8181:8080 --user root mct2-hapi-measure-base
+
+      - name: Wait for CDR and Measure containers to be healthy
+        run: |
+          echo "Waiting for CDR (port 8180) and Measure (port 8181)..."
+          CDR_OK=false
+          MEASURE_OK=false
+          DEADLINE=$((SECONDS + 300))
+          while [ $SECONDS -lt $DEADLINE ]; do
+            if [ "$CDR_OK" = "false" ] && curl -sf http://localhost:8180/fhir/metadata > /dev/null 2>&1; then
+              echo "CDR is healthy"
+              CDR_OK=true
+            fi
+            if [ "$MEASURE_OK" = "false" ] && curl -sf http://localhost:8181/fhir/metadata > /dev/null 2>&1; then
+              echo "Measure is healthy"
+              MEASURE_OK=true
+            fi
+            if [ "$CDR_OK" = "true" ] && [ "$MEASURE_OK" = "true" ]; then
+              echo "Both containers healthy"
+              break
+            fi
+            sleep 5
+          done
+          if [ "$CDR_OK" = "false" ]; then
+            echo "ERROR: CDR container did not become healthy within 300s"
+            exit 1
+          fi
+          if [ "$MEASURE_OK" = "false" ]; then
+            echo "ERROR: Measure container did not become healthy within 300s"
+            exit 1
+          fi
+
+      - name: Install httpx for connectathon bundle loader
+        run: pip install httpx
+
+      - name: Load connectathon bundles into both HAPI instances
+        run: |
+          MEASURE_FHIR_URL=http://localhost:8181/fhir \
+          CDR_FHIR_URL=http://localhost:8180/fhir \
+          CONNECTATHON_BUNDLES_DIR=seed/connectathon-bundles \
+          python3 scripts/load_connectathon_bundles.py
+
+      - name: Dump connectathon container state on failure
+        if: failure()
+        run: |
+          docker logs --tail 300 hapi-cdr-conn 2>&1 || true
+          docker logs --tail 300 hapi-measure-conn 2>&1 || true
+
+      - name: Commit and push CDR image (with connectathon bundles)
+        run: |
+          docker stop hapi-cdr-conn
+          docker commit hapi-cdr-conn ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker push ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker rm hapi-cdr-conn
+
+      - name: Commit and push Measure image (with connectathon bundles)
+        run: |
+          docker stop hapi-measure-conn
+          docker commit hapi-measure-conn ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
           docker push ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
-          docker push ghcr.io/bellese/mct2-hapi-measure:latest
+          docker rm hapi-measure-conn

--- a/scripts/load_connectathon_bundles.py
+++ b/scripts/load_connectathon_bundles.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import pathlib
 import sys
 import time
@@ -32,9 +33,9 @@ from typing import Any
 
 import httpx
 
-MEASURE_URL = "http://hapi-fhir-measure:8080/fhir"
-CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
-BUNDLE_DIR = pathlib.Path("/seed/connectathon-bundles")
+MEASURE_URL = os.environ.get("MEASURE_FHIR_URL", "http://hapi-fhir-measure:8080/fhir")
+CDR_URL = os.environ.get("CDR_FHIR_URL", "http://hapi-fhir-cdr:8080/fhir")
+BUNDLE_DIR = pathlib.Path(os.environ.get("CONNECTATHON_BUNDLES_DIR", "/seed/connectathon-bundles"))
 MANIFEST_PATH = BUNDLE_DIR / "manifest.json"
 
 _MEASURE_DEF_TYPES = {"Measure", "Library", "ValueSet", "CodeSystem"}


### PR DESCRIPTION
## Summary

- Restructures `bake-hapi-image.yml` so base bakes (IGs + ValueSets) commit to local Docker tags only — no push at that stage.
- Adds a Phase 2 block that restarts both containers from the locally-committed base images, loads all 12 connectathon bundles via `load_connectathon_bundles.py`, then commits and pushes a single `:${seed-hash}` tag for each image.
- Removes all `:latest` pushes from this workflow — retag to `:latest` is deferred to Phase 4 (verify-bake gate, tracked in #191).
- Adds env-var overrides (`MEASURE_FHIR_URL`, `CDR_FHIR_URL`, `CONNECTATHON_BUNDLES_DIR`) to `load_connectathon_bundles.py` so the script works from the GHA runner; defaults preserve existing in-container behavior.
- Adds `seed/connectathon-bundles/**` to the paths trigger and the seed hash computation so bundle changes trigger a rebake.
- Adds failure-dump step for the connectathon containers (`hapi-cdr-conn`, `hapi-measure-conn`).

Closes #191.

## Test plan

- [ ] Verify GitHub Actions "Bake HAPI Seeded Images" workflow runs successfully (can trigger via `workflow_dispatch`)
- [ ] Confirm `:${seed-hash}` tags are pushed to GHCR for both `mct2-hapi-cdr` and `mct2-hapi-measure`
- [ ] Confirm `:latest` is NOT updated in GHCR (Phase 4 gates this)
- [ ] Confirm `load_connectathon_bundles.py` still works unchanged inside the backend container (env-var defaults preserve existing behavior)
- [ ] Integration tests pass locally: `./scripts/run-integration-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)