### PR TITLE
chore: make GHCR packages public, remove deploy auth machinery (fixes #200)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   id-token: write
   contents: read
-  packages: read  # required for GHCR pull on EC2 (token relayed via SSM SecureString)
 
 jobs:
   test-and-deploy:
@@ -36,23 +35,6 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::439475769170:role/leonard-github-deploy
           aws-region: us-east-1
-
-      - name: Stage GHCR pull token in SSM
-        # Writes the workflow's GITHUB_TOKEN to SSM as a SecureString so the
-        # EC2 deploy script can `docker login ghcr.io` to pull pre-baked HAPI
-        # images. The token is short-lived (workflow run TTL, ~1h) and removed
-        # by the cleanup step below regardless of deploy outcome.
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          aws ssm put-parameter \
-            --name "/leonard/prod/GHCR_TOKEN" \
-            --value "$GH_TOKEN" \
-            --type "SecureString" \
-            --overwrite \
-            --region us-east-1 >/dev/null
-          echo "Staged ephemeral GHCR pull token in /leonard/prod/GHCR_TOKEN"
 
       - name: Deploy via SSM Run Command
         if: success()
@@ -98,17 +80,6 @@ jobs:
             echo "Deploy timed out waiting for SSM command $COMMAND_ID (final status: $STATUS)" >&2
             exit 1
           fi
-
-      - name: Remove staged GHCR pull token from SSM
-        # Always-run cleanup. Token is unusable after workflow ends anyway
-        # (~1h TTL), but we remove it so a static read of SSM never reveals
-        # an active credential between deploys.
-        if: always()
-        run: |
-          aws ssm delete-parameter \
-            --name "/leonard/prod/GHCR_TOKEN" \
-            --region us-east-1 2>/dev/null || true
-          echo "Cleared /leonard/prod/GHCR_TOKEN"
 
       - name: Health check
         if: success()

--- a/docs/runbooks/ghcr-pull-auth.md
+++ b/docs/runbooks/ghcr-pull-auth.md
@@ -1,112 +1,43 @@
 # GHCR Pull Auth on Prod
 
-## Why this exists
+## Current state
 
-CI and prod deploys consume pre-baked HAPI images from
-`ghcr.io/bellese/mct2-hapi-{cdr,measure}` via `docker-compose.prebaked.yml`
-(connectathon bundles + IGs baked in for fast cold-start, PR #199). GHCR
-packages owned by an org default to **private**, so an unauthenticated
-`docker compose pull` returns 401 and the deploy fails:
+`ghcr.io/bellese/mct2-hapi-cdr` and `ghcr.io/bellese/mct2-hapi-measure` are
+**public**. No authentication is required to pull them. `docker compose pull`
+on EC2 works without login, for both automated deploys and manual runs.
 
-```
-hapi-fhir-measure Error Head "https://ghcr.io/v2/bellese/mct2-hapi-measure/manifests/latest": unauthorized
-```
+Push still requires auth. The bake workflow (`.github/workflows/bake-hapi-image.yml`)
+authenticates with the workflow's ephemeral `GITHUB_TOKEN` (`packages: write`
+permission) — no change there.
 
-> **Note:** The original justification for this auth flow was the Phase 1
-> per-measure HAPI reset architecture (PR #167), which was reverted in
-> PR #180. The auth mechanism remains in use because pre-baked images
-> are still the deployment path for CI and prod under the current
-> single-instance architecture (PR #199).
+## Manual deploy
 
-## How auth works
-
-No long-lived credential. The deploy workflow's own ephemeral `GITHUB_TOKEN`
-(scope: `packages: read`) is relayed to the EC2 box for one deploy and then
-deleted.
-
-```
-.github/workflows/deploy.yml
-  ├─ Stage step:    aws ssm put-parameter --name /leonard/prod/GHCR_TOKEN
-  │                                       --value $GITHUB_TOKEN
-  │                                       --type SecureString --overwrite
-  ├─ Deploy step:   aws ssm send-command  (runs scripts/deploy-prod.sh on EC2)
-  │                   └─ deploy-prod.sh:  docker login ghcr.io < /run/leonard/env
-  └─ Cleanup step:  aws ssm delete-parameter (always-run, even on deploy fail)
+```bash
+ssh leonard@98.89.219.217 -i ~/.ssh/leonard.pem
+sudo ./scripts/deploy-prod.sh
 ```
 
-The token sits in SSM only for the duration of the deploy (~3-5 min). It would
-expire on its own at workflow end (~1 h) regardless.
-
-## IAM requirements
-
-The OIDC role `arn:aws:iam::439475769170:role/leonard-github-deploy` (assumed
-by the deploy workflow) needs:
-
-```json
-{
-  "Effect": "Allow",
-  "Action": [
-    "ssm:PutParameter",
-    "ssm:DeleteParameter"
-  ],
-  "Resource": "arn:aws:ssm:us-east-1:439475769170:parameter/leonard/prod/GHCR_TOKEN"
-},
-{
-  "Effect": "Allow",
-  "Action": ["kms:Encrypt"],
-  "Resource": "arn:aws:kms:us-east-1:439475769170:alias/aws/ssm"
-}
-```
-
-The EC2 instance role needs `ssm:GetParameter*` on `/leonard/prod/*` (already
-in place for `POSTGRES_PASSWORD`). No additional IAM change.
-
-## Failure modes
-
-**`Stage GHCR pull token in SSM` step fails with AccessDenied** — IAM doesn't
-yet allow `ssm:PutParameter` on the token path. Apply the policy snippet
-above and re-run the workflow.
-
-**Deploy step fails with `docker login ghcr.io failed`** — the workflow may
-not have `packages: read` permission. Check `.github/workflows/deploy.yml`
-permissions block. The token is also `packages: read`-scoped — if a future
-change reduces the workflow's permission, GHCR returns 401.
-
-**Manual deploy via `sudo ./scripts/deploy-prod.sh` on the EC2 box** —
-deploy-prod.sh prints a warning and skips `docker login`. If
-`docker-compose.prebaked.yml` is in the compose stack, the next pull will
-401. To run a manual deploy: either push to main (auto-redeploy via workflow
-with auth), or temporarily drop `-f docker-compose.prebaked.yml` from the
-COMPOSE array in `deploy-prod.sh`.
+No GHCR login step is needed. `docker compose pull` will pull from
+`ghcr.io/bellese/mct2-hapi-{cdr,measure}` without credentials.
 
 ## Verification
 
-After deploy:
+After deploy, confirm images are present:
 
-```
-ssh leonard@98.89.219.217 -i ~/.ssh/leonard.pem  # via session manager
+```bash
 sudo docker images | grep ghcr.io/bellese
 # Should list mct2-hapi-cdr:latest and mct2-hapi-measure:latest
 ```
 
-In CloudWatch logs (group `/leonard/deploy`), the deploy run should contain:
+## History
 
-```
-[+] Logging in to GHCR for pre-baked HAPI image pulls...
-[+] GHCR login OK
-```
-
-## Why not a long-lived PAT
-
-Considered. Rejected because:
-- A PAT is a long-lived credential needing rotation, monitoring, and SSM hygiene.
-- The workflow `GITHUB_TOKEN` is auto-rotated, scoped per-run, and free.
-- Bake workflow already pushes images using the same `GITHUB_TOKEN` pattern;
-  symmetry between push and pull auth is operationally clean.
+Previously, the deploy workflow used an ephemeral `GITHUB_TOKEN` (scope
+`packages: read`) staged into SSM SecureString `/leonard/prod/GHCR_TOKEN` for
+the duration of each deploy. That mechanism was removed in the PR that resolved
+issue #200 when the packages were made public. Images contain only public
+artifacts (HAPI binary, connectathon bundles, IGs) — no secrets.
 
 ## Related
 
-- PR that introduced the auth mechanism: #168
-- PR that introduced the prebaked dependency: #167 (Phase 1, reverted in #180)
-- PR that wired prebaked images into CI/prod under current architecture: #199
+- Issue #200 — the decision to make packages public
 - Bake workflow: `.github/workflows/bake-hapi-image.yml`

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -123,35 +123,6 @@ grep -E '^CDR_FERNET_KEY=' "$ENV_FILE" \
     | cut -d= -f2- \
     | install -o root -g root -m 0644 /dev/stdin "$FERNET_SECRET_FILE"
 
-# ── docker login to GHCR (if token was staged by the deploy workflow) ─────────
-# The deploy workflow writes GITHUB_TOKEN to /leonard/prod/GHCR_TOKEN as a
-# SecureString just before invoking this script and deletes it after. Manual
-# runs without that staging step skip login and will fail loudly at compose
-# pull time if the prebaked overlay references private GHCR images.
-# NOTE: ghcr.io/bellese/mct2-hapi-* packages are currently public; login is
-# best-effort. If it fails we log the real error and continue — the subsequent
-# `docker compose pull` will succeed without auth for public images.
-if grep -qE '^GHCR_TOKEN=' "$ENV_FILE"; then
-    printf '[+] Logging in to GHCR for pre-baked HAPI image pulls...\n'
-    GHCR_TOKEN_VALUE=$(grep -E '^GHCR_TOKEN=' "$ENV_FILE" | cut -d= -f2- | tr -d '\r\n')
-    # Username can be any non-empty string when the password is a GitHub token;
-    # GHCR ignores it. Use a label that's recognizable in `docker logout` output.
-    _ghcr_err=$(mktemp)
-    if ! printf '%s' "$GHCR_TOKEN_VALUE" \
-        | docker login ghcr.io --username leonard-deploy --password-stdin >"$_ghcr_err" 2>&1; then
-        printf '[!] docker login ghcr.io failed (non-fatal — images are public):\n' >&2
-        cat "$_ghcr_err" >&2
-    else
-        printf '[+] GHCR login OK\n'
-    fi
-    rm -f "$_ghcr_err"
-    unset GHCR_TOKEN_VALUE
-else
-    printf '[!] GHCR_TOKEN not in %s — skipping ghcr.io login.\n' "$ENV_FILE"
-    printf '    Manual deploys cannot pull the private pre-baked HAPI images.\n'
-    printf '    Trigger via the deploy workflow or omit docker-compose.prebaked.yml.\n'
-fi
-
 # ── shared preflight done; branch on mode ─────────────────────────────────────
 if [[ "$POST_DB_RESTART" -eq 1 ]]; then
     # ── --post-db-restart: reconcile only, no compose operations ──────────────


### PR DESCRIPTION
## Summary

- Flipped `ghcr.io/bellese/mct2-hapi-cdr` and `ghcr.io/bellese/mct2-hapi-measure` to **public** in GitHub org settings (done manually before this PR)
- Removed the SSM token-staging dance from `deploy.yml` (Stage + Cleanup GHCR token steps)
- Removed `packages: read` workflow permission (no longer needed)
- Removed the `docker login` block from `scripts/deploy-prod.sh`
- Rewrote `docs/runbooks/ghcr-pull-auth.md` to reflect the new public state

## Why

The packages contain only public artifacts (HAPI binary, connectathon bundles, IGs) — private visibility added operational complexity with no security benefit. Making them public eliminates auth entirely and means **manual deploys just work** with the prebaked overlay (no more needing to push to main or strip `docker-compose.prebaked.yml`).

The issue's original premise (personal OAuth token via `gh auth token`) was inaccurate — the existing mechanism was already an ephemeral `GITHUB_TOKEN` staged through SSM. The runbook's prior "Why not a long-lived PAT" rationale is now moot.

## Test plan

- [ ] Lint clean (`ruff check` + `ruff format --check`) ✅
- [ ] Unit suite passes ✅
- [ ] CI-equivalent integration suite passes (exit 0) ✅
- [ ] Packages confirmed public via `gh api /orgs/Bellese/packages/container/mct2-hapi-cdr` before merge ✅ (done)
- [ ] After merge: verify next automated deploy succeeds and CloudWatch logs show no GHCR login steps
- [ ] After merge: verify `docker compose pull ghcr.io/bellese/mct2-hapi-cdr:latest` works unauthenticated on EC2

🤖 Generated with [Claude Code](https://claude.com/claude-code)