### PR TITLE
fix(ci): pin LC_ALL=C in seed-hash sort so macOS and Linux agree

### DIFF
--- a/.github/workflows/bake-hapi-image.yml
+++ b/.github/workflows/bake-hapi-image.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "hash=$(find seed/ docker/seed-hapi.sh docker-compose.test.yml \
             docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
-            -type f 2>/dev/null | sort | xargs sha256sum | sha256sum | cut -c1-12)" \
+            -type f 2>/dev/null | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -c1-12)" \
             >> "$GITHUB_OUTPUT"
 
       # -----------------------------------------------------------------------

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -45,7 +45,7 @@ if [ "$USE_PREBAKED" = "1" ]; then
     echo "==> USE_PREBAKED=1 — resolving pre-baked HAPI images from GHCR..."
     SEED_HASH=$(cd "$PROJECT_ROOT" && find seed/ docker/seed-hapi.sh docker-compose.test.yml \
         docker/hapi-cdr-seeded.Dockerfile docker/hapi-measure-seeded.Dockerfile \
-        -type f 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | cut -c1-12)
+        -type f 2>/dev/null | LC_ALL=C sort | xargs sha256sum 2>/dev/null | sha256sum | cut -c1-12)
     echo "  Seed hash: ${SEED_HASH}"
 
     _try_pull() {


### PR DESCRIPTION
## Summary

- Follow-up to #208. Found while validating that the bake's hash-tagged image was reachable: the GHA workflow pushed \`e38401438037\` but a local hash computation on macOS produced \`46108d9be18b\` for the exact same files.
- Root cause: \`sort\` is locale-sensitive. macOS default \`LC_COLLATE=UTF-8\` orders differently than the GHA Linux runner's \`LC_ALL=C\`, and \`sha256sum\` embeds the filename in each line of its output — different sort orders → different intermediate lines → different aggregate hash.
- Fix: pin \`LC_ALL=C sort\` in both the workflow and the script. Byte-deterministic across platforms.

## Related issue

Follow-up to #184 / #208 (#184 closed by #208 — this PR doesn't need to close anything new).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Infrastructure / CI/CD
- [ ] Chore

## Checklist

- [x] Tests added or updated (N/A — one-token shell change, equivalent to #208)
- [x] docs/ updated (N/A — no behavior change for developers)
- [x] No new ADRs needed
- [x] Security implications considered (N/A — refactor only)

## Test plan

- [x] \`ruff check && ruff format --check\` — clean
- [x] After this fix, the script produces hash \`e38401438037\` on macOS — matches what the GHA bake actually pushed (#208's bake run [24998893012](https://github.com/Bellese/mct2/actions/runs/24998893012))
- [x] \`docker pull ghcr.io/bellese/mct2-hapi-cdr:e38401438037\` and \`...:measure:...\` both succeed — confirms the script will land on the hash-tagged image, not the \`:latest\` fallback

## Why this wasn't caught in #208

The hash equality I verified for #208 was a same-machine, same-shell comparison (workflow path-set vs. script path-set, both run on macOS). That proved bugs 1 and 2 (path style, duplicate traversal) but didn't expose the cross-platform sort divergence. Cross-platform divergence only becomes visible when you compare what GHA actually pushed to what the local script computes — which is what surfaced this.

## Breaking changes

None. The hash value will likely change once more with this fix (depending on whether GHA's ambient sort matches \`LC_ALL=C\` — it probably does, in which case the hash stays \`e38401438037\`). \`:latest\` continues to bridge any transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)