### PR TITLE
fix(orchestrator): surface HAPI-2788 missing ValueSet URL in job error message

### DIFF
--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -7,6 +7,8 @@ evaluates the measure, and stores results.
 import asyncio
 import copy
 import logging
+import re
+import urllib.parse
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -33,6 +35,28 @@ from app.services.validation import sanitize_error
 logger = logging.getLogger(__name__)
 
 LENNY_ERROR_EXT = "https://lenny.bellese.io/fhir/StructureDefinition/synthesized-error"
+
+# HAPI-2788: HAPI echoes ValueSet URLs percent-encoded in its diagnostic message.
+# sanitize_error() strips plain URLs (https?://...) but leaves percent-encoded ones intact,
+# so we match both forms here and decode before surfacing to the user.
+_HAPI_UNKNOWN_VS_RE = re.compile(
+    r"HAPI-2788[^:]*:\s*Unknown ValueSet:\s*(\S+)",
+    re.IGNORECASE,
+)
+
+
+def _extract_unknown_valueset_urls(error_messages: list[str]) -> list[str]:
+    """If ALL messages are HAPI-2788 Unknown ValueSet errors, return sorted unique decoded URLs.
+
+    Returns [] if any message does not match (mixed error types should use the generic message).
+    """
+    urls: set[str] = set()
+    for msg in error_messages:
+        m = _HAPI_UNKNOWN_VS_RE.search(msg)
+        if not m:
+            return []
+        urls.add(urllib.parse.unquote(m.group(1)))
+    return sorted(urls)
 
 
 def _extract_populations(measure_report: dict[str, Any]) -> dict[str, bool]:
@@ -240,7 +264,28 @@ async def run_job(job_id: int) -> None:
                 return
             if job.total_patients and job.processed_patients == 0 and job.failed_patients > 0:
                 job.status = JobStatus.failed
-                job.error_message = f"All {job.failed_patients} patient evaluations failed"
+                error_rows = (
+                    await session.execute(
+                        select(MeasureResult.populations).where(
+                            MeasureResult.job_id == job_id,
+                            MeasureResult.error_phase == "evaluate",
+                        )
+                    )
+                ).scalars().all()
+                patient_errors = [
+                    r["error_message"]
+                    for r in error_rows
+                    if isinstance(r, dict) and r.get("error_message")
+                ]
+                vs_urls = _extract_unknown_valueset_urls(patient_errors) if patient_errors else []
+                if vs_urls:
+                    vs_list = ", ".join(vs_urls)
+                    job.error_message = (
+                        f"All {job.failed_patients} patient evaluations failed: "
+                        f"unknown ValueSet(s): {vs_list}"
+                    )
+                else:
+                    job.error_message = f"All {job.failed_patients} patient evaluations failed"
             else:
                 job.status = JobStatus.complete
             job.completed_at = datetime.now(timezone.utc)

