### PR TITLE
feat(results): add Download FHIR JSON button for MeasureReport bundle (fixes #247)

### DIFF
--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import noload
 
 from app.config import settings
 from app.db import get_session
@@ -338,6 +339,65 @@ async def delete_job(
     await session.commit()
     logger.info("Job deleted", extra={"job_id": job_id})
     return Response(status_code=204)
+
+
+@router.get("/{job_id}/measure-report")
+async def get_job_measure_report(
+    job_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Return a FHIR Bundle (collection) of individual MeasureReports for a job.
+
+    Includes all patients whose populations["error"] is falsy — i.e. successful
+    evaluations AND gather_partial patients (those have real MeasureReports from the
+    engine; only their CDR push was partial). Excludes gather-failure and
+    evaluate-failure patients whose measure_report is a synthetic OperationOutcome.
+
+    Returns 404 if the job does not exist or has no results yet (consistent with
+    the /results endpoint). Direct API calls on an in-progress job receive a
+    partial bundle — intentional; no status gate is applied.
+
+    Memory: up to ~500 patients x ~20 KB/report = ~10 MB per query (single load,
+    no double-load due to noload() below). Revisit if cohort sizes grow to thousands.
+    """
+    job = await session.get(Job, job_id, options=[noload(Job.results), noload(Job.batches)])
+    if not job:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "resourceType": "OperationOutcome",
+                "issue": [{"severity": "error", "code": "not-found", "diagnostics": f"Job {job_id} not found"}],
+            },
+        )
+
+    result = await session.execute(select(MeasureResult).where(MeasureResult.job_id == job_id))
+    results = result.scalars().all()
+
+    if not results:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    {"severity": "error", "code": "not-found", "diagnostics": f"No results found for job {job_id}"}
+                ],
+            },
+        )
+
+    # populations is non-nullable (models/job.py) — no `or {}` needed.
+    # Filter by populations["error"] (not measure_report resourceType) so that
+    # gather_partial patients with real engine-produced reports are included.
+    entries = [
+        {"resource": mr.measure_report} for mr in results if mr.measure_report and not mr.populations.get("error")
+    ]
+
+    return {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "total": len(entries),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "entry": entries,
+    }
 
 
 @router.get("/{job_id}/comparison")

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -569,6 +569,70 @@ async def test_get_job_measure_report_no_results(client, test_session):
     assert detail["issue"][0]["code"] == "not-found"
 
 
+async def test_get_job_measure_report_in_progress_returns_partial_bundle(client, test_session):
+    """In-progress jobs return a partial bundle — no status gate is applied."""
+    from app.models.job import Job, JobStatus, MeasureResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.running,
+    )
+    test_session.add(job)
+    await test_session.flush()
+
+    report = {"resourceType": "MeasureReport", "type": "individual", "group": []}
+    test_session.add(
+        MeasureResult(
+            job_id=job.id,
+            patient_id="p1",
+            measure_report=report,
+            populations={"initial_population": True},
+        )
+    )
+    await test_session.commit()
+
+    resp = await client.get(f"/jobs/{job.id}/measure-report")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+
+
+async def test_get_job_measure_report_all_errors_returns_empty_bundle(client, test_session):
+    """When all results are errors, returns 200 with an empty bundle (not 404)."""
+    from app.models.job import Job, JobStatus, MeasureResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.flush()
+
+    test_session.add(
+        MeasureResult(
+            job_id=job.id,
+            patient_id="p-err",
+            measure_report={"resourceType": "OperationOutcome"},
+            populations={"error": True, "error_message": "gather failed", "error_phase": "gather"},
+            error_phase="gather",
+        )
+    )
+    await test_session.commit()
+
+    resp = await client.get(f"/jobs/{job.id}/measure-report")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["resourceType"] == "Bundle"
+    assert data["total"] == 0
+    assert data["entry"] == []
+
+
 # ---------------------------------------------------------------------------
 # GET /jobs/{id}/comparison
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -451,6 +451,125 @@ async def test_delete_running_job_sets_delete_requested(client, test_session):
 
 
 # ---------------------------------------------------------------------------
+# GET /jobs/{id}/measure-report
+# ---------------------------------------------------------------------------
+
+
+async def test_get_job_measure_report_success(client, test_session):
+    """Bundle contains only successful patients; error patients are excluded."""
+    from app.models.job import Job, JobStatus, MeasureResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.flush()
+
+    report = {"resourceType": "MeasureReport", "type": "individual", "group": []}
+
+    # 3 successful patients
+    for pid in ("p1", "p2", "p3"):
+        test_session.add(
+            MeasureResult(
+                job_id=job.id,
+                patient_id=pid,
+                measure_report=report,
+                populations={"initial_population": True, "denominator": True, "numerator": False},
+            )
+        )
+
+    # 1 error patient — should be excluded
+    test_session.add(
+        MeasureResult(
+            job_id=job.id,
+            patient_id="p-err",
+            measure_report={"resourceType": "OperationOutcome"},
+            populations={"error": True, "error_message": "gather failed", "error_phase": "gather"},
+            error_phase="gather",
+        )
+    )
+    await test_session.commit()
+
+    resp = await client.get(f"/jobs/{job.id}/measure-report")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["resourceType"] == "Bundle"
+    assert data["type"] == "collection"
+    assert data["total"] == 3
+    assert len(data["entry"]) == 3
+    assert all(e["resource"]["resourceType"] == "MeasureReport" for e in data["entry"])
+    assert "timestamp" in data
+
+
+async def test_get_job_measure_report_includes_gather_partial(client, test_session):
+    """gather_partial patients have real MeasureReports and no populations['error'] key — included."""
+    from app.models.job import Job, JobStatus, MeasureResult
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.flush()
+
+    report = {"resourceType": "MeasureReport", "type": "individual", "group": []}
+    test_session.add(
+        MeasureResult(
+            job_id=job.id,
+            patient_id="p-partial",
+            measure_report=report,
+            populations={"initial_population": True, "denominator": False, "numerator": False},
+            error_phase="gather_partial",
+            error_details={"operation": "gather", "failed_types": ["Observation"]},
+        )
+    )
+    await test_session.commit()
+
+    resp = await client.get(f"/jobs/{job.id}/measure-report")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["entry"][0]["resource"]["resourceType"] == "MeasureReport"
+
+
+async def test_get_job_measure_report_job_not_found(client):
+    """Returns 404 OperationOutcome when job does not exist."""
+    resp = await client.get("/jobs/99999/measure-report")
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["resourceType"] == "OperationOutcome"
+    assert detail["issue"][0]["code"] == "not-found"
+
+
+async def test_get_job_measure_report_no_results(client, test_session):
+    """Returns 404 when job exists but has no MeasureResult rows."""
+    from app.models.job import Job, JobStatus
+
+    job = Job(
+        measure_id="CMS124",
+        period_start="2024-01-01",
+        period_end="2024-12-31",
+        cdr_url="http://cdr/fhir",
+        status=JobStatus.complete,
+    )
+    test_session.add(job)
+    await test_session.commit()
+
+    resp = await client.get(f"/jobs/{job.id}/measure-report")
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["resourceType"] == "OperationOutcome"
+    assert detail["issue"][0]["code"] == "not-found"
+
+
+# ---------------------------------------------------------------------------
 # GET /jobs/{id}/comparison
 # ---------------------------------------------------------------------------
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,7 @@ backend/app/
   routes/
     health.py       GET /health
     jobs.py         POST /jobs, GET /jobs, GET /jobs/{id}, POST /jobs/{id}/cancel,
+                    GET /jobs/{id}/measure-report (FHIR Bundle of individual MeasureReports),
                     GET /jobs/{id}/comparison (actual vs. expected population counts)
     measures.py     GET /measures, POST /measures/upload
     results.py      GET /results, GET /results/{job_id}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -147,6 +147,11 @@ export function getResult(id) {
   return request(`/results/${id}`);
 }
 
+export function getMeasureReportBundle(jobId) {
+  // 60-second timeout: bundle can be several MB for large cohorts
+  return request(`/jobs/${jobId}/measure-report`, { _timeout: 60000 });
+}
+
 export function getEvaluatedResources(resultId) {
   return request(`/results/${resultId}/evaluated-resources`);
 }

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './ResultsPage.module.css';
-import { getJobs, getResults, getResult, createJob } from '../api/client';
+import { getJobs, getResults, getResult, createJob, getMeasureReportBundle } from '../api/client';
 import { useToast } from '../components/Toast';
 import PatientDetail from '../components/PatientDetail';
 import ComparisonView from '../components/ComparisonView';
@@ -78,6 +78,7 @@ export default function ResultsPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [populationFilter, setPopulationFilter] = useState('all');
   const [rerunning, setRerunning] = useState(false);
+  const [bundleDownloading, setBundleDownloading] = useState(false);
 
   useEffect(() => {
     async function loadJobs() {
@@ -170,6 +171,30 @@ export default function ResultsPage() {
     }
   };
 
+  const handleDownloadBundle = async () => {
+    if (!selectedJobId) return;
+    setBundleDownloading(true);
+    try {
+      const bundle = await getMeasureReportBundle(selectedJobId);
+      const json = JSON.stringify(bundle, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const mid = (selectedJob?.measure_id || 'measure').replace(/[^a-zA-Z0-9-_]/g, '-');
+      const period = selectedJob?.period_start && selectedJob?.period_end
+        ? `${selectedJob.period_start}-to-${selectedJob.period_end}`
+        : 'unknown-period';
+      a.download = `measure-report-${mid}-${period}-job-${selectedJobId}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(`Failed to download FHIR JSON: ${err.message}`);
+    } finally {
+      setBundleDownloading(false);
+    }
+  };
+
   const selectedJob = jobs.find(j => String(j.id) === String(selectedJobId));
   const populations = results?.populations || {};
   const allPatients = results?.patients || [];
@@ -226,6 +251,14 @@ export default function ResultsPage() {
                 disabled={allPatients.length === 0}
               >
                 Export CSV
+              </button>
+              <button
+                className={styles.btnGhost}
+                onClick={handleDownloadBundle}
+                disabled={allPatients.length === 0 || bundleDownloading}
+                aria-busy={bundleDownloading}
+              >
+                {bundleDownloading ? 'Downloading…' : 'Download FHIR JSON'}
               </button>
               {selectedJob && (
                 <button


### PR DESCRIPTION
## Summary

- Adds `GET /jobs/{job_id}/measure-report` endpoint that returns a FHIR Bundle (type=collection) of all individual MeasureReports for a job, excluding synthetic error-patient records
- Exports `getMeasureReportBundle` from the frontend API client (60 s timeout for large cohorts)
- Adds a "Download FHIR JSON" button to the Results page headerActions, next to "Export CSV", with a loading state and filename that encodes measure ID, period, and job ID

## Related issue

Closes #247

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (4 new unit tests for the backend endpoint)
- [x] docs/ updated (if architecture or API changed)
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered (N/A — read-only DB query, no new auth surface)

## Test plan

**Backend unit tests (already passing locally):**
```
cd backend && python3 -m pytest tests/test_routes_jobs.py -k "measure_report" -v
# → 4 tests pass: success, gather_partial included, job not found, no results
```

**Manual smoke (against local stack):**
1. `docker compose up -d`
2. Run a measure job to completion
3. Navigate to Results page, select the job
4. Click "Download FHIR JSON" — button shows "Downloading…" while fetching
5. Verify downloaded file:
   - Filename: `measure-report-{measureId}-{periodStart}-to-{periodEnd}-job-{jobId}.json`
   - Parses as valid JSON
   - `resourceType == "Bundle"`, `type == "collection"`
   - Each `entry[n].resource.resourceType == "MeasureReport"`
   - Entry count equals successful patient count (error patients excluded)