### PR TITLE
fix(docker): chown /app to app user before USER directive

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY app/ app/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-RUN useradd --create-home --uid 1000 app
+RUN useradd --create-home --uid 1000 app && chown -R app:app /app
 USER app
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary

- `USER app` landed in #220 but `/app` files remained root-owned
- At startup, the `app` user (UID 1000) couldn't write to the working directory → healthcheck failed → deploy failed
- Fix: add `&& chown -R app:app /app` to the same `RUN useradd` layer (no extra layer cost)

## Root cause

`backend/Dockerfile` builds as root, copies all files, then creates the `app` user and switches to it. Docker file ownership doesn't follow `USER` — files copied before the switch stay root-owned. Uvicorn/startup tasks (lifespan migrations, bundle load) need write access to `/app`.

## Verification

```
docker run --rm <image> id       # uid=1000(app)
docker run --rm <image> ls -la /app  # drwxr-xr-x app app
```

## Test plan

- [x] `docker build` succeeds
- [x] `docker run --rm id` → `uid=1000(app)`
- [x] `/app` owned by `app:app`
- [ ] Deploy succeeds (CI will confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)