### PR TITLE
chore: fix OIDC trust policy repo case (lenny → Lenny)

### DIFF
--- a/iam/github-deploy-trust-policy.json
+++ b/iam/github-deploy-trust-policy.json
@@ -10,8 +10,8 @@
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:Bellese/lenny:ref:refs/heads/main",
-          "token.actions.githubusercontent.com:job_workflow_ref": "Bellese/lenny/.github/workflows/deploy.yml@refs/heads/main"
+          "token.actions.githubusercontent.com:sub": "repo:Bellese/Lenny:ref:refs/heads/main",
+          "token.actions.githubusercontent.com:job_workflow_ref": "Bellese/Lenny/.github/workflows/deploy.yml@refs/heads/main"
         }
       }
     }


### PR DESCRIPTION
## Summary

GitHub OIDC tokens emit \`repo:Bellese/Lenny:ref:refs/heads/main\` (capital L) because the repo's canonical case after the issue #248 rename is \`Lenny\`. IAM \`StringEquals\` is case-sensitive, so the lowercase entries that landed in #262 caused **every post-rename deploy to fail** with \`Not authorized to perform sts:AssumeRoleWithWebIdentity\` (CloudTrail confirmed the OIDC \`sub\` was \`repo:Bellese/Lenny:...\`).

AWS already has the corrected (capital-L) policy applied directly via \`update-assume-role-policy\` to unblock deploys. This PR brings the repo file in sync so any future re-apply doesn't regress.

## Related issue

Refs #248

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI/CD

## Checklist

- [x] No code change — IAM JSON only
- [x] AWS policy already updated; this PR closes the file/AWS drift

## Test plan

- [x] AWS policy applied directly: \`AWS_PROFILE=leonard aws iam update-assume-role-policy ...\`
- [x] Failed deploy run #25332562860 re-run after fix — OIDC AssumeRole succeeds
- After merge: no further AWS action needed (AWS already matches what's in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)