### PR TITLE
fix(deploy): write CDR_FERNET_KEY secret file as 0644 so app user can read it

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -121,7 +121,7 @@ grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" \
     | install -o root -g root -m 0600 /dev/stdin "$SECRET_FILE"
 grep -E '^CDR_FERNET_KEY=' "$ENV_FILE" \
     | cut -d= -f2- \
-    | install -o root -g root -m 0600 /dev/stdin "$FERNET_SECRET_FILE"
+    | install -o root -g root -m 0644 /dev/stdin "$FERNET_SECRET_FILE"
 
 # ── docker login to GHCR (if token was staged by the deploy workflow) ─────────
 # The deploy workflow writes GITHUB_TOKEN to /leonard/prod/GHCR_TOKEN as a


### PR DESCRIPTION
## Summary

One-line hotfix found during the v0.0.10.0 deploy.

`deploy-prod.sh` wrote `/run/leonard/CDR_FERNET_KEY` as mode 0600 (root-only). Docker bind-mounts that file directly into the container at `/run/secrets/cdr_fernet_key`. The backend drops to the non-root `app` user via `gosu` before Python starts, so `credential_crypto._get_fernet()` got `PermissionError` and encryption was unavailable.

**Immediate mitigation already applied:** `chmod 0644 /run/leonard/CDR_FERNET_KEY` + backend restart via SSM — production is working now (`cdr_credential_crypto: ready` confirmed in logs).

This PR fixes future deploys so they write the correct mode from the start.

**Why 0644 is safe:** The `/run/leonard/` host directory is mode 0700 owned by root, so other host processes cannot traverse to the file. Inside the container the bind mount is read-only from the app user's perspective (it never writes back).

`POSTGRES_PASSWORD` keeps 0600 — the postgres container reads it as root before dropping privileges.

## Test plan
- [x] `chmod 0644` + restart confirmed `cdr_credential_crypto: ready` on v0.0.10.0 prod
- [ ] Next deploy picks up the fixed mode automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)