### PR TITLE
feat(local): wire docker-compose.yml to prebaked HAPI images (Phase 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # Non-secret config. Copy to .env and fill in values.
 # POSTGRES_PASSWORD is no longer stored here — it lives in AWS SSM (/leonard/prod/POSTGRES_PASSWORD).
 CADDY_HOST=
+
+# Pre-baked HAPI FHIR images (optional — speeds up docker compose up from 15-30min to ~30s)
+# Pull from GHCR: docker login ghcr.io && docker pull ghcr.io/bellese/mct2-hapi-cdr:latest
+# See docs/runbooks/ghcr-pull-auth.md for auth setup.
+# Leave unset to use vanilla hapiproject/hapi:v8.8.0-1 (slower cold start but no GHCR auth needed).
+HAPI_CDR_IMAGE=ghcr.io/bellese/mct2-hapi-cdr:latest
+HAPI_MEASURE_IMAGE=ghcr.io/bellese/mct2-hapi-measure:latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Design doc with full evidence and option analysis: `~/.gstack/projects/Bellese-m
 1. `cd backend && ruff check app/ tests/ && ruff format --check app/ tests/` — lint clean
 2. `cd backend && python3 -m pytest tests/ --ignore=tests/integration -q` — unit suite passes
 3. `./scripts/run-integration-tests.sh` — **integration suite passes against real HAPI containers.** This is the suite that fails most often in CI; it MUST pass locally first. Takes ~3-5 min.
-4. End-to-end smoke against a local stack (`docker compose -f docker-compose.yml -f docker-compose.prebaked.yml up -d`, fall back to `hapiproject/hapi:v8.8.0-1` for CDR if GHCR pull fails) for any change touching:
+4. End-to-end smoke against a local stack (`docker compose up -d` with `HAPI_CDR_IMAGE` and `HAPI_MEASURE_IMAGE` set in `.env` for the fast path — see `.env.example`; falls back to vanilla hapiproject/hapi:v8.8.0-1 if vars are unset) for any change touching:
    - The data flow (`fhir_client.py`, `validation.py`, `orchestrator.py`)
    - HAPI behavior or configuration
    - Bundle import / `$everything` / `$evaluate-measure` paths

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       retries: 5
 
   hapi-fhir-cdr:
-    image: hapiproject/hapi:v8.8.0-1
+    image: ${HAPI_CDR_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
     ports: ["8081:8080"]
     volumes: ["cdrdata:/data/hapi"]
@@ -74,7 +74,7 @@ services:
       - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
 
   hapi-fhir-measure:
-    image: hapiproject/hapi:v8.8.0-1
+    image: ${HAPI_MEASURE_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
     ports: ["8080:8080"]
     volumes: ["measuredata:/data/hapi"]


### PR DESCRIPTION
## Summary

- `docker-compose.yml`: CDR and Measure HAPI services now consume `${HAPI_CDR_IMAGE}` / `${HAPI_MEASURE_IMAGE}` env vars, defaulting to `hapiproject/hapi:v8.8.0-1` (no behavior change without the vars set)
- `.env.example`: documents both vars pointing to the GHCR prebaked images
- `CLAUDE.md`: step 4 smoke test updated to use `docker compose up -d` (env vars drive image selection)

## What this closes

Local `docker compose up` now resolves to the pre-seeded GHCR image when `HAPI_CDR_IMAGE` / `HAPI_MEASURE_IMAGE` are set, bringing cold-start time from 15-30 min down to ~30s (image pull + JVM boot from already-seeded H2).

## Test plan

- [ ] `docker compose down -v && docker compose up -d` with vars set → `/fhir/metadata` 200 in ≤2 min
- [ ] Without vars set → falls back to vanilla `hapiproject/hapi:v8.8.0-1` (no regression)
- [ ] `./scripts/run-integration-tests.sh` with `USE_PREBAKED=1 REQUIRE_PREBAKED=1` → `USED PREBAKED: yes`

Closes #191 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)