### PR TITLE
fix(ci): align seed-hash computation between bake workflow and run-integration-tests.sh

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -43,11 +43,8 @@ _using_prebaked=false
 
 if [ "$USE_PREBAKED" = "1" ]; then
     echo "==> USE_PREBAKED=1 — resolving pre-baked HAPI images from GHCR..."
-    SEED_HASH=$(find "$PROJECT_ROOT/seed/" \
-        "$PROJECT_ROOT/docker/seed-hapi.sh" \
-        "$PROJECT_ROOT/docker-compose.test.yml" \
-        "$PROJECT_ROOT/docker/hapi-cdr-seeded.Dockerfile" \
-        "$PROJECT_ROOT/docker/hapi-measure-seeded.Dockerfile" \
+    SEED_HASH=$(cd "$PROJECT_ROOT" && find seed/ seed/connectathon-bundles/ docker/seed-hapi.sh docker-compose.test.yml \
+        docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
         -type f 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | cut -c1-12)
     echo "  Seed hash: ${SEED_HASH}"
 


### PR DESCRIPTION
## Summary

- `bake-hapi-image.yml` uses **relative paths** (`seed/`, `docker/seed-hapi.sh`, …) run from the repo root
- `run-integration-tests.sh` used **absolute paths** (`$PROJECT_ROOT/seed/`, …)
- `sha256sum` embeds the filename in its output — different path prefixes → different lines → different aggregate hash every time
- Result: the script always fell back to `:latest` ("WARNING: hash-tagged images not found; falling back to :latest"), ignoring the hash-tagged image the bake workflow produced

**Fix:** wrap the `find` call in `cd "$PROJECT_ROOT" && ...` so both scripts produce the same relative paths and the same hash. Also adds the previously-missing `seed/connectathon-bundles/` argument to match the bake workflow's file-set exactly.

No rebake needed — the bake workflow is unchanged; only the script's lookup is fixed to agree with the tags already in GHCR.

Closes #184

## Test plan

- [ ] CI green on this PR
- [ ] After merge: trigger `workflow_dispatch` on `connectathon-measures` → confirm `connectathon-eval` log shows "Using hash-tagged prebaked images." (not ":latest" fallback warning)
- [ ] After next scheduled bake: confirm hash-tagged pull succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)