### PR TITLE
fix(validation): report upload counters incrementally as each phase completes

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -13,7 +13,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import httpx
 from sqlalchemy import delete, select
@@ -686,6 +686,8 @@ async def triage_test_bundle(
     bundle_json: dict[str, Any],
     filename: str,
     session: AsyncSession,
+    *,
+    progress_fn: Callable[[str, int], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Triage a test bundle: send resources to their correct destinations.
 
@@ -720,6 +722,9 @@ async def triage_test_bundle(
                 f"Details: {str(exc)}"
             ) from exc
 
+    if progress_fn:
+        await progress_fn("measures_loaded", sum(1 for r in measure_defs if r.get("resourceType") == "Measure"))
+
     # Delete stale expected results in two passes:
     # 1. Remove all rows owned by this exact filename so a re-upload of the same file
     #    with fewer patients or a renamed measure URL leaves nothing behind.
@@ -748,6 +753,9 @@ async def triage_test_bundle(
     # atomically.  If push_resources raises below, the session context manager in
     # process_bundle_upload rolls back both the delete and these inserts.  (Fixes #65.)
 
+    if progress_fn:
+        await progress_fn("expected_results_loaded", len(test_cases))
+
     # Push clinical data to active CDR (default or external)
     patients_loaded = 0
     if clinical:
@@ -761,6 +769,9 @@ async def triage_test_bundle(
             "Clinical resources loaded to CDR",
             extra={"count": len(clinical), "cdr_url": cdr_url},
         )
+
+    if progress_fn:
+        await progress_fn("patients_loaded", patients_loaded)
 
     if settings.HAPI_SYNC_AFTER_UPLOAD:
         sync_started = datetime.now(timezone.utc)
@@ -808,7 +819,14 @@ async def process_bundle_upload(upload_id: int) -> None:
 
             bundle_json = await asyncio.to_thread(lambda: json.loads(Path(upload.file_path).read_bytes()))
 
-            summary = await triage_test_bundle(bundle_json, upload.filename, session)
+            async def _on_progress(field: str, value: int) -> None:
+                async with async_session() as prog_session:
+                    u = await prog_session.get(BundleUpload, upload_id)
+                    if u:
+                        setattr(u, field, value)
+                        await prog_session.commit()
+
+            summary = await triage_test_bundle(bundle_json, upload.filename, session, progress_fn=_on_progress)
 
             upload.measures_loaded = summary["measures_loaded"]
             upload.patients_loaded = summary["patients_loaded"]

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -852,6 +852,44 @@ class TestTriageTestBundle:
         mock_reindex.assert_not_called()
         mock_wait.assert_not_called()
 
+    async def test_progress_fn_called_for_each_phase(self, test_session, mock_test_bundle_with_expected, monkeypatch):
+        """progress_fn is called once per phase with the correct field name and count."""
+        monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", False)
+        monkeypatch.setattr("app.services.validation.settings.DEFAULT_CDR_URL", "http://hapi-fhir-cdr:8080/fhir")
+
+        calls: list[tuple[str, int]] = []
+
+        async def record_progress(field: str, value: int) -> None:
+            calls.append((field, value))
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock):
+            await triage_test_bundle(
+                mock_test_bundle_with_expected, "test.json", test_session, progress_fn=record_progress
+            )
+
+        fields_called = [c[0] for c in calls]
+        assert "measures_loaded" in fields_called
+        assert "expected_results_loaded" in fields_called
+        assert "patients_loaded" in fields_called
+        # measures must be reported before expected_results which must be before patients
+        assert fields_called.index("measures_loaded") < fields_called.index("expected_results_loaded")
+        assert fields_called.index("expected_results_loaded") < fields_called.index("patients_loaded")
+        # values match summary counts
+        assert dict(calls)["measures_loaded"] == 1
+        assert dict(calls)["expected_results_loaded"] == 1
+        assert dict(calls)["patients_loaded"] == 1
+
+    async def test_progress_fn_none_does_not_raise(self, test_session, mock_test_bundle_with_expected, monkeypatch):
+        """Omitting progress_fn (None) does not raise and returns correct summary."""
+        monkeypatch.setattr("app.services.validation.settings.HAPI_SYNC_AFTER_UPLOAD", False)
+
+        with patch("app.services.validation.push_resources", new_callable=AsyncMock):
+            result = await triage_test_bundle(mock_test_bundle_with_expected, "test.json", test_session)
+
+        assert result["measures_loaded"] == 1
+        assert result["patients_loaded"] == 1
+        assert result["expected_results_loaded"] == 1
+
 
 # ---------------------------------------------------------------------------
 # process_bundle_upload (async, mocked async_session + triage)


### PR DESCRIPTION
## Summary

Fixes #185.

`/validation/uploads` was displaying `measures_loaded=0, patients_loaded=0, expected_results_loaded=0` throughout the entire upload because `process_bundle_upload` only wrote those counters **after** `triage_test_bundle` returned. Large bundles can take several minutes (HAPI pushes + async reindex wait), leaving the status stuck at `running 0 0 0` for the entire duration even when data was already usable.

**Changes:**
- Added optional `progress_fn: Callable[[str, int], Awaitable[None]] | None = None` keyword argument to `triage_test_bundle`. Called after each of the three phases: measure defs pushed → `measures_loaded`, expected results saved → `expected_results_loaded`, clinical resources pushed → `patients_loaded`.
- `process_bundle_upload` now provides an `_on_progress` callback that opens a short-lived separate DB session per phase and flushes the counter immediately so polling clients see real progress. The main session's final commit still sets the authoritative values.
- Two new unit tests: `test_progress_fn_called_for_each_phase` (verifies ordering and values) and `test_progress_fn_none_does_not_raise` (backward-compat guard).

**No behavior change for existing callers** — the parameter defaults to `None` and the function returns the same summary dict.

## Test plan

- [x] `ruff check app/ tests/ && ruff format --check app/ tests/` — clean
- [x] `pytest tests/ --ignore=tests/integration -q` — 314 passed
- [ ] Integration suite (`./scripts/run-integration-tests.sh`) — not required for this change (no data flow, FHIR client, or orchestrator code touched; only the DB write timing for the `BundleUpload` counters changed)

## Notes

The `_on_progress` callback uses a **separate** async session from the main triage session. This is safe because:
1. The main session has not dirtied the `BundleUpload` row when the callbacks fire (those writes happen after `triage_test_bundle` returns).
2. The callback commits are independent UPDATE statements with no optimistic-locking conflict risk (no version column on `BundleUpload`).
3. In the error path, the main session rolls back `ExpectedResult` inserts as before — progress counter commits in separate sessions are not rolled back, which is intentional: operators should see that measures were loaded even if the overall upload fails.

https://claude.ai/code/session_01NV42xRhmPbNCCyu2JtDDQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NV42xRhmPbNCCyu2JtDDQx)_