### PR TITLE
fix(ci): align seed-hash computation between bake workflow and test script

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Compute seed hash
         id: seed-hash
         run: |
-          echo "hash=$(find seed/ seed/connectathon-bundles/ docker/seed-hapi.sh docker-compose.test.yml \
+          echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml \
             docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
             -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" \
             >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,14 @@ Design doc with full evidence and option analysis: `~/.gstack/projects/Bellese-m
 
 1. `cd backend && ruff check app/ tests/ && ruff format --check app/ tests/` — lint clean
 2. `cd backend && python3 -m pytest tests/ --ignore=tests/integration -q` — unit suite passes
-3. `./scripts/run-integration-tests.sh` — **integration suite passes against real HAPI containers.** This is the suite that fails most often in CI; it MUST pass locally first. Takes ~3-5 min.
+3. Run the CI-equivalent integration suite — **same ignore flags that `pr-checks.yml` uses, against real HAPI containers.** This is the suite that fails most often in CI; it MUST pass locally first. Takes ~3-5 min.
+   ```bash
+   ./scripts/run-integration-tests.sh \
+     --ignore=tests/integration/test_golden_measures.py \
+     --ignore=tests/integration/test_connectathon_measures.py \
+     --ignore=tests/integration/test_full_workflow.py
+   ```
+   (The full suite — `./scripts/run-integration-tests.sh` with no flags — runs 600+ connectathon-measure patient tests that CI skips on PRs. Only run those when changing the measure evaluation pipeline or before a nightly run.)
 4. End-to-end smoke against a local stack (`docker compose up -d` with `HAPI_CDR_IMAGE` and `HAPI_MEASURE_IMAGE` set in `.env` for the fast path — see `.env.example`; falls back to vanilla hapiproject/hapi:v8.8.0-1 if vars are unset) for any change touching:
    - The data flow (`fhir_client.py`, `validation.py`, `orchestrator.py`)
    - HAPI behavior or configuration

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -43,11 +43,8 @@ _using_prebaked=false
 
 if [ "$USE_PREBAKED" = "1" ]; then
     echo "==> USE_PREBAKED=1 — resolving pre-baked HAPI images from GHCR..."
-    SEED_HASH=$(find "$PROJECT_ROOT/seed/" \
-        "$PROJECT_ROOT/docker/seed-hapi.sh" \
-        "$PROJECT_ROOT/docker-compose.test.yml" \
-        "$PROJECT_ROOT/docker/hapi-cdr-seeded.Dockerfile" \
-        "$PROJECT_ROOT/docker/hapi-measure-seeded.Dockerfile" \
+    SEED_HASH=$(cd "$PROJECT_ROOT" && find seed/ docker/seed-hapi.sh docker-compose.test.yml \
+        docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
         -type f 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | cut -c1-12)
     echo "  Seed hash: ${SEED_HASH}"
 


### PR DESCRIPTION
## Summary

- Workflow used relative paths (\`seed/\`), script used absolute (\`\$PROJECT_ROOT/seed/\`). \`sha256sum\` embeds the filename in its output, so the intermediate hash lines never matched even when content was byte-identical.
- Workflow also passed both \`seed/\` AND \`seed/connectathon-bundles/\` to \`find\`, which traverses each start point independently — files in the subdir were hashed twice. Removed the duplicate (recursive descent into \`seed/\` already covers it).
- Both files now use identical inputs; verified locally that both produce hash \`46108d9be18b\`.

## Related issue

Closes #184

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Infrastructure / CI/CD
- [ ] Chore (deps, tooling, lockfile)

## Checklist

- [x] Tests added or updated (N/A — script change, no new logic)
- [x] docs/ updated (CLAUDE.md step 3 now points at the CI-equivalent integration command)
- [x] No new ADRs needed
- [x] Security implications considered (N/A — refactor only)

## Test plan

- [x] \`cd backend && ruff check app/ tests/ && ruff format --check app/ tests/\` — clean
- [x] \`cd backend && python3 -m pytest tests/ --ignore=tests/integration -q\` — 314 passed
- [x] \`USE_PREBAKED=1 ./scripts/run-integration-tests.sh --ignore=tests/integration/test_golden_measures.py --ignore=tests/integration/test_connectathon_measures.py --ignore=tests/integration/test_full_workflow.py\` — 35 passed, 5 skipped (loader-dependent), 0 failed
- [x] Hash equality verified: workflow path-set + script path-set both produce \`46108d9be18b\`
- [x] \`USE_PREBAKED=1\` log shows \`Seed hash: 46108d9be18b\` then \`WARNING: hash-tagged images not found; falling back to :latest prebaked images\` — confirms the fallback path works during the merge → re-bake gap

## Post-merge action

Trigger the \`Bake HAPI Seeded Images\` workflow manually from \`main\` (\`workflow_dispatch\`). It will compute the corrected hash, push \`ghcr.io/bellese/mct2-hapi-{cdr,measure}:<new-hash>\`, and re-tag \`:latest\`. After that, \`run-integration-tests.sh\` will land directly on the hash-tagged image instead of the \`:latest\` fallback.

## Breaking changes

The hash value changes. Existing \`:<old-hash>\` GHCR tags become orphaned (still pullable by digest, but nothing tags them). \`:latest\` continues to point at the most recent successful bake, so CI stays green throughout the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)