### PR TITLE
fix(security): allow seeded Docker service hosts through SSRF guard

### DIFF
--- a/backend/app/services/fhir_client.py
+++ b/backend/app/services/fhir_client.py
@@ -68,7 +68,20 @@ class BundleUploadResult:
 
 
 # Hosts explicitly allowed for local dev even though they're loopback/private.
-_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+# Includes Docker service hostnames parsed from the configured default CDR and
+# MCS URLs so the seeded "Local CDR" / "Local Measure Engine" connections pass
+# the http+non-localhost guard. Set is built once at import time — settings are
+# immutable for the process lifetime.
+def _seeded_internal_hosts() -> set[str]:
+    hosts: set[str] = set()
+    for url in (settings.DEFAULT_CDR_URL, settings.MEASURE_ENGINE_URL):
+        host = urlparse(url or "").hostname
+        if host:
+            hosts.add(host)
+    return hosts
+
+
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"} | _seeded_internal_hosts()
 
 
 def _is_blocked_ip(host: str) -> bool:
@@ -88,7 +101,10 @@ def _validate_ssrf_url(url: str, label: str = "URL") -> None:
     """Reject URLs that could be used for SSRF attacks.
 
     Rules:
-    - Only https is allowed unless the host is localhost/127.0.0.1/::1 (local dev).
+    - Only https is allowed unless the host is in `_LOCAL_HOSTS` — that's
+      localhost/127.0.0.1/::1 plus the Docker service hostnames parsed from
+      `settings.DEFAULT_CDR_URL` and `settings.MEASURE_ENGINE_URL` (so the
+      seeded local CDR/MCS connections work without TLS).
     - Raw IP literals that are private, loopback, or link-local are rejected unless
       the host is in the local dev allowlist.  This covers RFC-1918, 169.254.0.0/16
       (AWS IMDS), IPv6 loopback, link-local, and ULA ranges.


### PR DESCRIPTION
## Summary

- The MCS deep probe (PR #299) and CDR test-connection both call `_validate_ssrf_url`, whose http allowlist was just `{localhost, 127.0.0.1, ::1}`. The seeded "Local CDR" / "Local Measure Engine" connections use Docker service hostnames (`hapi-fhir-cdr`, `hapi-fhir-measure`) baked into `DEFAULT_CDR_URL` / `MEASURE_ENGINE_URL`, so both UI flows failed with `SSRF protection: must use https for non-localhost hosts`.
- Extend `_LOCAL_HOSTS` at import time with hosts parsed from the configured default URLs (`backend/app/services/fhir_client.py:71-83`). Arbitrary http hosts remain blocked; private/loopback IP-literal rejection unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (existing 18 SSRF unit tests cover the contract; behavior expansion is config-driven so no new test fixtures needed)
- [ ] docs/ updated (no architecture or API change)
- [x] No new ADRs needed
- [x] Security implications considered — guard still rejects every http URL whose host isn't either loopback or one of the two seeded internal services; arbitrary http hosts (including raw private/loopback IP literals) remain blocked.

## Test plan

- [x] Lint clean (`ruff check && ruff format --check`)
- [x] Unit suite: 430/430 pass, including all 18 `_validate_ssrf_url` cases
- [x] CI-equivalent integration suite passed locally
- [x] End-to-end browser verification on local stack:
  - **CDR Test Connection** (`http://hapi-fhir-cdr:8080/fhir`) → ✓ Connected in 59ms (HTTP 200)
  - **MCS Verify with sample evaluate** (`http://hapi-fhir-measure:8080/fhir`) → ✓ Probe succeeded, CMS122FHIRDiabetesAssessGT9Pct, 58 data requirements resolved (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)