### PR TITLE
docs: refresh connectathon A/B status

### DIFF
--- a/docs/connectathon-measures-status.md
+++ b/docs/connectathon-measures-status.md
@@ -24,6 +24,23 @@ Previous pass rate was 29% before session 11 infrastructure fixes.
 
 ---
 
+## Status Rollup
+
+- **4/12** Passing 100% — CMS124, CMS506, CMS816, CMSFHIR529
+- **3/12** Mostly passing (known HAPI CQL divergence, 17 xfails total) —
+  CMS122 (89%), CMS125 (85%), CMS130 (98%)
+- **5/12** Broken
+  - **4/5** need corrected MADiE bundles — CMS2, CMS71, CMS165, CMS1218
+  - **1/5** needs HAPI upstream fix — CMS1017 (HTTP 400 on scoring type)
+
+**A vs B headline:** Direct HAPI strict=true holds at **302/319** with the
+same 17 known xfails. The Lenny Jobs path passes every strict=true measure
+and now fails CMS2 / CMS165 / CMS1218 because PR #258 surfaces
+`MeasureReport.status=error` as a job failure instead of storing
+silent all-zero results.
+
+---
+
 ## A+B Retest Result (2026-05-04)
 
 **A: Direct HAPI/source-of-truth harness** — `test_golden_measures.py` plus `test_connectathon_measures.py` against latest prebaked HAPI finished `488 passed, 66 skipped, 17 xfailed` in 23m36s. The strict=true connectathon baseline is now 302/319 with 17 known xfails and no XPASS. Golden CMS816 and CMS529 passed; `basic-measure` remained skipped.
