### PR TITLE
chore: cut Lenny prod URLs over to lenny.bellese.dev (#264)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,8 +85,8 @@ jobs:
         if: success()
         run: |
           for i in $(seq 1 24); do
-            curl -fsS "https://api.98-89-219-217.nip.io/health" >/dev/null 2>&1 && break
+            curl -fsS "https://api.lenny.bellese.dev/health" >/dev/null 2>&1 && break
             [[ "$i" == "24" ]] && { echo "Health check failed after 2 min"; exit 1; }
             sleep 5
           done
-          echo "Deploy verified: https://api.98-89-219-217.nip.io/health is healthy"
+          echo "Deploy verified: https://api.lenny.bellese.dev/health is healthy"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Shortcuts: bug fixes start at Build (use `/investigate` for root cause); small t
 
 - **Profile:** `leonard` (account `439475769170`). Always use `AWS_PROFILE=leonard` for any AWS CLI commands.
 - EC2 instance: `i-0f00585639d2f3ef1`, t3.medium (4 GB RAM), Elastic IP `98.89.219.217`, region `us-east-1`
-- Live URLs: `https://98-89-219-217.nip.io` (UI), `https://api.98-89-219-217.nip.io` (API)
+- Live URLs: `https://lenny.bellese.dev` (UI), `https://api.lenny.bellese.dev` (API)
 
 ## Do NOT
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -25,3 +25,13 @@ api.{$CADDY_HOST} {
         header_up X-Forwarded-For {remote_host}
     }
 }
+
+# Soft cutover from the legacy nip.io URLs to lenny.bellese.dev (issue #264).
+# Remove these two blocks ≥ 2 weeks after cutover lands.
+98-89-219-217.nip.io {
+    redir https://{$CADDY_HOST}{uri} permanent
+}
+
+api.98-89-219-217.nip.io {
+    redir https://api.{$CADDY_HOST}{uri} permanent
+}

--- a/docs/runbooks/ghcr-pull-auth.md
+++ b/docs/runbooks/ghcr-pull-auth.md
@@ -13,8 +13,8 @@ permission) — no change there.
 ## Manual deploy
 
 ```bash
-ssh leonard@98.89.219.217 -i ~/.ssh/leonard.pem
-sudo ./scripts/deploy-prod.sh
+ssh ec2-user@98.89.219.217 -i ~/.ssh/leonard-ec2.pem
+cd /opt/leonard && sudo ./scripts/deploy-prod.sh
 ```
 
 No GHCR login step is needed. `docker compose pull` will pull from

--- a/docs/runbooks/measure-engine-h2-recovery.md
+++ b/docs/runbooks/measure-engine-h2-recovery.md
@@ -88,7 +88,7 @@ If any count is 0, the seed did not complete. Re-check `docker logs leonard-seed
 ### Step 2: Run a /jobs cycle and verify populations
 
 ```bash
-curl -s -X POST https://api.98-89-219-217.nip.io/jobs \
+curl -s -X POST https://api.lenny.bellese.dev/jobs \
   -H "Content-Type: application/json" \
   -d '{"measure_id":"CMS124FHIRCervicalCancerScreening",
        "period_start":"2026-01-01","period_end":"2026-12-31",
@@ -100,8 +100,8 @@ Wait for the job to complete, then check populations:
 
 ```bash
 JOB_ID=<id-from-above>
-curl -s "https://api.98-89-219-217.nip.io/jobs/$JOB_ID" | jq '{status,total_patients}'
-curl -s "https://api.98-89-219-217.nip.io/jobs/$JOB_ID/comparison" | jq .
+curl -s "https://api.lenny.bellese.dev/jobs/$JOB_ID" | jq '{status,total_patients}'
+curl -s "https://api.lenny.bellese.dev/jobs/$JOB_ID/comparison" | jq .
 ```
 
 Expected CMS124 with connectathon group filter: `matched=33/33  IPP=29  denom=29  numer=4  denom-excl=16`.

--- a/docs/runbooks/rotate-db-password.md
+++ b/docs/runbooks/rotate-db-password.md
@@ -38,7 +38,7 @@ cd /opt/leonard && git fetch && git reset --hard origin/main && scripts/deploy-p
 
 ### 3. Verify
 ```bash
-curl -fsS https://api.98-89-219-217.nip.io/health
+curl -fsS https://api.lenny.bellese.dev/health
 ```
 Expected: HTTP 200.
 

