### PR TITLE
fix: bump dev/CI measure engine to 6g/Xmx4g

### DIFF
--- a/docker-compose.prebaked.yml
+++ b/docker-compose.prebaked.yml
@@ -10,6 +10,6 @@ services:
 
   hapi-fhir-measure:
     volumes: []
-    mem_limit: 4g
+    mem_limit: 6g
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx2g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
+      - JAVA_TOOL_OPTIONS=-Xmx4g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ Both HAPI services are memory-capped to prevent the JVM from consuming host RAM 
 | Environment | Service | `mem_limit` | `-Xmx` | Compose file |
 |---|---|---|---|---|
 | Dev + CI (prebaked) | CDR | 2 GB | 1 GB | `docker-compose.yml` |
-| Dev + CI (prebaked) | Measure Engine | 4 GB | 2 GB | `docker-compose.prebaked.yml` |
+| Dev + CI (prebaked) | Measure Engine | 6 GB | 4 GB | `docker-compose.prebaked.yml` |
 | Prod | CDR | 3 GB | 2 GB | `docker-compose.prod.yml` |
 | Prod | Measure Engine | 4 GB | 2 GB | `docker-compose.prod.yml` |
 


### PR DESCRIPTION
## Summary

Follow-up to #310. Live validation of two consecutive 319-patient jobs showed:

- Job 1 peak: **3.74 GiB / 4 GiB (93%)**
- Job 2 peak: **3.99 GiB / 4 GiB (99.7%)** — JVM GC held it under the limit but with only ~10 MB headroom

The JVM managed it, but a slightly larger workload or a third back-to-back job would OOM again. Bumping dev/CI to `mem_limit: 6g` / `-Xmx4g` gives proper breathing room.

Prod stays at 4g — t3.large (8 GiB) is already fully allocated between measure (4g) + CDR (3g) + DB/backend/Caddy (~1g). Prod doesn't run 319-patient jobs in normal operation, so 4g is sufficient there.

## Test plan

- [ ] CI green
- [ ] `docker compose config` shows `mem_limit: 6442450944` and `JAVA_TOOL_OPTIONS=-Xmx4g …` for `hapi-fhir-measure` on prebaked path

🤖 Generated with [Claude Code](https://claude.com/claude-code)