### PR TITLE
chore(frontend): harden index.html — noindex, OG tags, robots.txt, SPA-fallback fix

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=build /app/build ./build
 RUN chown -R appuser:appgroup /app
 USER appuser
 EXPOSE 3001
-CMD ["serve", "-s", "build", "-l", "3001"]
+CMD ["serve", "build", "-l", "3001"]

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0066CC" />
     <meta name="description" content="Lenny - Healthcare Quality Measure Calculation Tool" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="format-detection" content="telephone=no" />
+    <link rel="canonical" href="https://lenny.bellese.dev/" />
+    <meta property="og:title" content="Lenny" />
+    <meta property="og:description" content="Healthcare quality measure calculation and validation" />
+    <meta property="og:url" content="https://lenny.bellese.dev/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Bellese" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Lenny" />
+    <meta name="twitter:description" content="Healthcare quality measure calculation and validation" />
     <title>Lenny</title>
   </head>
   <body>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/frontend/public/serve.json
+++ b/frontend/public/serve.json
@@ -1,0 +1,11 @@
+{
+  "rewrites": [
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/measures", "destination": "/index.html" },
+    { "source": "/jobs", "destination": "/index.html" },
+    { "source": "/results", "destination": "/index.html" },
+    { "source": "/results/:jobId", "destination": "/index.html" },
+    { "source": "/validation", "destination": "/index.html" },
+    { "source": "/settings", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #266 (code-only items; favicon + og:image deferred to follow-up).

- **Blocks indexing** — `<meta name="robots" content="noindex, nofollow">` + `robots.txt` (Disallow: /) so neither crawlers nor bots can index this internal tool
- **Slack/Teams unfurls** — Open Graph (`og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`) and Twitter Card tags added; unfurls will now show explicit Bellese site name
- **iOS format-detection** — `<meta name="format-detection" content="telephone=no">` prevents Safari from auto-linking NPIs and member IDs as `tel:` links
- **Canonical URL** — `<link rel="canonical" href="https://lenny.bellese.dev/">` points crawlers/bots at the canonical public URL
- **SPA-fallback fix** — Drop `-s` (single-page mode) from `serve` CMD; replace with explicit `serve.json` rewrites for all six app routes. `/favicon.ico`, `/manifest.json`, and any other missing static asset now return a clean `404` instead of `Content-Type: text/html`

## Files changed

| File | Change |
|---|---|
| `frontend/public/index.html` | 11 new `<head>` tags |
| `frontend/public/serve.json` | New — explicit SPA route rewrites |
| `frontend/public/robots.txt` | New — `User-agent: *\nDisallow: /` |
| `frontend/Dockerfile` | Drop `-s` from `serve` CMD |

## Implementation note — serve.json pattern

The original plan used a glob `**/!(*.*)` (extensionless paths only). `serve-handler` uses `path-to-regexp` v3.3.0, which doesn't support extglob syntax and crashes on startup. Instead, the six app routes (`/`, `/measures`, `/jobs`, `/results`, `/results/:jobId`, `/validation`, `/settings`) are enumerated explicitly — cleaner and predictable. If a new route is added, `serve.json` needs a matching entry.

## Test plan

- [x] `npm run build && npx serve build -l 3099` — server starts without error
- [x] `curl -s http://localhost:3099/ | grep -E 'robots|og:|twitter:|canonical|format-detection'` — all tag families present
- [x] `curl -sI http://localhost:3099/favicon.ico` → `HTTP/1.1 404 Not Found` (not `text/html`)
- [x] `curl -sI http://localhost:3099/robots.txt` → `HTTP/1.1 200 OK`
- [x] `curl -s http://localhost:3099/jobs` → contains `<div id="root">` (SPA routing intact)
- [x] `curl -s http://localhost:3099/results/abc` → contains `<div id="root">` (nested SPA route intact)
- [x] `curl -sI http://localhost:3099/static/js/main.*.js` → `HTTP/1.1 200 OK` (static assets unaffected)
- [ ] Post to Slack after merge — verify OG unfurl shows "Bellese" site name

## Out of scope

Favicon assets (`favicon.svg`, `favicon-32x32.png`, `apple-touch-icon.png`) and `og:image` card need design work — tracked as follow-up to this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)