### PR TITLE
fix(ci): bump bundle-loader-test timeout 90→120 min

### DIFF
--- a/.github/workflows/connectathon-measures.yml
+++ b/.github/workflows/connectathon-measures.yml
@@ -34,13 +34,14 @@ jobs:
   bundle-loader-test:
     name: Bundle Loader Test (vanilla HAPI)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     # Validates load_connectathon_bundles() end-to-end: manifest integrity, SHA256,
     # bundle upload, canonical URL resolution, and ExpectedResult row counts.
     # Must run on vanilla HAPI — when HAPI_PREBAKED=1 these tests skip themselves.
     # Runtime: cold HAPI startup + full 12-bundle upload via load_connectathon_bundles()
     # (no cross-bundle VS deduplication, slower than the fixture path) + static checks.
-    # Worst-case on slow runners: ~50-60 min; 90 min gives comfortable headroom.
+    # Empirical: Apr 27 run hit the 90-min wall; 120 min matches the original monolithic
+    # source-of-truth budget and gives headroom for slow runners.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6


### PR DESCRIPTION
## Summary

Apr 27 verification run (GH run [24996392929](https://github.com/Bellese/mct2/actions/runs/24996392929)) hit the 90-min wall exactly — started 12:58:58, cancelled 14:28:47. `load_connectathon_bundles()` on a cold vanilla GitHub runner takes >90 min end-to-end (cold HAPI startup + 12-bundle upload with no cross-bundle VS deduplication).

120 min matches the original monolithic `source-of-truth` budget and gives real headroom for slow runners.

## Test plan

- [ ] CI green
- [ ] After merge: trigger `workflow_dispatch` to confirm `bundle-loader-test` completes within 120 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)