### PR TITLE
fix(docker): use gosu for privilege drop instead of Dockerfile USER

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,12 @@ COPY app/ app/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+# gosu: privilege-drop helper used by entrypoint to read root-owned Docker
+# secrets before dropping to the app user. Pattern from official postgres/redis images.
+RUN apt-get update && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN useradd --create-home --uid 1000 app && chown -R app:app /app
-USER app
 
 EXPOSE 8000
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -e
-# In prod, assemble DATABASE_URL from Docker secret.
+# In prod, assemble DATABASE_URL from Docker secret (file is 0600 root-only).
 # In local dev, DATABASE_URL is already set via docker-compose.yml.
 if [ -s /run/secrets/postgres_password ]; then
   PW=$(cat /run/secrets/postgres_password)
   export DATABASE_URL="postgresql+asyncpg://mct2:${PW}@db:5432/mct2"
   unset PW
 fi
-exec "$@"
+# Drop from root to the app user before exec so the process never runs as root.
+exec gosu app "$@"


### PR DESCRIPTION
## Summary

- #220 added `USER app` to run the backend as non-root
- #221 added `chown -R app:app /app` so the app user can write to the workdir
- Both deploys still failed: the production secret `/run/leonard/POSTGRES_PASSWORD` is `0600 root:root` (intentional, see `deploy-prod.sh:117`). With `USER app`, `cat /run/secrets/postgres_password` in the entrypoint fails with permission denied. `set -e` immediately exits the container before uvicorn starts.

## Fix

Install `gosu` (same pattern as official postgres/redis images):
1. Container starts as root → entrypoint can read the `0600` secret
2. `exec gosu app "$@"` drops to `uid=1000` before uvicorn runs
3. `USER app` directive removed from Dockerfile (gosu handles the drop at runtime)

## Verified locally before push

```
docker run --entrypoint="" id             → uid=0(root)   reads 0600 secret OK
gosu app id                               → uid=1000(app) uvicorn runs unprivileged
Full entrypoint with secret simulation    → DATABASE_URL set, uid=1000
```

## Test plan

- [x] `docker build` succeeds
- [x] `docker run --entrypoint="" id` → `uid=0(root)`
- [x] `gosu app id` inside container → `uid=1000(app)`
- [x] Full entrypoint: DATABASE_URL set from secret, process drops to app user
- [ ] Deploy succeeds (CI will confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)