--- a/scripts/compare_connectathon_local_vs_prod.py
+++ b/scripts/compare_connectathon_local_vs_prod.py
@@ -266,7 +266,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--production-api-base",
-        default="https://api.98-89-219-217.nip.io",
+        default="https://api.lenny.bellese.dev",
         help="Production Lenny API base URL",
     )
     parser.add_argument(

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -9,7 +9,7 @@
 #   5. Wait for db healthcheck to pass (12 × 5s = 60s max)
 #   6. scripts/reconcile-db-password.sh
 #   7. docker compose up -d (remaining services)
-#   8. Health check: curl https://api.98-89-219-217.nip.io/health (24 × 5s = 2 min max)
+#   8. Health check: curl https://api.lenny.bellese.dev/health (24 × 5s = 2 min max)
 #
 # --post-db-restart mode:
 #   Runs only steps 1–3 and 6 (preflight, fetch, extract secret, reconcile).
@@ -47,7 +47,7 @@ readonly SECRET_FILE="${ENV_DIR}/POSTGRES_PASSWORD"
 readonly FERNET_SECRET_FILE="${ENV_DIR}/CDR_FERNET_KEY"
 readonly FETCH_SCRIPT="${LEONARD_DIR}/scripts/fetch-prod-secrets.sh"
 readonly RECONCILE_SCRIPT="${LEONARD_DIR}/scripts/reconcile-db-password.sh"
-readonly HEALTH_URL="https://api.98-89-219-217.nip.io/health"
+readonly HEALTH_URL="https://api.lenny.bellese.dev/health"
 
 # ── argument parsing ───────────────────────────────────────────────────────────
 POST_DB_RESTART=0


### PR DESCRIPTION
Closes #264.

## Summary
- Cuts Lenny prod URLs over from `98-89-219-217.nip.io` → `lenny.bellese.dev` (UI) and `api.lenny.bellese.dev` (API).
- Soft cutover: legacy nip.io hostnames 301-redirect to the new URLs for ~2 weeks, then a follow-up PR removes the legacy `Caddyfile` blocks.
- DNS records were added in Route 53 by Phillip on 2026-05-04 and verified resolving from authoritative + public resolvers (8.8.8.8, 1.1.1.1, 9.9.9.9).

## Pre-merge checklist (already done)

- [x] DNS records live for `lenny.bellese.dev` and `api.lenny.bellese.dev`
- [x] `/opt/leonard/.env` on the EC2 box updated: `CADDY_HOST=lenny.bellese.dev` (backup at `/opt/leonard/.env.bak.20260504-192605`)

The `.env` change is required **before** merge — otherwise Caddy fails to start on deploy because the `{$CADDY_HOST}` block and the new legacy `98-89-219-217.nip.io` redirect block would both claim the same hostname.

## What changed

| File | Change |
|---|---|
| `Caddyfile` | Added 301 redirect blocks for the legacy nip.io hostnames → `https://{$CADDY_HOST}{uri}`. |
| `scripts/deploy-prod.sh` | `HEALTH_URL` + boot-flow comment updated to `api.lenny.bellese.dev`. |
| `.github/workflows/deploy.yml` | Post-deploy curl + log line updated. |
| `scripts/compare_connectathon_local_vs_prod.py` | `--production-api-base` default updated. |
| `CLAUDE.md` | Live URLs stanza updated. |
| `docs/runbooks/{measure-engine-h2-recovery,rotate-db-password}.md` | curl examples updated. |

`docs/runbooks/ghcr-pull-auth.md` SSH command intentionally left on the raw EIP — SSH access should not depend on DNS health.

No application code changes. Pre-push hook ran ruff lint + format + 397 unit tests (all green, 8m31s).

## Test plan

Post-merge, the `Deploy` workflow's own health check (`curl -fsS https://api.lenny.bellese.dev/health`) is the gating test. After it goes green:

- [ ] `curl -fsS https://api.lenny.bellese.dev/health` → 200
- [ ] `https://lenny.bellese.dev` loads in browser; log in, run a job to completion
- [ ] `curl -sI https://98-89-219-217.nip.io | grep -iE '^(location|HTTP)'` → 301 + `location: https://lenny.bellese.dev/`
- [ ] `curl -sI https://api.98-89-219-217.nip.io | grep -iE '^(location|HTTP)'` → 301 + `location: https://api.lenny.bellese.dev/`
- [ ] `openssl s_client -connect lenny.bellese.dev:443 -servername lenny.bellese.dev </dev/null 2>/dev/null | openssl x509 -noout -issuer -dates` → valid Let's Encrypt cert

## Rollback

Single command on the EC2 box:

```sh
sudo cp /opt/leonard/.env.bak.20260504-192605 /opt/leonard/.env
sudo docker compose -f /opt/leonard/docker-compose.yml -f /opt/leonard/docker-compose.prod.yml up -d caddy
```

Combined with reverting this PR, that returns to the nip.io-primary state.

## Follow-ups (not in this PR)

- ≥ 2 weeks after merge: remove the legacy redirect blocks from `Caddyfile` (Phase 5 of #264).
- Stale runbook reference: `docs/runbooks/ghcr-pull-auth.md:16` says `~/.ssh/leonard.pem` and `leonard@`, but the actual SSH key is `~/.ssh/leonard-ec2.pem` and the username is `ec2-user`. Worth a docs-only PR.
