### PR TITLE
chore: add gstack skill routing rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,21 @@ Shortcuts: bug fixes start at Build (use `/investigate` for root cause); small t
 - Use Python 3.9-style `Optional[X]` — `X | None` is preferred
 - Modify HAPI FHIR H2 storage paths without reading `docs/architecture.md`
 - Modify `TODOS.md` — it is frozen 2026-04-27. Open a GitHub Issue for any new work item.
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore


### PR DESCRIPTION
## Summary

- Adds a `## Skill routing` section to `CLAUDE.md` so Claude Code automatically invokes the right gstack skill for common task types (bugs → /investigate, review → /review, ship → /ship, etc.)

## Test plan

- [ ] Documentation-only change — no code modified, no tests required
- [ ] Confirmed `CLAUDE.md` is the only changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)