### PR TITLE
docs: reflect shipped multi-MCS connection management + SSRF fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **"Test connection" on the seeded Local CDR and "Verify with sample evaluate" on the seeded Local MCS now succeed in local Docker.** Both flows previously returned `SSRF protection: must use https for non-localhost hosts` because `_validate_ssrf_url`'s http allowlist was just `{localhost, 127.0.0.1, ::1}` — the seeded connections use Docker service hostnames (`hapi-fhir-cdr`, `hapi-fhir-measure`) baked into `DEFAULT_CDR_URL` / `MEASURE_ENGINE_URL`. The allowlist now extends with hosts parsed from those settings at import time. Arbitrary http hosts and private/loopback IP literals remain blocked. (#302)
+
 ## [0.0.17.9] - 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Local dev (per `.env.example`) and CI use `docker-compose.prebaked.yml` (HAPI im
 2. **Jobs** — Create a calculation job: select a measure, set the measurement period, optionally filter by FHIR Group, click Calculate
 3. **Results** — Inspect aggregate population summaries and drill into individual patient results
 4. **Validation** — Upload a FHIR test bundle with expected population results; Lenny runs the measure and compares actual vs. expected populations, reporting pass/fail per patient *(hidden by default; enable via Settings → Admin → Features → Validation toggle)*
-5. **Settings** — Configure your organization's clinical data repository (CDR) connection
+5. **Settings** — Manage clinical data repository (CDR) and measure calculation server (MCS) connections. Add multiple of each, switch the active one, test connectivity per connection (with a deeper "Verify with sample evaluate" probe on the active MCS). The active CDR provides patient/clinical data; the active MCS runs `$evaluate-measure`. Useful at connectathons for swapping between your own server and a reference server.
 
 ## Validation Pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@
 | hapi-fhir-measure | hapiproject/hapi:v8.8.0-1 | Measure calculation engine | internal (8080) |
 | seed | local build | One-time data loader (exits after run) | none |
 
-The CDR and Measure Engine are intentionally separate. The CDR is replaceable — users connect their own FHIR server in Settings. The Measure Engine is permanent and is the only service with `hapi.fhir.cr.enabled=true`.
+The CDR and Measure Engine are intentionally separate. Both are user-configurable in Settings: multiple CDR and MCS (Measure Calculation Server) connections can be saved, with one of each active at a time. The bundled `hapi-fhir-measure` service is the default MCS — the only one with `hapi.fhir.cr.enabled=true` — but attendees can point at their own MCS via Settings → MCS Connections (issue #12).
 
 ### Compose modes: vanilla vs. prebaked
 
@@ -33,9 +33,10 @@ backend/app/
   dependencies.py   FastAPI dependency providers (DB session, config lookups)
 
   models/
-    job.py          Job, MeasureReport
+    job.py          Job, MeasureReport (each Job snapshots cdr_id + mcs_id at creation)
     validation.py   ExpectedResult, ValidationRun
-    config.py       AppConfig (CDR URL, auth)
+    config.py       CDRConfig + ConnectionConfigMixin (URL, auth, encrypted credentials)
+    mcs_config.py   MCSConfig (parallel of CDRConfig, no is_read_only flag)
     base.py         SQLAlchemy declarative base
 
   routes/
@@ -45,13 +46,19 @@ backend/app/
                     GET /jobs/{id}/comparison (actual vs. expected population counts)
     measures.py     GET /measures, POST /measures/upload
     results.py      GET /results, GET /results/{job_id}
-    settings.py     GET /settings, PUT /settings, POST /settings/test
+    settings.py     /settings/admin (feature flags), seeds CDR + MCS routers from connection_factory
+    connection_factory.py
+                    Generic per-kind CRUD + activate + test-connection. Mounted twice:
+                    /settings/connections (CDR) and /settings/mcs-connections (MCS).
+                    Plus /settings/mcs-connections/{id}/probe (deep $data-requirements probe).
     validation.py   POST /validation/upload, GET /validation/runs
 
   services/
     orchestrator.py      Core job execution. Pulls patients, runs $evaluate-measure in batches,
                          stores MeasureReports. Group filtering via group_id param. Reads live
-                         CDR credentials from cdr_configs via job.cdr_id FK.
+                         CDR credentials from cdr_configs via job.cdr_id FK; routes
+                         $evaluate-measure at the per-job MCS snapshot (job.mcs_url, falling
+                         back to settings.MEASURE_ENGINE_URL for legacy rows).
     fhir_client.py       All FHIR server communication. DataAcquisitionStrategy ABC with two
                          implementations: BatchQueryStrategy (paginated /Patient + $everything)
                          and DataRequirementsStrategy (DEQM spec — calls $data-requirements on
@@ -79,11 +86,11 @@ frontend/src/
     JobsPage.js       Create and monitor calculation jobs
     MeasuresPage.js   Upload and view FHIR Measure bundles
     ResultsPage.js    Aggregate population summaries + patient drill-down
-    SettingsPage.js   CDR connection configuration
+    SettingsPage.js   CDR + MCS connection management (two stacked sections), admin tab
     ValidationPage.js Upload test bundles, view pass/fail results
   components/
     ComparisonView.js  Per-patient actual vs. expected population comparison panel
-    ConnectionModal.js CDR connection test / credentials modal used by SettingsPage
+    ConnectionModal.js Kind-driven connection modal (KIND_SPECS for cdr/mcs); shared by both connection sections
     PatientDetail.js   Per-patient result expansion panel
     ProgressBar.js     Job progress indicator
     Toast.js           Notification component


### PR DESCRIPTION
## Summary

- **README** Settings entry now describes CDR + MCS management (was CDR-only), surfaces the "Verify with sample evaluate" probe, and frames the connectathon use case from #12.
- **docs/architecture.md** Drops the stale "Measure Engine is permanent" claim; updates models / routes / services / frontend descriptions to reflect the `connection_factory` + `MCSConfig` + `SettingsPage` refactor that landed across PRs #283/#290/#292/#293/#294/#298.
- **CHANGELOG (Unreleased)** Records the SSRF allowlist fix from #302 so the next ship picks it up.

## Type of change

- [x] Documentation

## Checklist

- [x] Tests added or updated — N/A (docs only)
- [x] docs/ updated
- [x] No new ADRs needed
- [x] Security implications considered — N/A (docs only)

## Test plan

- [ ] Render the README and architecture diff locally and confirm the wording matches the shipped behavior.
- [ ] Confirm the Unreleased CHANGELOG entry survives the next `/ship` (no clobbering).

## Documentation

- README.md: Settings bullet now describes CDR + MCS management and the deeper MCS probe.
- docs/architecture.md: Service Map intro, Backend Structure (`models/`, `routes/`, `services/orchestrator.py`), Frontend Structure (`SettingsPage.js`, `ConnectionModal.js`) all updated to reflect post-#12 reality.
- CHANGELOG.md: Unreleased section captures #302's SSRF allowlist fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)