### PR TITLE
feat(ci): bake connectathon bundles into HAPI images + verify-bake gate (Phases 2 & 4)

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -7,6 +7,11 @@ name: Bake HAPI Seeded Images
 # We cannot use Dockerfile RUN steps because hapiproject/hapi is distroless
 # (no shell inside the container). Instead, seed-hapi.sh runs on the runner
 # and targets the container's exposed port.
+#
+# Phase 2: After the base seed, both containers are restarted from their
+# locally-committed base images, all 12 connectathon bundles are loaded via
+# load_connectathon_bundles.py, and the final images are pushed with :${seed-hash}.
+# :latest is NOT pushed here — that is gated on Phase 4 (verify-bake).
 
 on:
   schedule:
@@ -15,6 +20,7 @@ on:
   push:
     paths:
       - 'seed/**'
+      - 'seed/connectathon-bundles/**'
       - 'docker/hapi-*-seeded.Dockerfile'
       - 'docker/seed-hapi.sh'
       - 'docker-compose.test.yml'
@@ -42,7 +48,7 @@ jobs:
       - name: Compute seed hash
         id: seed-hash
         run: |
-          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml \
+          echo "hash=$(find seed/ seed/connectathon-bundles/ docker/seed-hapi.sh docker-compose.test.yml \
             docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
             -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" \
             >> "$GITHUB_OUTPUT"
@@ -67,7 +73,8 @@ jobs:
             .
 
       # -----------------------------------------------------------------------
-      # Bake CDR image: run → seed from runner → stop → commit → push
+      # Bake CDR base image: run → seed from runner → stop → commit locally
+      # (No push yet — connectathon bundles are loaded in Phase 2 below)
       # -----------------------------------------------------------------------
       - name: Start CDR container
         run: |
@@ -87,20 +94,16 @@ jobs:
           echo "=== docker logs hapi-cdr (last 300 lines) ==="
           docker logs --tail 300 hapi-cdr 2>&1 || true
 
-      - name: Commit and push CDR image
+      - name: Commit CDR base image locally
         run: |
           docker stop hapi-cdr
-          docker commit hapi-cdr ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
-          docker tag \
-            ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }} \
-            ghcr.io/bellese/mct2-hapi-cdr:latest
-          docker push ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
-          docker push ghcr.io/bellese/mct2-hapi-cdr:latest
+          docker commit hapi-cdr mct2-hapi-cdr-base
           # Free runner memory before starting the Measure container
           docker rm hapi-cdr
 
       # -----------------------------------------------------------------------
-      # Bake Measure image: run → seed from runner → stop → commit → push
+      # Bake Measure base image: run → seed from runner → stop → commit locally
+      # (No push yet — connectathon bundles are loaded in Phase 2 below)
       # -----------------------------------------------------------------------
       - name: Start Measure container
         run: |
@@ -120,12 +123,81 @@ jobs:
           echo "=== docker logs hapi-measure (last 300 lines) ==="
           docker logs --tail 300 hapi-measure 2>&1 || true
 
-      - name: Commit and push Measure image
+      - name: Commit Measure base image locally
         run: |
           docker stop hapi-measure
-          docker commit hapi-measure ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
-          docker tag \
-            ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }} \
-            ghcr.io/bellese/mct2-hapi-measure:latest
+          docker commit hapi-measure mct2-hapi-measure-base
+          docker rm hapi-measure
+
+      # -----------------------------------------------------------------------
+      # Phase 2: Load connectathon bundles into both base images simultaneously
+      # Both containers start from their locally-committed base images (IGs and
+      # ValueSets already expanded, so startup is fast and memory is settled).
+      # -----------------------------------------------------------------------
+      - name: Start CDR container for connectathon seed
+        run: |
+          docker run -d --name hapi-cdr-conn -p 8180:8080 --user root mct2-hapi-cdr-base
+
+      - name: Start Measure container for connectathon seed
+        run: |
+          docker run -d --name hapi-measure-conn -p 8181:8080 --user root mct2-hapi-measure-base
+
+      - name: Wait for CDR and Measure containers to be healthy
+        run: |
+          echo "Waiting for CDR (port 8180) and Measure (port 8181)..."
+          CDR_OK=false
+          MEASURE_OK=false
+          DEADLINE=$((SECONDS + 300))
+          while [ $SECONDS -lt $DEADLINE ]; do
+            if [ "$CDR_OK" = "false" ] && curl -sf http://localhost:8180/fhir/metadata > /dev/null 2>&1; then
+              echo "CDR is healthy"
+              CDR_OK=true
+            fi
+            if [ "$MEASURE_OK" = "false" ] && curl -sf http://localhost:8181/fhir/metadata > /dev/null 2>&1; then
+              echo "Measure is healthy"
+              MEASURE_OK=true
+            fi
+            if [ "$CDR_OK" = "true" ] && [ "$MEASURE_OK" = "true" ]; then
+              echo "Both containers healthy"
+              break
+            fi
+            sleep 5
+          done
+          if [ "$CDR_OK" = "false" ]; then
+            echo "ERROR: CDR container did not become healthy within 300s"
+            exit 1
+          fi
+          if [ "$MEASURE_OK" = "false" ]; then
+            echo "ERROR: Measure container did not become healthy within 300s"
+            exit 1
+          fi
+
+      - name: Install httpx for connectathon bundle loader
+        run: pip install httpx
+
+      - name: Load connectathon bundles into both HAPI instances
+        run: |
+          MEASURE_FHIR_URL=http://localhost:8181/fhir \
+          CDR_FHIR_URL=http://localhost:8180/fhir \
+          CONNECTATHON_BUNDLES_DIR=seed/connectathon-bundles \
+          python3 scripts/load_connectathon_bundles.py
+
+      - name: Dump connectathon container state on failure
+        if: failure()
+        run: |
+          docker logs --tail 300 hapi-cdr-conn 2>&1 || true
+          docker logs --tail 300 hapi-measure-conn 2>&1 || true
+
+      - name: Commit and push CDR image (with connectathon bundles)
+        run: |
+          docker stop hapi-cdr-conn
+          docker commit hapi-cdr-conn ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker push ghcr.io/bellese/mct2-hapi-cdr:${{ steps.seed-hash.outputs.hash }}
+          docker rm hapi-cdr-conn
+
+      - name: Commit and push Measure image (with connectathon bundles)
+        run: |
+          docker stop hapi-measure-conn
+          docker commit hapi-measure-conn ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
           docker push ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
