### PR TITLE
fix: prevent measure engine OOM-kill loop and add auto-recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Shortcuts: bug fixes start at Build (use `/investigate` for root cause); small t
 **Always export `AWS_PROFILE=leonard` before any AWS CLI call.** Using any other profile/account is a bug — Claude has gotten this wrong before. Verify with `aws sts get-caller-identity` if unsure.
 
 - Region: `us-east-1`
-- Prod runs on a single t3.medium EC2 instance (look up by tag with `aws ec2 describe-instances --filters "Name=tag:Name,Values=lenny-prod"`).
+- Prod runs on a single t3.large EC2 instance (tagged `leonard`; look up with `aws ec2 describe-instances --query 'Reservations[].Instances[].[InstanceId,InstanceType,State.Name]' --output text`).
 - Live: `https://lenny.bellese.dev` (UI), `https://api.lenny.bellese.dev` (API)
 
 ## Do NOT

--- a/docker-compose.prebaked.yml
+++ b/docker-compose.prebaked.yml
@@ -10,3 +10,6 @@ services:
 
   hapi-fhir-measure:
     volumes: []
+    mem_limit: 4g
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xmx2g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,9 +30,15 @@ services:
 
   hapi-fhir-cdr:
     restart: unless-stopped
+    mem_limit: 3g
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xmx2g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
 
   hapi-fhir-measure:
     restart: unless-stopped
+    mem_limit: 4g
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xmx2g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
 
   caddy:
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   hapi-fhir-cdr:
     image: ${HAPI_CDR_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
+    restart: unless-stopped
     ports: ["8081:8080"]
     volumes: ["cdrdata:/data/hapi"]
     mem_limit: 2g
@@ -72,11 +73,12 @@ services:
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
       - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
-      - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m
+      - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
 
   hapi-fhir-measure:
     image: ${HAPI_MEASURE_IMAGE:-hapiproject/hapi:v8.8.0-1}
     user: root
+    restart: unless-stopped
     ports: ["8080:8080"]
     volumes: ["measuredata:/data/hapi"]
     mem_limit: 3g
@@ -106,7 +108,7 @@ services:
       - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
       - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100 # Reduce HAPI search-index lag after uploads.
       - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
-      - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m
+      - JAVA_TOOL_OPTIONS=-Xmx1500m -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
 
   seed:
     build: ./seed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,21 @@ Critical settings and why they are set:
 
 Storage: both instances use H2 file-based storage under `/data/hapi` (mounted as Docker volumes). This is appropriate for local/demo use. Production deployments should use external Postgres.
 
+### Memory Sizing
+
+Both HAPI services are memory-capped to prevent the JVM from consuming host RAM uncontrolled. JVM RSS routinely runs 400–600 MB above the heap cap (`-Xmx`) due to metaspace, NIO/Lucene off-heap buffers, thread stacks, and CQL classloader overhead.
+
+| Environment | Service | `mem_limit` | `-Xmx` | Compose file |
+|---|---|---|---|---|
+| Dev + CI (prebaked) | CDR | 2 GB | 1 GB | `docker-compose.yml` |
+| Dev + CI (prebaked) | Measure Engine | 4 GB | 2 GB | `docker-compose.prebaked.yml` |
+| Prod | CDR | 3 GB | 2 GB | `docker-compose.prod.yml` |
+| Prod | Measure Engine | 4 GB | 2 GB | `docker-compose.prod.yml` |
+
+Prod runs on a **t3.large** EC2 instance (8 GiB RAM) to fit both containers plus DB, backend, and Caddy.
+
+Both services are configured with `-XX:+ExitOnOutOfMemoryError` so an OOM causes immediate process exit (rather than leaving a degraded JVM alive), and `restart: unless-stopped` so Docker auto-recovers the container without manual intervention. `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof` captures a heap dump in the named volume for post-mortem analysis (`docker cp` to retrieve it).
+
 ## Environment Variables
 
 Defined in `backend/app/config.py`. All overridable via environment variables.


### PR DESCRIPTION
## Summary

Closes #309.

Two stacked problems caused every 319-patient job to leave the measure engine dead and all subsequent jobs failing with `Measure engine unreachable: 3 consecutive timeouts during wipe. Job aborted.`:

- **Memory ceiling**: 1500m heap + JVM native overhead (metaspace, NIO/Lucene off-heap, CQL classloaders) exceeded the 3 GB `mem_limit` at `$evaluate-measure` peak load. Live evidence: 16 failed-job rows in the DB with the exact issue error, container `Exited (137)` timestamped during CMS122 parallel evaluation, CDR container at 99.8% of its 2 GB limit.
- **No auto-recovery in dev**: `docker-compose.yml` had no `restart` policy, so each OOM required manual `docker compose up`.

## Changes

| File | What changed |
|---|---|
| `docker-compose.yml` | `restart: unless-stopped` on both HAPI services; `-XX:+ExitOnOutOfMemoryError` + heap-dump flags on both `JAVA_TOOL_OPTIONS` |
| `docker-compose.prebaked.yml` | `hapi-fhir-measure` bumped to `mem_limit: 4g` / `-Xmx2g` for dev + CI prebaked path |
| `docker-compose.prod.yml` | Explicit `mem_limit` + `-Xmx2g` on both services; prod instance is already t3.large (8 GiB), no resize needed |
| `docs/architecture.md` | Memory sizing table + OOM flag rationale |
| `CLAUDE.md` | Correct stale `t3.medium` reference to `t3.large` |

**Why `-XX:+ExitOnOutOfMemoryError`**: without it, the JVM stays alive in a degraded state after OOM (H2 closes internally, requests hang for 24 min). Documented failure mode from `fe88b3c`. Forces clean process exit so the `restart: unless-stopped` policy can close the recovery loop.

**Why heap dumps on the named volume**: dumps at `/data/hapi/heapdump.hprof` survive container restart and are retrievable via `docker cp` for post-mortem analysis.

## Test plan

- [ ] Lint: `ruff check` + `ruff format --check` — **passes**
- [ ] Unit suite: `python3 -m pytest tests/ --ignore=tests/integration` — **passes**
- [ ] `docker compose config` shows no duplicate `JAVA_TOOL_OPTIONS`, correct `mem_limit`, and `restart: unless-stopped` on both HAPI services — **verified locally**
- [ ] After merge + prod deploy: confirm `docker exec lenny-hapi-fhir-measure-1 sh -c 'echo $JAVA_TOOL_OPTIONS'` shows `-Xmx2g` and heap-dump flags; `docker inspect` shows `MemLimit: 4294967296` and `RestartPolicy: unless-stopped`
- [ ] Run two consecutive CMS122 jobs — both must complete; measure container must stay up between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)