### PR TITLE
fix(test): reindex all clinical types and add Observation/Condition index gate

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -38,8 +38,10 @@ SKIP_MESSAGE = (
 # reference-type search parameters indexed, causing Encounter?patient=… to
 # return 0 results and $evaluate-measure to produce all-zero populations.
 #
-# Fix: after each bulk data load, trigger a fresh $reindex and poll until a
-# known patient's encounters appear in search results.
+# Fix: after each bulk data load, trigger a fresh $reindex for all clinical
+# resource types (Encounter, Observation, Condition, Procedure, …) and poll
+# until Encounter reference-param indexing AND Observation/Condition global
+# counts confirm the index is serving results.
 _REINDEX_POLL_INTERVAL = 1  # seconds between probe checks
 _REINDEX_TIMEOUT = 300  # seconds before giving up
 
@@ -102,35 +104,79 @@ def _wait_for_valueset_expansion(base_url: str, large_valueset_ids: list[str]) -
 def _trigger_reindex_and_wait(base_url: str, probe_patient_id: str, probe_encounter_id: str) -> None:
     """Trigger HAPI $reindex and block until reference search indexes are ready.
 
-    Calls ``POST /fhir/$reindex`` then polls ``Encounter?patient={probe}``
-    until at least one result appears.  The probe resources must already
-    exist in HAPI (written before calling this function).
+    Reindexes all clinical resource types queried by CMS measures via patient/$everything.
+    Two gates must pass before returning:
+      1. Encounter?patient= returns results (reference-param indexing ready).
+      2. Observation and Condition have global count > 0 (CMS122/124/125 initial-population
+         criteria depend on these; they produce all-zero populations if not yet indexed).
+
+    The probe resources must already exist in HAPI (written before calling this function).
     """
+    import warnings as _warnings
+
     import httpx as _httpx
 
     headers = {"Content-Type": "application/fhir+json"}
-    params = {"resourceType": "Parameters", "parameter": [{"name": "type", "valueString": "Encounter"}]}
-    import warnings as _warnings
 
-    r = _httpx.post(f"{base_url}/$reindex", json=params, headers=headers, timeout=30)
-    if r.status_code >= 400:
-        _warnings.warn(f"$reindex trigger at {base_url} returned {r.status_code}: {r.text[:200]}")
+    # Reindex all clinical types that CMS measures query via $everything.  Previously only
+    # Encounter was reindexed; the missing types caused CMS122/124/125 to see empty
+    # Observation/Condition results and produce IP=0 for all patients.
+    _CLINICAL_TYPES = (
+        "Encounter",
+        "Observation",
+        "Condition",
+        "Procedure",
+        "MedicationRequest",
+        "MedicationAdministration",
+    )
+    for resource_type in _CLINICAL_TYPES:
+        params = {"resourceType": "Parameters", "parameter": [{"name": "type", "valueString": resource_type}]}
+        r = _httpx.post(f"{base_url}/$reindex", json=params, headers=headers, timeout=30)
+        if r.status_code >= 400:
+            _warnings.warn(f"$reindex({resource_type}) at {base_url} returned {r.status_code}: {r.text[:200]}")
 
+    # Gate 1: Encounter reference-param indexing (patient-scoped probe)
     deadline = time.monotonic() + _REINDEX_TIMEOUT
     while time.monotonic() < deadline:
         resp = _httpx.get(f"{base_url}/Encounter?patient={probe_patient_id}&_count=1", timeout=10)
         if resp.status_code == 200:
             try:
                 if resp.json().get("entry"):
-                    return
+                    break
             except Exception:
                 pass
         time.sleep(_REINDEX_POLL_INTERVAL)
+    else:
+        raise RuntimeError(
+            f"HAPI at {base_url} reference-param indexing did not complete within {_REINDEX_TIMEOUT}s "
+            f"(probe: Encounter?patient={probe_patient_id})"
+        )
 
-    raise RuntimeError(
-        f"HAPI at {base_url} reference-param indexing did not complete within {_REINDEX_TIMEOUT}s "
-        f"(probe: Encounter?patient={probe_patient_id})"
-    )
+    # Gate 2: Observation and Condition reference-param indexing must be ready.
+    # $everything uses patient-reference searches to retrieve these; CMS122/124/125
+    # produce IP=0 when their Observation/Condition data is missing.
+    # Use the same probe patient as Gate 1 — connectathon patients all have
+    # clinical data so a patient?= probe is a genuine reference-param index test
+    # (unlike ?_summary=count which HAPI may serve from JPA row-counts, not Lucene).
+    for resource_type, search_param in (("Observation", "patient"), ("Condition", "patient")):
+        deadline = time.monotonic() + _REINDEX_TIMEOUT
+        while time.monotonic() < deadline:
+            resp = _httpx.get(
+                f"{base_url}/{resource_type}?{search_param}={probe_patient_id}&_count=1",
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                try:
+                    if resp.json().get("entry"):
+                        break
+                except Exception:
+                    pass
+            time.sleep(_REINDEX_POLL_INTERVAL)
+        else:
+            _warnings.warn(
+                f"HAPI at {base_url} {resource_type} reference-param index not ready within {_REINDEX_TIMEOUT}s; "
+                f"CMS measures depending on {resource_type} may return IP=0."
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes the nightly CI failure in `test_lenny_jobs_produce_correct_results` where CMS122, CMS124, and CMS125 produced all-False populations for every patient.

## Root cause

`_trigger_reindex_and_wait` in `conftest.py` called `POST /fhir/$reindex` targeting only the `Encounter` resource type, then declared HAPI "ready" as soon as `Encounter?patient=` returned results. Observation and Condition reference-param indexes were still rebuilding when those measures ran. `$everything` on the CDR uses patient-reference searches internally — with an incomplete Observation/Condition Lucene index, those resource types came back empty, so `$evaluate-measure` saw no clinical evidence and produced IP=False for all patients.

This is the same HAPI async-indexing race documented in CLAUDE.md and PR history (#142, #155, #159, #161, #167, #206). The `sync` indexing strategy (set in the Dockerfiles) covers new writes; it does NOT cover the Lucene rebuild of pre-existing H2 data at startup. That rebuild is what this fix gates on.

## Fix

Two changes to `_trigger_reindex_and_wait`:

1. **Trigger `$reindex` for all 6 clinical types** (Encounter, Observation, Condition, Procedure, MedicationRequest, MedicationAdministration) — not just Encounter.
2. **Gate 2 readiness probe** — after the existing `Encounter?patient=` gate (Gate 1), add a polling loop for `Observation?patient=` and `Condition?patient=` using the same probe patient. Uses patient-scoped reference-param probes rather than `?_summary=count` (HAPI may serve count queries from JPA row counts, not Lucene).

## Test plan

- [x] Lint clean (`ruff check` + `ruff format --check`)
- [x] Unit suite: 396 passed
- [x] `USE_PREBAKED=1 ./scripts/run-integration-tests.sh tests/integration/test_full_jobs_pipeline.py` — **11/11 passed** locally (CMS122, CMS124, CMS125 previously all-False, now all-True)

🤖 Generated with [Claude Code](https://claude.com/claude-code)