-          docker push ghcr.io/bellese/mct2-hapi-measure:latest
+          docker rm hapi-measure-conn

--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -34,6 +34,8 @@ jobs:
     name: Bake and push seeded HAPI images
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      seed-hash: ${{ steps.seed-hash.outputs.hash }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -201,3 +203,125 @@ jobs:
           docker commit hapi-measure-conn ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
           docker push ghcr.io/bellese/mct2-hapi-measure:${{ steps.seed-hash.outputs.hash }}
           docker rm hapi-measure-conn
+
+  # -------------------------------------------------------------------------
+  # Phase 4: Verify-bake correctness gate
+  #
+  # Pulls the just-pushed :${seed-hash} images, starts the integration test
+  # stack, runs test_connectathon_measures.py with STRICT_STU6=1 (hard-fail
+  # on the 7 strict measures; the 5 non-strict measures with known issues
+  # auto-skip).  :latest is retagged and pushed ONLY if all strict assertions
+  # pass.  This prevents shipping semantically-divergent images the way the
+  # 815a1c6 → d4ff73b revert did.
+  # -------------------------------------------------------------------------
+  verify-bake:
+    name: Verify baked image correctness
+    needs: bake
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      STRICT_STU6: "1"
+      PYTHON_VERSION: "3.10"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-test.txt
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt -r requirements-test.txt
+
+      - name: Pull baked images
+        run: |
+          docker pull ghcr.io/bellese/mct2-hapi-cdr:${{ needs.bake.outputs.seed-hash }}
+          docker pull ghcr.io/bellese/mct2-hapi-measure:${{ needs.bake.outputs.seed-hash }}
+
+      - name: Start test stack with baked images
+        run: |
+          HAPI_CDR_IMAGE=ghcr.io/bellese/mct2-hapi-cdr:${{ needs.bake.outputs.seed-hash }} \
+          HAPI_MEASURE_IMAGE=ghcr.io/bellese/mct2-hapi-measure:${{ needs.bake.outputs.seed-hash }} \
+          docker compose -f docker-compose.test.yml -f docker-compose.prebaked.yml up -d
+
+      - name: Wait for HAPI FHIR instances to be ready
+        run: |
+          echo "==> Waiting for CDR (port 8180) and Measure (port 8181)..."
+          DEADLINE=$((SECONDS + 300))
+          CDR_OK=false MEASURE_OK=false
+          while [ $SECONDS -lt $DEADLINE ]; do
+            if [ "$CDR_OK" = "false" ] && curl -sf http://localhost:8180/fhir/metadata > /dev/null 2>&1; then
+              echo "CDR ready"; CDR_OK=true
+            fi
+            if [ "$MEASURE_OK" = "false" ] && curl -sf http://localhost:8181/fhir/metadata > /dev/null 2>&1; then
+              echo "Measure ready"; MEASURE_OK=true
+            fi
+            [ "$CDR_OK" = "true" ] && [ "$MEASURE_OK" = "true" ] && break
+            sleep 5
+          done
+          if [ "$CDR_OK" = "false" ] || [ "$MEASURE_OK" = "false" ]; then
+            echo "ERROR: HAPI instances did not become ready within 300s"
+            exit 1
+          fi
+
+      - name: Wait for PostgreSQL to be ready
+        run: |
+          ELAPSED=0
+          until docker compose -f docker-compose.test.yml exec -T db pg_isready -U mct2 > /dev/null 2>&1; do
+            if [ "$ELAPSED" -ge 60 ]; then echo "ERROR: PostgreSQL timeout"; exit 1; fi
+            sleep 2; ELAPSED=$((ELAPSED + 2))
+          done
+          echo "PostgreSQL ready."
+
+      - name: Run verify-bake tests (strict measures must pass)
+        working-directory: backend
+        run: |
+          python3 -m pytest \
+            tests/integration/test_connectathon_measures.py \
+            -m integration -v --tb=short --durations=20 \
+            2>&1 | tee /tmp/verify-output.txt
+          STATUS=${PIPESTATUS[0]}
+          echo "## Verify-bake Results ($([ $STATUS -eq 0 ] && echo PASS || echo FAIL))" >> "$GITHUB_STEP_SUMMARY"
+          grep -A 200 'slowest durations' /tmp/verify-output.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+          exit $STATUS
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "=== hapi-fhir-cdr logs (last 200 lines) ==="
+          docker compose -f docker-compose.test.yml logs --tail=200 hapi-fhir-cdr 2>&1 || true
+          echo "=== hapi-fhir-measure logs (last 200 lines) ==="
+          docker compose -f docker-compose.test.yml logs --tail=200 hapi-fhir-measure 2>&1 || true
+
+      - name: Stop test stack
+        if: always()
+        run: |
+          HAPI_CDR_IMAGE=ghcr.io/bellese/mct2-hapi-cdr:${{ needs.bake.outputs.seed-hash }} \
+          HAPI_MEASURE_IMAGE=ghcr.io/bellese/mct2-hapi-measure:${{ needs.bake.outputs.seed-hash }} \
+          docker compose -f docker-compose.test.yml -f docker-compose.prebaked.yml down -v 2>/dev/null || true
+
+      - name: Retag :latest (only reached if verification passed)
+        run: |
+          docker tag \
+            ghcr.io/bellese/mct2-hapi-cdr:${{ needs.bake.outputs.seed-hash }} \
+            ghcr.io/bellese/mct2-hapi-cdr:latest
+          docker push ghcr.io/bellese/mct2-hapi-cdr:latest
+          docker tag \
+            ghcr.io/bellese/mct2-hapi-measure:${{ needs.bake.outputs.seed-hash }} \
+            ghcr.io/bellese/mct2-hapi-measure:latest
+          docker push ghcr.io/bellese/mct2-hapi-measure:latest
+          echo "✅ :latest retagged (hash: ${{ needs.bake.outputs.seed-hash }})"

--- a/scripts/load_connectathon_bundles.py
+++ b/scripts/load_connectathon_bundles.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import pathlib
 import sys
 import time
@@ -32,9 +33,9 @@ from typing import Any
 
 import httpx
 
-MEASURE_URL = "http://hapi-fhir-measure:8080/fhir"
-CDR_URL = "http://hapi-fhir-cdr:8080/fhir"
-BUNDLE_DIR = pathlib.Path("/seed/connectathon-bundles")
+MEASURE_URL = os.environ.get("MEASURE_FHIR_URL", "http://hapi-fhir-measure:8080/fhir")
+CDR_URL = os.environ.get("CDR_FHIR_URL", "http://hapi-fhir-cdr:8080/fhir")
+BUNDLE_DIR = pathlib.Path(os.environ.get("CONNECTATHON_BUNDLES_DIR", "/seed/connectathon-bundles"))
 MANIFEST_PATH = BUNDLE_DIR / "manifest.json"
 
 _MEASURE_DEF_TYPES = {"Measure", "Library", "ValueSet", "CodeSystem"}


### PR DESCRIPTION
## Summary

- **Phase 2**: Extends `bake-hapi-image.yml` to load all 12 connectathon bundles into the HAPI images before push. Both containers are started simultaneously from their locally-committed base images, `load_connectathon_bundles.py` runs on the runner (targeting localhost), and final images are pushed as `:{seed-hash}` only.
- **Phase 4**: Adds a `verify-bake` job that pulls the just-pushed `:{seed-hash}` images, starts the integration test stack, and runs `test_connectathon_measures.py` with `STRICT_STU6=1`. `:latest` is retagged **only if all strict measures pass** — this closes the exact failure class that caused the `815a1c6` and `dcb2967` reverts.

Also adds env-var overrides to `load_connectathon_bundles.py` so it can be called from the bake runner (targeting localhost HAPI) instead of requiring in-container execution.

## What this closes

The previous bake only included the CMS122 demo bundle. All 12 May connectathon measures are now baked in, so integration tests and local dev start with correct seed state instead of spending 10-20 min loading bundles fresh.

## Test plan

- [ ] `bake-hapi-image.yml` runs (or trigger manually via `gh workflow run bake-hapi-image.yml`)
- [ ] Both `bake` and `verify-bake` jobs succeed
- [ ] `verify-bake` logs show all 7 strict measures passing with `STRICT_STU6=1`
- [ ] `:latest` is retagged after `verify-bake` succeeds
- [ ] Deliberately corrupt a bundle → verify `verify-bake` blocks `:latest` retag

Closes #192 (Phase 2), #194 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)