--- a/backend/app/services/orchestrator.py
+++ b/backend/app/services/orchestrator.py
@@ -265,24 +265,25 @@ async def run_job(job_id: int) -> None:
             if job.total_patients and job.processed_patients == 0 and job.failed_patients > 0:
                 job.status = JobStatus.failed
                 error_rows = (
-                    await session.execute(
-                        select(MeasureResult.populations).where(
-                            MeasureResult.job_id == job_id,
-                            MeasureResult.error_phase == "evaluate",
+                    (
+                        await session.execute(
+                            select(MeasureResult.populations).where(
+                                MeasureResult.job_id == job_id,
+                                MeasureResult.error_phase == "evaluate",
+                            )
                         )
                     )
-                ).scalars().all()
+                    .scalars()
+                    .all()
+                )
                 patient_errors = [
-                    r["error_message"]
-                    for r in error_rows
-                    if isinstance(r, dict) and r.get("error_message")
+                    r["error_message"] for r in error_rows if isinstance(r, dict) and r.get("error_message")
                 ]
                 vs_urls = _extract_unknown_valueset_urls(patient_errors) if patient_errors else []
                 if vs_urls:
                     vs_list = ", ".join(vs_urls)
                     job.error_message = (
-                        f"All {job.failed_patients} patient evaluations failed: "
-                        f"unknown ValueSet(s): {vs_list}"
+                        f"All {job.failed_patients} patient evaluations failed: unknown ValueSet(s): {vs_list}"
                     )
                 else:
                     job.error_message = f"All {job.failed_patients} patient evaluations failed"

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -442,7 +442,10 @@ async def test_run_job_all_hapi_2788_produces_valueset_job_message(test_session,
     diag = f"HAPI-2788: Unknown ValueSet: {vs_url_encoded}"
     hapi_outcome = FhirOperationOutcome(
         issues=[FhirIssue(severity="error", code="processing", diagnostics=diag)],
-        raw={"resourceType": "OperationOutcome", "issue": [{"severity": "error", "code": "processing", "diagnostics": diag}]},
+        raw={
+            "resourceType": "OperationOutcome",
+            "issue": [{"severity": "error", "code": "processing", "diagnostics": diag}],
+        },
     )
     fhir_err = FhirOperationError(
         operation="evaluate-measure",

--- a/backend/tests/test_services_orchestrator.py
+++ b/backend/tests/test_services_orchestrator.py
@@ -427,6 +427,64 @@ async def test_run_job_nonexistent(session_factory):
         await run_job(99999)
 
 
+async def test_run_job_all_hapi_2788_produces_valueset_job_message(test_session, session_factory):
+    """When ALL patients fail with HAPI-2788 Unknown ValueSet, job.error_message names the ValueSet URL."""
+    from app.services.fhir_errors import FhirIssue, FhirOperationError, FhirOperationOutcome
+
+    job_id = await _setup_job(test_session)
+    patients = [
+        {"resourceType": "Patient", "id": "p1"},
+        {"resourceType": "Patient", "id": "p2"},
+    ]
+
+    vs_url_encoded = "http%3A%2F%2Fcts.nlm.nih.gov%2Ffhir%2FValueSet%2F2.16.840.1.113883.3.600.1916"
+    vs_url_decoded = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916"
+    diag = f"HAPI-2788: Unknown ValueSet: {vs_url_encoded}"
+    hapi_outcome = FhirOperationOutcome(
+        issues=[FhirIssue(severity="error", code="processing", diagnostics=diag)],
+        raw={"resourceType": "OperationOutcome", "issue": [{"severity": "error", "code": "processing", "diagnostics": diag}]},
+    )
+    fhir_err = FhirOperationError(
+        operation="evaluate-measure",
+        url="http://mcs/fhir/Measure/CMS2/$evaluate-measure",
+        status_code=200,
+        outcome=hapi_outcome,
+        latency_ms=10,
+    )
+
+    with (
+        _make_session_factory_patch(session_factory),
+        patch("app.services.orchestrator.wipe_patient_data", new_callable=AsyncMock),
+        patch("app.services.orchestrator._get_cdr_auth_headers", new_callable=AsyncMock, return_value={}),
+        patch("app.services.orchestrator._get_cdr_url", new_callable=AsyncMock, return_value="http://cdr/fhir"),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patients",
+            new_callable=AsyncMock,
+            return_value=patients,
+        ),
+        patch.object(
+            __import__("app.services.fhir_client", fromlist=["BatchQueryStrategy"]).BatchQueryStrategy,
+            "gather_patient_data",
+            new_callable=AsyncMock,
+            return_value=GatherResult(resources=[{"resourceType": "Patient", "id": "p1"}]),
+        ),
+        patch("app.services.orchestrator.push_resources", new_callable=AsyncMock),
+        patch("app.services.orchestrator.evaluate_measure", new_callable=AsyncMock, side_effect=fhir_err),
+        patch("app.services.orchestrator.settings.HAPI_SYNC_AFTER_UPLOAD", False),
+        patch("app.services.orchestrator.settings.HAPI_INDEX_WAIT_SECONDS", 0),
+    ):
+        await run_job(job_id)
+
+    async with session_factory() as session:
+        job = await session.get(Job, job_id)
+        assert job.status == JobStatus.failed
+        assert job.failed_patients == 2
+        # Must name the decoded ValueSet URL, not just "All 2 patient evaluations failed"
+        assert vs_url_decoded in job.error_message
+        assert "ValueSet" in job.error_message
+
+
 async def test_get_cdr_auth_headers_reads_live_cdr_config(test_session, session_factory):
     """_get_cdr_auth_headers joins cdr_configs via cdr_id for live credentials."""
     from app.models.config import AuthType, CDRConfig


### PR DESCRIPTION
## Summary

- When all patient evaluations fail with HAPI-2788 Unknown ValueSet, `job.error_message` now includes the decoded ValueSet URL(s) instead of the generic *"All N patient evaluations failed"* message
- Adds `_HAPI_UNKNOWN_VS_RE` regex + `_extract_unknown_valueset_urls()` helper that detects mixed vs. homogeneous error types — falls back to the generic message when errors are not all HAPI-2788
- HAPI echoes ValueSet URLs percent-encoded (`http%3A%2F%2F...`); the helper decodes them before surfacing to operators

Example new message:
```
All 36 patient evaluations failed: unknown ValueSet(s): http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916
```

Closes #267

## Test plan

- [x] New unit test `test_run_job_all_hapi_2788_produces_valueset_job_message` — watched it fail (RED), then pass (GREEN)
- [x] Full orchestrator test suite: 31/31 passed
- [x] Full backend test suite: 398 passed, 634 skipped, 0 failures
- [x] `ruff check` clean on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)