### PR TITLE
chore: drop Bellese/mct2 from OIDC trust policy

### DIFF
--- a/iam/github-deploy-trust-policy.json
+++ b/iam/github-deploy-trust-policy.json
@@ -10,14 +10,8 @@
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": [
-            "repo:Bellese/mct2:ref:refs/heads/main",
-            "repo:Bellese/lenny:ref:refs/heads/main"
-          ],
-          "token.actions.githubusercontent.com:job_workflow_ref": [
-            "Bellese/mct2/.github/workflows/deploy.yml@refs/heads/main",
-            "Bellese/lenny/.github/workflows/deploy.yml@refs/heads/main"
-          ]
+          "token.actions.githubusercontent.com:sub": "repo:Bellese/lenny:ref:refs/heads/main",
+          "token.actions.githubusercontent.com:job_workflow_ref": "Bellese/lenny/.github/workflows/deploy.yml@refs/heads/main"
         }
       }
     }


### PR DESCRIPTION
## Summary

Cleanup pass after the rename in #261. The `Bellese/mct2` entries in the OIDC trust policy were added as a transition window safety net — now that the rename is live and deploys are emitting `repo:Bellese/lenny:...` (verified on the post-merge deploy of #261), the legacy entries are unreferenced. Collapsing the arrays back to single-string form keeps the policy minimal.

## Related issue

Refs #248

## Type of change

- [x] Chore / cleanup
- [x] Infrastructure / CI/CD

## Checklist

- [x] No code change — IAM JSON only
- [x] No new ADRs needed

## Test plan

After merge, re-apply to AWS:

```bash
AWS_PROFILE=leonard aws iam update-assume-role-policy \
  --role-name leonard-github-deploy \
  --policy-document file://iam/github-deploy-trust-policy.json \
  --region us-east-1
```

Then trigger a deploy run, confirm OIDC AssumeRole still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)