@@ -67,7 +84,7 @@ Previous pass rate was 29% before session 11 infrastructure fixes.
 | CMS1017FHIRHHFI | 65 | 65 skipped | Not run in Jobs pipeline | HTTP 400 — cannot evaluate | ⚠️ BROKEN — HAPI scoring-type incompatibility | Await HAPI DEQM update (issue #100 closed — HAPI upstream fix still needed) |
 | CMS1218FHIRHHRF | 55 | 55 pass¹ | ❌ failed: 55/55 eval errors | Population warnings; missing ValueSets now surface as job failure | ⚠️ BROKEN — 0 ValueSets in bundle | Refreshed bundle from MADiE with ValueSets |
 
-¹ **"Pass" in strict=false direct-HAPI tests means the test did not crash, not that populations are correct.** The direct-HAPI harness treats population mismatches as non-fatal warnings for strict=false measures. After PR #258, the Lenny Jobs path raises `FhirOperationError` when HAPI returns `MeasureReport.status=error`, so CMS2, CMS165, and CMS1218 now fail as jobs instead of storing silent all-zero/non-usable results.
+¹ **"Pass" in strict=false direct-HAPI tests means the test did not crash, not that populations are correct.** The direct-HAPI harness treats population mismatches as non-fatal warnings for strict=false measures. After PR #258, the Lenny Jobs path raises `FhirOperationError` when HAPI returns `MeasureReport.status=error`, so CMS2, CMS165, and CMS1218 now fail as jobs instead of storing silent all-zero/non-usable results. Earlier revisions of this doc showed lower direct-HAPI pass counts for CMS71 (9/83) and CMS165 (0/10) because pre-v8.8.0 HAPI returned HTTP errors for those cases, which the test counted as failures. The prebaked HAPI v8.8.0 image returns 200 + MeasureReport with population warnings for the same inputs, so strict=false now soft-passes all 83 and 10 respectively. Population correctness is unchanged.
 
 ### Notes (strict=true measures)
 

--- a/docs/connectathon-measures-status.md
+++ b/docs/connectathon-measures-status.md
@@ -2,7 +2,7 @@
 
 **HAPI version:** v8.8.0-1
 **Target:** MADiE May 2026 Connectathon (12 measures)
-**Last updated:** 2026-05-04 (doc-only: rewrote Per-Measure Results table into strict=true / strict=false sections with UI Result column and footnote; updated issue #100 references to reflect it is closed; pass/fail numbers unchanged from last nightly run)
+**Last updated:** 2026-05-04 (full A+B retest against `:latest` prebaked HAPI images after PR #258: direct HAPI strict=true held at 302/319 with 17 known xfails; Lenny Jobs passed all strict=true measures and failed only broken strict=false measures CMS2, CMS165, and CMS1218)
 
 > **Maintenance note:** This file is hand-edited and drifts within days of a connectathon-measures workflow run. Auto-generation from nightly output is tracked as a follow-up. Resource baselines listed below (Patient: 568, Measure: ≥12, etc.) are connectathon-seed counts, not arbitrary thresholds — they reflect the sum of all 12 bundles' test patients/resources, not a target for a deployed CDR.
 
@@ -13,14 +13,24 @@
 | | Count |
 |---|---|
 | Total test cases | 568 |
-| ✅ Correct — strict=true, populations match expected | 219 (of 233 strict=true cases) |
-| ⚠️ Broken bundle — strict=false, populations wrong | 270 (CMS2 + CMS71 + CMS165 + CMS1218 cases) |
-| ❌ Fail — strict=true, genuine HAPI CQL divergence | 17 (xfailed) |
+| ✅ Correct — strict=true, populations match expected | 302 (of 319 strict=true cases; 95%) |
+| ⚠️ Broken bundle — strict=false / not clinically trusted | 184 direct-HAPI non-strict cases (CMS2 + CMS71 + CMS165 + CMS1218); Lenny Jobs fails CMS2/CMS165/CMS1218 |
+| ❌ Known HAPI CQL divergence — strict=true xfailed | 17 |
 | ⏭ Skip — HTTP 400 (CMS1017) | 65 |
 
-> **The 71% figure cited in earlier docs is misleading** — it counted strict=false "passes" the same as strict=true passes. The 270 cases from broken-bundle measures never produce correct populations. The meaningful pass rate across the 7 strict=true measures is 219/233 = 94%, with all 17 failures traced to a known HAPI upstream CQL divergence (not a Lenny defect).
+> **The 71% figure cited in earlier docs is misleading** — it counted strict=false "passes" the same as strict=true passes. The 184 cases from broken-bundle measures are not clinically trusted even when the direct-HAPI harness records them as non-strict passes. The meaningful pass rate across the 7 strict=true measures is 302/319 = 95%, with all 17 failures traced to a known HAPI upstream CQL divergence (not a Lenny defect).
 
 Previous pass rate was 29% before session 11 infrastructure fixes.
+
+---
+
+## A+B Retest Result (2026-05-04)
+
+**A: Direct HAPI/source-of-truth harness** — `test_golden_measures.py` plus `test_connectathon_measures.py` against latest prebaked HAPI finished `488 passed, 66 skipped, 17 xfailed` in 23m36s. The strict=true connectathon baseline is now 302/319 with 17 known xfails and no XPASS. Golden CMS816 and CMS529 passed; `basic-measure` remained skipped.
+
+**B: Lenny orchestration path** — `test_full_jobs_pipeline.py` against the same prebaked images finished `8 passed, 3 failed` in 8m44s. All strict=true Jobs measures passed: CMS122, CMS124, CMS125, CMS130, CMS506, CMS816, and CMSFHIR529. The only Jobs failures were broken strict=false measures: CMS2, CMS165, and CMS1218, each failing all patient evaluations after PR #258 surfaced `MeasureReport.status=error` as `FhirOperationError`.
+
+**Interpretation** — direct HAPI did not regress; the stale `219/233` headline is superseded by `302/319`. Lenny Jobs matches the direct-HAPI baseline for every strict=true measure. The A/B delta is isolated to broken strict=false measures where direct HAPI still records non-strict warning passes, but Lenny now fails the job when HAPI returns error reports.
 
 ---
 
@@ -43,36 +53,36 @@ Previous pass rate was 29% before session 11 infrastructure fixes.
 | CMS130FHIRColorectalCancerScreening | 64 | 63 | 1 | 0 | MOSTLY PASSING (98%) | 1 failure xfailed (`f9ef1fd1` dementia) — file HAPI upstream issue when ready |
 | CMS506FHIRSafeUseofOpioids | 38 | 38 | 0 | 0 | ✅ PASS (100%) | — |
 | CMS816FHIRHHHypo | 9 | 9 | 0 | 0 | ✅ PASS (100%) | — |
-| CMS529FHIRHybridHospitalWideReadmission | 53 | 53 | 0 | 0 | ✅ PASS (100%) | — |
+| CMSFHIR529HybridHospitalWideReadmission | 53 | 53 | 0 | 0 | ✅ PASS (100%) | — |
 
 ### Strict=false — ⚠️ BROKEN BUNDLES. Results are NOT clinically accurate.
 
 > These measures have known bundle defects. The nightly test runs them in non-strict mode **only to detect regressions**, not to validate correctness. A "0 Fail" row here does not mean the measure works — it means the defect hasn't gotten worse. Do not run these measures in Lenny and expect meaningful results.
 
-| Measure | Cases | Pass¹ | Fail | Skip | UI Result | Status | Fix Needed |
-|---|---|---|---|---|---|---|---|
-| CMS2FHIRPCSDepressionScreenAndFollowUp | 36 | 36¹ | 0 | 0 | IP=0 most patients | ⚠️ BROKEN — missing 10 VSAC ValueSets | Refreshed bundle from MADiE with ValueSets |
-| CMS71FHIRSTKAnticoagAFFlutter | 83 | 9 | 74 | 0 | 80/83 patients missing Claims | ⚠️ BROKEN — duplicate Claim IDs in export | Refreshed bundle from MADiE (per-patient Claims) |
-| CMS165FHIRControllingHighBloodPressure | 10 | 0 | 10 | 0 | IP=0 all patients | ⚠️ BROKEN — library version mismatch | Refreshed bundle from MADiE (AdultOutpatientEncounters v4.19.000) |
-| CMS1017FHIRHHFI | 65 | 0 | 0 | 65 | HTTP 400 — cannot evaluate | ⚠️ BROKEN — HAPI scoring-type incompatibility | Await HAPI DEQM update (issue #100 closed — HAPI upstream fix still needed) |
-| CMS1218FHIRHHRF | 55 | 55¹ | 0 | 0 | **IP=0 all 55 patients** | ⚠️ BROKEN — 0 ValueSets in bundle | Refreshed bundle from MADiE with ValueSets |
+| Measure | Cases | Direct HAPI | Lenny Jobs | UI / Clinical Result | Status | Fix Needed |
+|---|---|---|---|---|---|---|
+| CMS2FHIRPCSDepressionScreenAndFollowUp | 36 | 36 pass¹ | ❌ failed: 36/36 eval errors | Population warnings; missing ValueSets now surface as job failure | ⚠️ BROKEN — missing 10 VSAC ValueSets | Refreshed bundle from MADiE with ValueSets |
+| CMS71FHIRSTKAnticoagAFFlutter | 83 | 83 pass¹ | ✅ passed | Population warnings; Claims remain incomplete | ⚠️ BROKEN — duplicate Claim IDs in export | Refreshed bundle from MADiE (per-patient Claims) |
+| CMS165FHIRControllingHighBloodPressure | 10 | 10 pass¹ | ❌ failed: 10/10 eval errors | Population warnings; library mismatch now surfaces as job failure | ⚠️ BROKEN — library version mismatch | Refreshed bundle from MADiE (AdultOutpatientEncounters v4.19.000) |
+| CMS1017FHIRHHFI | 65 | 65 skipped | Not run in Jobs pipeline | HTTP 400 — cannot evaluate | ⚠️ BROKEN — HAPI scoring-type incompatibility | Await HAPI DEQM update (issue #100 closed — HAPI upstream fix still needed) |
+| CMS1218FHIRHHRF | 55 | 55 pass¹ | ❌ failed: 55/55 eval errors | Population warnings; missing ValueSets now surface as job failure | ⚠️ BROKEN — 0 ValueSets in bundle | Refreshed bundle from MADiE with ValueSets |
 
-¹ **"Pass" in strict=false means the test didn't crash, not that populations are correct.** For CMS2 and CMS1218, population mismatches (actual IP=0 vs expected IP>0) are silently treated as non-fatal warnings. If you run either measure in Lenny you will see 0 results for every population. That is the correct expected behavior given the broken bundle — not a Lenny bug.
+¹ **"Pass" in strict=false direct-HAPI tests means the test did not crash, not that populations are correct.** The direct-HAPI harness treats population mismatches as non-fatal warnings for strict=false measures. After PR #258, the Lenny Jobs path raises `FhirOperationError` when HAPI returns `MeasureReport.status=error`, so CMS2, CMS165, and CMS1218 now fail as jobs instead of storing silent all-zero/non-usable results.
 
 ### Notes (strict=true measures)
 
-- **CMS124, CMS506, CMS816, CMS529** — 100% pass, strict=true
+- **CMS124, CMS506, CMS816, CMSFHIR529** — 100% pass, strict=true
 - **CMS122** — 50/56 (89%); 6 `denominator-exclusion` mismatches confirmed as HAPI CQL divergence (xfailed in test suite)
 - **CMS125** — 56/66 (85%); 10 `denominator-exclusion` mismatches confirmed as HAPI CQL divergence (xfailed)
 - **CMS130** — 63/64 (98%); 1 failure (`f9ef1fd1` dementia condition) confirmed as HAPI CQL divergence (xfailed)
 
 ### Notes (strict=false measures)
 
-- **CMS71** — MADiE v0.3.002 exports all 83 Claims with the same ID; `fix_duplicate_claim_ids()` partially recovers (only 3/83 patients get Claims). Needs refreshed MADiE bundle.
-- **CMS165** — v0.3.000 bundle missing library dependencies (`AdultOutpatientEncounters v4.16.000` vs. available `v4.19.000`). Needs refreshed MADiE bundle.
-- **CMS2** — missing 10 VSAC ValueSets (depression screening/medications); IP=0 for most patients. Non-strict mode treats all population mismatches as warns so the test shows 0 Fail.
+- **CMS71** — MADiE v0.3.002 exports all 83 Claims with the same ID; `fix_duplicate_claim_ids()` partially recovers the bundle enough for Lenny Jobs to complete, but populations remain warning-only and clinically untrusted. Needs refreshed MADiE bundle.
+- **CMS165** — v0.3.000 bundle missing library dependencies (`AdultOutpatientEncounters v4.16.000` vs. available `v4.19.000`). Direct HAPI records non-strict warning passes; Lenny Jobs now fails all 10 evaluations. Needs refreshed MADiE bundle.
+- **CMS2** — missing 10 VSAC ValueSets (depression screening/medications); IP=0 for most patients. Direct HAPI records non-strict warning passes; Lenny Jobs now fails all 36 evaluations after error reports are surfaced.
 - **CMS1017** — HAPI v8.8.0 returns HTTP 400 for this measure's scoring type; all 65 tests skipped. Issue #100 (tracking this) is closed — HAPI upstream fix for composite/ratio scoring type still needed.
-- **CMS1218** — 0 ValueSets in bundle. The required ValueSets (e.g. `2.16.840.1.113762.1.4.1248.208` "General And Neuraxial Anesthesia") are not present in any bundle in this repo. HAPI returns `MeasureReport.status=error` (Unknown ValueSet) for every patient, producing IP=0 across the board. Non-strict mode treats the resulting population mismatches as warns, so the nightly test shows 0 Fail — but 0 patients evaluate correctly.
+- **CMS1218** — 0 ValueSets in bundle. The required ValueSets (e.g. `2.16.840.1.113762.1.4.1248.208` "General And Neuraxial Anesthesia") are not present in any bundle in this repo. Direct HAPI records non-strict warning passes; Lenny Jobs now fails all 55 evaluations after HAPI error reports are surfaced.
 
 ---
 
@@ -80,7 +90,7 @@ Previous pass rate was 29% before session 11 infrastructure fixes.
 
 | Bundle | Description | Status |
 |---|---|---|
-| `basic-measure` | Simple EXM test | PASS |
+| `basic-measure` | Simple EXM test | SKIP |
 | `CMS816FHIRHHHypo` | HH Hypoglycemia (inpatient, 9 patients) | PASS |
 | `CMS529FHIRHybridHospitalWideReadmission` | Hospital-Wide Readmission (53 patients) | PASS |
 
@@ -96,7 +106,7 @@ CMS1218 bundle ships 0 ValueSets. Its IP criteria ("Elective Inpatient Encounter
 
 Fix needed: MADiE must include the required VSes in the CMS1218 bundle, or all 12 bundles must be pre-loaded before the golden test (defeats the purpose of isolation).
 
-CMS1218 is fully covered by the nightly connectathon test (55/55 pass, strict=false, full-bundle context).
+CMS1218 is covered by the direct nightly connectathon harness as 55 non-strict warning passes in full-bundle context. Lenny Jobs currently fails all 55 evaluations because the missing ValueSets surface as HAPI error reports.
 
 ---
 
@@ -220,11 +230,11 @@ Status: Genuine HAPI vs. MADiE CQL evaluation differences — **not fixable in L
 
 ### Class B: CMS71 — MADiE bundle export bug (strict=false)
 
-MADiE v0.3.002 exports all 83 Claim resources with the same ID. `fix_duplicate_claim_ids()` assigns unique IDs but only 3/83 patients get valid Claims (only 3 patients have encounter refs in their Claim items). Remaining 80 patients need a refreshed bundle from MADiE.
+MADiE v0.3.002 exports all 83 Claim resources with the same ID. `fix_duplicate_claim_ids()` assigns unique IDs and the Lenny Jobs pipeline completes, but the direct-HAPI harness still emits population warnings and the measure remains clinically untrusted until MADiE ships corrected per-patient Claims.
 
 ### Class C: CMS165 — library version mismatch (strict=false)
 
-Bundle v0.3.000 requires `AdultOutpatientEncounters v4.16.000`; HAPI has `v4.19.000` (loaded by CMS125/CMS130). Library resolution fails; all patients evaluate to IP=0. Needs refreshed bundle from MADiE.
+Bundle v0.3.000 requires `AdultOutpatientEncounters v4.16.000`; HAPI has `v4.19.000` (loaded by CMS125/CMS130). Direct HAPI records non-strict warning passes; Lenny Jobs fails all 10 patient evaluations after PR #258 surfaces error reports. Needs refreshed bundle from MADiE.
 
 ---
 
@@ -254,9 +264,10 @@ All EXM FHIR4 bundles (EXM104, EXM105, EXM108, EXM124, EXM125, EXM130, EXM165, E
 ## Next Steps
 
 1. **File HAPI upstream issue** (when ready) — hapifhir/hapi-fhir for the DE criteria evaluation divergence (frailty, dementia, mastectomy date boundary). When filed, update `_HAPI_DE_XFAIL` comment in `test_connectathon_measures.py` with the issue number.
-2. **CMS122/124/125/130** — obtain QI-Core 6 dQM v1.0.000 bundles from MADiE (issue #115)
-3. **CMS165** — get refreshed bundle from MADiE with updated library versions
-4. **CMS71** — get refreshed bundle from MADiE with correct per-patient Claim resources
-5. **CMS1017** — await HAPI DEQM upstream fix for composite/ratio scoring type (issue #100 closed; HTTP 400 still present in v8.8.0); re-add to golden tests after fix ships and VS conflicts are verified gone
-6. **CMS1218** — once MADiE ships bundle with required ValueSets, re-add to golden tests
-7. **Remove xfail marks** — when HAPI ships a fix for the DE divergence, run `--runxfail` to confirm xpassed, then remove from `_HAPI_DE_XFAIL`
+2. **Lenny Jobs strict=false expectation** — decide whether `test_full_jobs_pipeline.py` should explicitly expect/xfail failed jobs for CMS2, CMS165, and CMS1218 now that HAPI error reports are surfaced instead of silently stored
+3. **CMS122/124/125/130** — obtain QI-Core 6 dQM v1.0.000 bundles from MADiE (issue #115)
+4. **CMS165** — get refreshed bundle from MADiE with updated library versions
+5. **CMS71** — get refreshed bundle from MADiE with correct per-patient Claim resources
+6. **CMS1017** — await HAPI DEQM upstream fix for composite/ratio scoring type (issue #100 closed; HTTP 400 still present in v8.8.0); re-add to golden tests after fix ships and VS conflicts are verified gone
+7. **CMS1218** — once MADiE ships bundle with required ValueSets, re-add to golden tests
+8. **Remove xfail marks** — when HAPI ships a fix for the DE divergence, run `--runxfail` to confirm xpassed, then remove from `_HAPI_DE_XFAIL`


### PR DESCRIPTION
## Summary
- refreshed `docs/connectathon-measures-status.md` from a full 2026-05-04 A+B retest against `:latest` prebaked HAPI images
- replaced stale `219/233` strict=true headline with current `302/319` strict=true baseline and 17 known xfails
- documented the Lenny Jobs delta: all strict=true Jobs measures pass; broken strict=false CMS2, CMS165, and CMS1218 now fail as jobs after PR #258 surfaces HAPI error reports

## Headline
No strict=true regression found.

Direct HAPI did not regress. The previous `219/233` figure was stale and is superseded by `302/319` strict=true pass coverage with 17 known HAPI CQL divergence xfails.

Lenny Jobs matched direct HAPI for every strict=true measure. The only B failures were broken strict=false measures:
- CMS2FHIRPCSDepressionScreenAndFollowUp: failed all 36 patient evaluations
- CMS165FHIRControllingHighBloodPressure: failed all 10 patient evaluations
- CMS1218FHIRHHRF: failed all 55 patient evaluations

No XPASS results were reported, so no xfail markers were changed.

## Test output
Full pytest logs are in this secret gist:
https://gist.github.com/michaelrobertsutton/bd714860c334485b41d173a63542ed97

## Test plan
- `USE_PREBAKED=1 REQUIRE_PREBAKED=1 ./scripts/run-integration-tests.sh tests/integration/test_golden_measures.py tests/integration/test_connectathon_measures.py --durations=20 -rA`
  - `488 passed, 66 skipped, 17 xfailed, 266 warnings in 1416.50s (0:23:36)`
  - runner reported `USED PREBAKED: yes`
  - no XPASS
- `USE_PREBAKED=1 REQUIRE_PREBAKED=1 ./scripts/run-integration-tests.sh tests/integration/test_full_jobs_pipeline.py --durations=20 -rA`
  - `3 failed, 8 passed in 523.94s (0:08:43)`
  - runner reported `USED PREBAKED: yes`
  - failures isolated to broken strict=false CMS2/CMS165/CMS1218; all strict=true Jobs measures passed
