### PR TITLE
fix(security): HTML-escape JSON tokens in PatientDetail syntax highlighter (XSS)

### DIFF
--- a/frontend/src/components/PatientDetail.js
+++ b/frontend/src/components/PatientDetail.js
@@ -44,9 +44,12 @@ function translateResource(resource) {
   return { label: type || 'Resource', value: display };
 }
 
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 function syntaxHighlightJson(json) {
   const str = typeof json === 'string' ? json : JSON.stringify(json, null, 2);
-  // Input is parsed FHIR JSON from our own backend — not user-supplied HTML
   return str.replace(
     /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
     (match) => {
@@ -54,7 +57,7 @@ function syntaxHighlightJson(json) {
       if (/^"/.test(match)) cls = /:$/.test(match) ? 'key' : 'string';
       else if (/true|false/.test(match)) cls = 'boolean';
       else if (/null/.test(match)) cls = 'null';
-      return `<span class="${cls}">${match}</span>`;
+      return `<span class="${cls}">${escapeHtml(match)}</span>`;
     }
   );
 }


### PR DESCRIPTION
## Summary

- `syntaxHighlightJson()` in `PatientDetail.js` was passing regex-matched JSON token content directly into `<span>` tags without HTML-escaping
- Result was inserted into the DOM via `dangerouslySetInnerHTML`
- FHIR resource string values can contain `<`, `>`, `&` (narrative fields, display text, identifiers) — these passed through as raw HTML, enabling stored XSS

**Fix:** Add a four-character `escapeHtml()` helper (`&`, `<`, `>`, `"` → entities) and call it on every matched token before wrapping in `<span>`. Between-match text (JSON structural chars: `{`, `}`, `[`, `]`, `:`, `,`, whitespace) contains no HTML-sensitive characters and doesn't need escaping.

**Note on issue #7 (SSRF):** That vulnerability is already fully implemented — `_validate_ssrf_url()` in `fhir_client.py` is wired at every URL-accepting entry point (`_check_cdr_url` in settings, `jobs.py` line 181, `verify_fhir_connection` line 850, SMART `token_endpoint` line 105). Please close #7 as already resolved.

Closes #8

## Test plan

- [ ] CI green
- [ ] Manual smoke: open PatientDetail for a patient, confirm JSON renders correctly with syntax highlighting intact
- [ ] Manual XSS test: if a FHIR resource has a string value containing `<b>bold</b>`, it should render as literal text (not bold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)