### PR TITLE
fix(hapi): apply HS6 sync strategy to eliminate async-indexing race (#206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,9 @@ PUT/POST 200 means the resource is durable. Search consistency is async, governe
 - `/validation/upload-bundle` returns 200 before CDR indexing completes; subsequent `/jobs` runs race the index. There is no CDR-side wait.
 - `$everything` is a victim of this bug, not a cause. Don't propose replacing it.
 
-### Structural fix (NOT yet applied — tracked in #206)
+### Structural fix (applied in PR #206)
 
-Setting `hibernate.search.indexing.plan.synchronization.strategy=sync` on both HAPI services would make POST/PUT block until the index is refreshed, eliminating the bug class entirely (write-throughput hit). See issue #206 for the rollout plan.
+`spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync` is now set on both HAPI services in `docker-compose.yml`, `docker-compose.test.yml`, and both seeded Dockerfiles. POST/PUT blocks until the Lucene index is refreshed, eliminating the bug class. The Python-side compensator (`HAPI_SYNC_AFTER_UPLOAD` + `trigger_reindex_and_wait*`) is still present as a rollback safety net; removal is a follow-up.
 
 ### History
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -44,6 +44,7 @@ services:
       - hapi.fhir.maximum_expansion_size=50000
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
 
   hapi-fhir-measure:
     image: ${HAPI_MEASURE_IMAGE:-hapiproject/hapi:v8.8.0-1}
@@ -70,6 +71,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
       - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
+      - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
       - hapi.fhir.reuse_cached_search_results_millis=${HAPI_REUSE_SEARCH_CACHE_MS:-0}
       - hapi.fhir.client_id_strategy=ANY
       - hapi.fhir.allow_external_references=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - hapi.fhir.maximum_expansion_size=50000 # Connectathon ValueSets exceed HAPI's default expansion limit.
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
       - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
 
   hapi-fhir-measure:
@@ -104,6 +105,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
       - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100 # Reduce HAPI search-index lag after uploads.
+      - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
       - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m
 
   seed:

--- a/docker/hapi-cdr-seeded.Dockerfile
+++ b/docker/hapi-cdr-seeded.Dockerfile
@@ -25,3 +25,4 @@ ENV hapi.fhir.enforce_referential_integrity_on_write=false
 ENV hapi.fhir.maximum_expansion_size=50000
 ENV spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
 ENV spring.datasource.driverClassName=org.h2.Driver
+ENV spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync

--- a/docker/hapi-measure-seeded.Dockerfile
+++ b/docker/hapi-measure-seeded.Dockerfile
@@ -34,3 +34,4 @@ ENV spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fh
 ENV spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
 ENV spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
 ENV spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
+ENV spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync


### PR DESCRIPTION
## Summary

- Sets `hibernate.search.indexing.plan.synchronization.strategy=sync` on both HAPI FHIR services (CDR + measure) in all four config surfaces: `docker-compose.yml`, `docker-compose.test.yml`, `docker/hapi-cdr-seeded.Dockerfile`, `docker/hapi-measure-seeded.Dockerfile`
- Makes POST/PUT block until the Lucene index is committed **and** refreshed, eliminating the async-indexing race class by construction
- Python-side compensator (`HAPI_SYNC_AFTER_UPLOAD` + `trigger_reindex_and_wait_for_patients`) intentionally kept as a rollback safety net; removal deferred to follow-up PR after this proves stable

Closes #206.

## Context

PRs #142, #155, #159, #161, #167+, and #178 each patched a different slice of the same bug: HAPI's default HS6 strategy commits to Lucene disk but does NOT request an index refresh. Searches see stale snapshots until the next 100ms refresh tick fires — or forever if refresh stalls under bulk-upload load. This PR applies the structural fix across all config surfaces.

The Dockerfiles are required (not just the compose files) because `bake-hapi-image.yml` runs containers from the Dockerfiles directly with no compose layer — baked images need to be born with the correct config.

## Files changed

| File | Change |
|------|--------|
| `docker-compose.yml` | Added sync strategy env var to CDR and measure services |
| `docker-compose.test.yml` | Added sync strategy env var to CDR and measure services |
| `docker/hapi-cdr-seeded.Dockerfile` | Added `ENV` line for sync strategy |
| `docker/hapi-measure-seeded.Dockerfile` | Added `ENV` line for sync strategy |
| `CLAUDE.md` | Updated recurring-bug note: fix is now applied, compensator kept as rollback |

## Local validation

All CI-equivalent checks run locally before push — no exceptions:

```
ruff check app/ tests/ && ruff format --check app/ tests/  →  clean
python3 -m pytest tests/ --ignore=tests/integration -q    →  passed
./scripts/run-integration-tests.sh (full suite)            →  531 passed, 67 skipped, 17 xfailed
```

### Wall-clock comparison (full integration suite, both runs on same machine)

| Run | Wall time | Notes |
|-----|-----------|-------|
| Baseline (`origin/main` before edits) | 2:10:51 | 531 passed |
| Branch (after 6-line config change) | 2:00:31 | 531 passed |
| Delta | **−8%** | Passes <25% regression gate |

The branch run is ~10 min faster — likely fewer retries eliminated by closing the race window.

## Test plan

- [x] Lint clean
- [x] Unit suite passed
- [x] Full integration suite passed (531 tests, −8% vs baseline — within acceptance gate)
- [x] `test_connectathon_measures.py` passed (568 patient evals)
- [x] `test_smart_load.py` incl. `test_loader_zero_failures` (all 12 bundles cold)
- [x] `test_full_workflow.py` passed
- [ ] Post-merge: trigger `bake-hapi-image.yml` to rebuild GHCR images with new config baked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)