### PR TITLE
fix(fhir): delete clinical resources before Patient in wipe_patient_data (fixes #235)

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -855,9 +855,10 @@ async def wipe_patient_data(*, strict: bool = True) -> None:
     data over it causes the in-flight DELETE to wipe the freshly-pushed resources.
     The strict parameter is kept for API compatibility but no longer silences failures.
     """
+    # Delete clinical resources before Patient: HAPI returns 409 when Patient is
+    # referenced by Condition/Encounter/etc., so Patient must be last.
     resource_types = [
         "MeasureReport",
-        "Patient",
         "Condition",
         "Observation",
         "Encounter",
@@ -880,6 +881,7 @@ async def wipe_patient_data(*, strict: bool = True) -> None:
         "Location",
         "Practitioner",
         "Organization",
+        "Patient",
     ]
     _MAX_CONSECUTIVE_FAILURES = 3
     consecutive_failures = 0

--- a/backend/tests/test_services_fhir_client.py
+++ b/backend/tests/test_services_fhir_client.py
@@ -594,6 +594,46 @@ async def test_wipe_patient_data_includes_qi_core_types():
         assert expected_type in wiped_types, f"{expected_type} missing from wipe list"
 
 
+async def test_wipe_patient_data_patient_deleted_after_clinical_resources():
+    """Patient must be deleted AFTER clinical types to avoid HAPI 409 referential-integrity errors.
+
+    HAPI returns 409 when a DELETE targets Patient while Condition/Encounter/etc.
+    still reference it.  Regression test for issue #235.
+    """
+    mock_response = _make_response(200, {})
+    delete_order: list[str] = []
+
+    with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
+        mock_ctx = AsyncMock()
+
+        async def capture_delete(url, **kwargs):
+            rt = url.split("/")[-1].split("?")[0]
+            delete_order.append(rt)
+            return mock_response
+
+        mock_ctx.delete = AsyncMock(side_effect=capture_delete)
+        mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+        mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await wipe_patient_data()
+
+    assert "Patient" in delete_order, "Patient must be in the wipe list"
+    patient_idx = delete_order.index("Patient")
+    clinical_types = {
+        "Condition",
+        "Observation",
+        "Encounter",
+        "Procedure",
+        "MedicationRequest",
+        "MedicationAdministration",
+    }
+    for rt in clinical_types:
+        assert rt in delete_order, f"{rt} missing from wipe list"
+        assert delete_order.index(rt) < patient_idx, (
+            f"{rt} must be deleted before Patient (got {rt} at {delete_order.index(rt)}, Patient at {patient_idx})"
+        )
+
+
 async def test_wipe_patient_data_strict_raises_after_consecutive_failures():
     with patch("app.services.fhir_client.httpx.AsyncClient") as mock_httpx:
         mock_ctx = AsyncMock()


### PR DESCRIPTION
## Summary

- **Root cause confirmed (local repro):** `Patient` was at position 2 in `wipe_patient_data`'s delete list, before all clinical resources. HAPI returns 409 when a Patient DELETE is attempted while Condition/Encounter/etc. still reference it via `subject`/`patient` fields. The `_delete_all_of_type` fallback also 409s for the same reason. Patient records leaked across every job run — diagnostic showed 74/143 patients surviving each wipe cycle.
- **Fix:** Move `"Patient"` to the end of the `resource_types` list so all clinical resources are deleted first, leaving Patient with no references.
- **Regression test:** Asserts `Condition`, `Observation`, `Encounter`, `Procedure`, `MedicationRequest`, and `MedicationAdministration` are all wiped before `Patient`.
- **Note on the cross-job zero-results symptom:** The orchestrator already re-gathers from CDR and re-pushes on every job run, so the accumulating stale Patients are the primary confirmed bug. The IP=0 in the local repro was traced to ValueSet expansion lag (separate known issue), not the wipe ordering.

## Files changed

- `backend/app/services/fhir_client.py` — reorder `resource_types` in `wipe_patient_data`
- `backend/tests/test_services_fhir_client.py` — add regression test asserting Patient is deleted last

## Test plan

- [x] Lint (`ruff check` + `ruff format --check`) — clean
- [x] Unit suite (388 tests) — all pass
- [x] CI-equivalent integration suite — pre-existing failures (`test_wipe_patient_data`, `test_test_connection_real_server`, `test_smart_load.py` errors) confirmed identical against original code via `git stash`; no new failures introduced
- [x] Local repro: diagnostic confirmed 74 Patient records surviving wipe before fix, 0 after fix

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)