### PR TITLE
feat(results): master-detail redesign — population dots, inline drawer, comparison toggle

### DIFF
--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -64,7 +64,9 @@ async def health_check(
                 "url": None,
                 "status_code": None,
                 "latency_ms": None,
-                "hint": None,
+                "hint": (
+                    "Cannot connect to the database. Check that it is running and the connection settings are correct."
+                ),
             },
         }
         status["status"] = "degraded"

--- a/backend/app/routes/results.py
+++ b/backend/app/routes/results.py
@@ -14,6 +14,42 @@ from app.services.validation import sanitize_error
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/results", tags=["results"])
 
+_POP_DESC_URL = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MeasureReport.population.description"
+
+
+def _extract_pop_info(
+    measure_report: dict | None,
+) -> tuple[dict[str, str] | None, list[str] | None]:
+    """Extract population descriptions and defined codes from a MeasureReport.
+
+    Returns (descriptions_dict, defined_codes_list).
+    descriptions_dict maps FHIR population code → description string (only codes that
+    have a description extension).
+    defined_codes_list lists all population codes that appear in the MeasureReport,
+    whether or not they have a description (used to hide irrelevant rows in the UI).
+    Both values are None when the MeasureReport is absent.
+    """
+    if not measure_report:
+        return None, None
+    descriptions: dict[str, str] = {}
+    defined: list[str] = []
+    for group in measure_report.get("group", []):
+        for pop in group.get("population", []):
+            code: str | None = None
+            for coding in pop.get("code", {}).get("coding", []):
+                code = coding.get("code")
+                break
+            if not code:
+                continue
+            defined.append(code)
+            for ext in pop.get("extension", []):
+                if ext.get("url") == _POP_DESC_URL:
+                    desc = (ext.get("valueString") or "").strip()
+                    if desc:
+                        descriptions[code] = desc
+                    break
+    return (descriptions or None), (defined or None)
+
 
 @router.get("")
 async def get_results(
@@ -53,11 +89,15 @@ async def get_results(
     }
     patients_list = []
     failed_patients = 0
+    population_descriptions: dict[str, str] | None = None
+    defined_populations: list[str] | None = None
 
     for mr in results:
         populations = mr.populations or {}
         is_error = bool(populations.get("error"))
         is_partial = mr.error_phase == "gather_partial"
+        if population_descriptions is None and mr.measure_report:
+            population_descriptions, defined_populations = _extract_pop_info(mr.measure_report)
         if is_error:
             failed_patients += 1
         else:
@@ -89,6 +129,8 @@ async def get_results(
         "failed_patients": failed_patients,
         "populations": pops,
         "performance_rate": performance_rate,
+        "population_descriptions": population_descriptions,
+        "defined_populations": defined_populations,
         "patients": patients_list,
     }
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -220,6 +220,7 @@ async def probe_mcs_connection(
 
 _ADMIN_DEFAULTS: dict[str, str] = {
     "validation_enabled": "false",
+    "comparison_enabled": "false",
 }
 
 
@@ -233,11 +234,13 @@ async def get_admin_settings(session: AsyncSession = Depends(get_session)) -> di
     """Return current admin settings."""
     return {
         "validation_enabled": (await _get_setting(session, "validation_enabled")) == "true",
+        "comparison_enabled": (await _get_setting(session, "comparison_enabled")) == "true",
     }
 
 
 class AdminSettingsUpdate(BaseModel):
     validation_enabled: bool | None = None
+    comparison_enabled: bool | None = None
 
 
 @router.put("/admin")
@@ -249,6 +252,8 @@ async def update_admin_settings(
     updates: dict[str, str] = {}
     if body.validation_enabled is not None:
         updates["validation_enabled"] = "true" if body.validation_enabled else "false"
+    if body.comparison_enabled is not None:
+        updates["comparison_enabled"] = "true" if body.comparison_enabled else "false"
 
     for key, value in updates.items():
         row = await session.get(AppSetting, key)
@@ -260,6 +265,7 @@ async def update_admin_settings(
 
     return {
         "validation_enabled": (await _get_setting(session, "validation_enabled")) == "true",
+        "comparison_enabled": (await _get_setting(session, "comparison_enabled")) == "true",
     }
 
 

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -64,6 +64,13 @@ def sanitize_error(exc: Exception) -> str:
     http://hostname:port), then _HOSTPORT_RE catches bare hostname:port without
     a scheme (common in httpx ConnectError messages).
     """
+    # Connectivity errors: return clean messages instead of raw socket/OS errors.
+    if isinstance(exc, httpx.ConnectError):
+        return "Service is unreachable. Check that it is running and the URL is correct."
+    if isinstance(exc, httpx.TimeoutException):
+        return "Request timed out. The service may be overloaded or unreachable."
+    if isinstance(exc, httpx.NetworkError):
+        return "Network error communicating with service."
     try:
         msg = str(exc)[:2000]
     except Exception:

--- a/backend/tests/test_routes_settings.py
+++ b/backend/tests/test_routes_settings.py
@@ -744,3 +744,44 @@ async def test_put_admin_settings_empty_body_is_noop(client):
     assert resp.status_code == 200
     # Default state is validation disabled
     assert resp.json()["validation_enabled"] is False
+
+
+async def test_get_admin_settings_defaults_comparison_disabled(client):
+    """GET /settings/admin with no AppSetting rows returns comparison_enabled=False."""
+    resp = await client.get("/settings/admin")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["comparison_enabled"] is False
+
+
+async def test_put_admin_settings_enables_comparison(client):
+    """PUT /settings/admin can enable comparison and GET reflects the change."""
+    put_resp = await client.put("/settings/admin", json={"comparison_enabled": True})
+    assert put_resp.status_code == 200
+    assert put_resp.json()["comparison_enabled"] is True
+
+    get_resp = await client.get("/settings/admin")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["comparison_enabled"] is True
+
+
+async def test_put_admin_settings_disables_comparison(client):
+    """PUT /settings/admin can disable comparison after it was enabled."""
+    await client.put("/settings/admin", json={"comparison_enabled": True})
+    put_resp = await client.put("/settings/admin", json={"comparison_enabled": False})
+    assert put_resp.status_code == 200
+    assert put_resp.json()["comparison_enabled"] is False
+
+    get_resp = await client.get("/settings/admin")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["comparison_enabled"] is False
+
+
+async def test_put_admin_settings_comparison_independent_of_validation(client):
+    """comparison_enabled and validation_enabled are stored independently."""
+    await client.put("/settings/admin", json={"validation_enabled": True})
+    resp = await client.put("/settings/admin", json={"comparison_enabled": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["validation_enabled"] is True
+    assert data["comparison_enabled"] is True

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "lenny-frontend",
-  "version": "0.0.17.0",
+  "version": "0.0.17.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lenny-frontend",
-      "version": "0.0.17.0",
+      "version": "0.0.17.12",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.0.0",
         "@fontsource/ibm-plex-sans": "^5.0.0",

--- a/frontend/src/components/Icons.js
+++ b/frontend/src/components/Icons.js
@@ -49,6 +49,9 @@ export function CheckIcon(p) {
 export function XIcon(p) {
   return <svg {...base(p, { strokeWidth: '1.4' })}><path d="M4 4l6 6M10 4l-6 6" /></svg>;
 }
+export function WarnIcon(p) {
+  return <svg {...base(p)}><path d="M7 1.5L12.5 12H1.5L7 1.5z" strokeWidth="1.3" /><path d="M7 5.5V8.5" /><circle cx="7" cy="10.2" r="0.5" fill="currentColor" stroke="none" /></svg>;
+}
 export function FilterIcon(p) {
   return <svg {...base(p)}><path d="M2.5 3h9l-3.4 4.5V11l-2.2 1.2V7.5L2.5 3z" /></svg>;
 }

--- a/frontend/src/components/OperationOutcomeView.js
+++ b/frontend/src/components/OperationOutcomeView.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styles from './OperationOutcomeView.module.css';
-import { syntaxHighlightJson } from '../utils/json';
 
 const SEVERITY_CLASS = {
   fatal: styles.sevFatal,
@@ -9,22 +8,59 @@ const SEVERITY_CLASS = {
   information: styles.sevInfo,
 };
 
+const CODE_LABEL = {
+  security: 'Auth error',
+  'not-found': 'Not found',
+  transient: 'Transient error',
+  exception: 'Server error',
+  timeout: 'Timeout',
+  throttled: 'Rate limited',
+  invalid: 'Invalid request',
+  structure: 'Invalid structure',
+  processing: 'Processing error',
+};
+
+const DIAG_TRUNCATE = 160;
+
+function DiagnosticsText({ text }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!text) return null;
+  if (text.length <= DIAG_TRUNCATE) return <span className={styles.diagnostics}>{text}</span>;
+  return (
+    <span className={styles.diagnostics}>
+      {expanded ? text : `${text.slice(0, DIAG_TRUNCATE)}…`}
+      <button className={styles.diagToggle} onClick={() => setExpanded(v => !v)} type="button">
+        {expanded ? ' show less' : ' show more'}
+      </button>
+    </span>
+  );
+}
+
+function isRedactedUrl(url) {
+  return !url || url.includes('[host]') || url === '[url-parse-error]';
+}
+
 export default function OperationOutcomeView({ issues = [], errorDetails = null, defaultExpanded = false }) {
   const [showRaw, setShowRaw] = useState(defaultExpanded);
 
   if (!issues.length && !errorDetails) return null;
 
+  const visibleUrl = errorDetails?.url && !isRedactedUrl(errorDetails.url) ? errorDetails.url : null;
+
   return (
     <div className={styles.root}>
       {issues.length > 0 && (
         <ul className={styles.issueList}>
-          {issues.map((issue, i) => (
-            <li key={i} className={styles.issueRow}>
-              <span className={`${styles.severityDot} ${SEVERITY_CLASS[issue.severity] || styles.sevError}`} title={issue.severity} />
-              <span className={styles.codeLabel}>{issue.code}</span>
-              {issue.diagnostics && <span className={styles.diagnostics}>{issue.diagnostics}</span>}
-            </li>
-          ))}
+          {issues.map((issue, i) => {
+            const codeLabel = CODE_LABEL[issue.code];
+            return (
+              <li key={i} className={styles.issueRow}>
+                <span className={`${styles.severityDot} ${SEVERITY_CLASS[issue.severity] || styles.sevError}`} title={issue.severity} />
+                {codeLabel && <span className={styles.codeLabel}>{codeLabel}</span>}
+                <DiagnosticsText text={issue.diagnostics} />
+              </li>
+            );
+          })}
         </ul>
       )}
       {errorDetails && (
@@ -37,8 +73,8 @@ export default function OperationOutcomeView({ issues = [], errorDetails = null,
             {errorDetails.latency_ms != null && (
               <span className={styles.metaBadge}>{errorDetails.latency_ms}ms</span>
             )}
-            {errorDetails.url && (
-              <span className={styles.metaUrl} title={errorDetails.url}>{errorDetails.url}</span>
+            {visibleUrl && (
+              <span className={styles.metaUrl} title={visibleUrl}>{visibleUrl}</span>
             )}
           </div>
           {errorDetails.raw_outcome && (
@@ -47,11 +83,9 @@ export default function OperationOutcomeView({ issues = [], errorDetails = null,
                 {showRaw ? '▲ Hide raw FHIR' : '▼ Show raw FHIR'}
               </button>
               {showRaw && (
-                /* syntaxHighlightJson escapes all content via escapeHtml before adding span tags — safe */
-                <pre
-                  className={styles.fhirJson}
-                  dangerouslySetInnerHTML={{ __html: syntaxHighlightJson(errorDetails.raw_outcome) }}
-                />
+                <pre className={styles.fhirJson}>
+                  {JSON.stringify(errorDetails.raw_outcome, null, 2)}
+                </pre>
               )}
             </div>
           )}

--- a/frontend/src/components/OperationOutcomeView.module.css
+++ b/frontend/src/components/OperationOutcomeView.module.css
@@ -51,6 +51,17 @@
   line-height: 1.4;
 }
 
+.diagToggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .details {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/PopulationDots.js
+++ b/frontend/src/components/PopulationDots.js
@@ -24,13 +24,27 @@ const countsShape = PropTypes.shape({
   numExc: membershipShape,
 });
 
+const POP_ARIA_LABELS = {
+  ip:     'initial population',
+  den:    'denominator',
+  denExc: 'denominator exclusion',
+  num:    'numerator',
+  numExc: 'numerator exclusion',
+};
+
 /**
  * Compact 5-chip population summary. Pass `exp` to enable mismatch highlighting.
+ * Filled chip = in population; hollow chip = not in population.
  * @param {{ act: PopulationCounts, exp?: PopulationCounts }} props
  */
 export default function PopulationDots({ act, exp }) {
+  const ariaLabel = POP_KEYS.map(({ key }) => {
+    const a = act[key] ?? 0;
+    return `${a ? 'In' : 'Not in'} ${POP_ARIA_LABELS[key]}`;
+  }).join(', ');
+
   return (
-    <div className={styles.row}>
+    <div className={styles.row} aria-label={ariaLabel}>
       {POP_KEYS.map(({ key, label }) => {
         const a = act[key] ?? 0;
         const e = exp != null ? (exp[key] ?? 0) : null;
@@ -49,7 +63,6 @@ export default function PopulationDots({ act, exp }) {
         return (
           <span key={key} className={`${styles.chip} ${chipCls}`}>
             {label}
-            <span className={styles.val}>{a}</span>
             {miss && <span className={styles.exp}>/{e}</span>}
           </span>
         );

--- a/frontend/src/components/PopulationDots.js
+++ b/frontend/src/components/PopulationDots.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './PopulationDots.module.css';
+
+/**
+ * @typedef {0 | 1} Membership
+ * @typedef {{ ip: Membership, den: Membership, denExc: Membership, num: Membership, numExc: Membership }} PopulationCounts
+ */
+
+const POP_KEYS = [
+  { key: 'ip',     label: 'IP' },
+  { key: 'den',    label: 'Denom' },
+  { key: 'denExc', label: 'DnEx' },
+  { key: 'num',    label: 'Numer' },
+  { key: 'numExc', label: 'NmEx' },
+];
+
+const membershipShape = PropTypes.oneOf([0, 1]);
+const countsShape = PropTypes.shape({
+  ip:     membershipShape,
+  den:    membershipShape,
+  denExc: membershipShape,
+  num:    membershipShape,
+  numExc: membershipShape,
+});
+
+/**
+ * Compact 5-chip population summary. Pass `exp` to enable mismatch highlighting.
+ * @param {{ act: PopulationCounts, exp?: PopulationCounts }} props
+ */
+export default function PopulationDots({ act, exp }) {
+  return (
+    <div className={styles.row}>
+      {POP_KEYS.map(({ key, label }) => {
+        const a = act[key] ?? 0;
+        const e = exp != null ? (exp[key] ?? 0) : null;
+        const inPop = !!a;
+        const miss = e !== null && a !== e;
+
+        let chipCls = styles.chipDefault;
+        if (miss) {
+          chipCls = styles.chipMiss;
+        } else if (inPop) {
+          if (key === 'denExc' || key === 'numExc') chipCls = styles.chipWarn;
+          else if (key === 'num') chipCls = styles.chipAccent;
+          else chipCls = styles.chipIn;
+        }
+
+        return (
+          <span key={key} className={`${styles.chip} ${chipCls}`}>
+            {label}
+            <span className={styles.val}>{a}</span>
+            {miss && <span className={styles.exp}>/{e}</span>}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+PopulationDots.propTypes = {
+  act: countsShape.isRequired,
+  exp: countsShape,
+};

--- a/frontend/src/components/PopulationDots.js
+++ b/frontend/src/components/PopulationDots.js
@@ -35,6 +35,8 @@ const POP_ARIA_LABELS = {
 /**
  * Compact 5-chip population summary. Pass `exp` to enable mismatch highlighting.
  * Filled chip = in population; hollow chip = not in population.
+ * Rendered as `role="img"` so screen readers announce the whole cluster as a
+ * single labeled image rather than navigating into each chip individually.
  * @param {{ act: PopulationCounts, exp?: PopulationCounts }} props
  */
 export default function PopulationDots({ act, exp }) {
@@ -44,7 +46,7 @@ export default function PopulationDots({ act, exp }) {
   }).join(', ');
 
   return (
-    <div className={styles.row} aria-label={ariaLabel}>
+    <span role="img" className={styles.row} aria-label={ariaLabel}>
       {POP_KEYS.map(({ key, label }) => {
         const a = act[key] ?? 0;
         const e = exp != null ? (exp[key] ?? 0) : null;
@@ -67,7 +69,7 @@ export default function PopulationDots({ act, exp }) {
           </span>
         );
       })}
-    </div>
+    </span>
   );
 }
 

--- a/frontend/src/components/PopulationDots.module.css
+++ b/frontend/src/components/PopulationDots.module.css
@@ -1,0 +1,61 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 5px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+
+/* Not in population (act === 0) */
+.chipDefault {
+  background: var(--line-soft);
+  color: var(--text-dim);
+}
+
+/* In population: IP or Denom */
+.chipIn {
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+}
+
+/* In population: exclusion type (denExc, numExc) */
+.chipWarn {
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+  color: oklch(0.5 0.14 70);
+}
+
+/* In population: numerator */
+.chipAccent {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+}
+
+/* Mismatch (actual !== expected) */
+.chipMiss {
+  background: color-mix(in srgb, var(--err) 14%, transparent);
+  border-color: color-mix(in srgb, var(--err) 30%, transparent);
+  color: var(--err);
+}
+
+.val {
+  opacity: 0.7;
+}
+
+.exp {
+  opacity: 0.85;
+}

--- a/frontend/src/components/PopulationDots.module.css
+++ b/frontend/src/components/PopulationDots.module.css
@@ -26,7 +26,6 @@
   background: transparent;
   border-color: var(--line-soft);
   color: var(--text-dim);
-  opacity: 0.65;
 }
 
 /* In population: IP or Denom — clearly filled */

--- a/frontend/src/components/PopulationDots.module.css
+++ b/frontend/src/components/PopulationDots.module.css
@@ -21,16 +21,19 @@
   border: 1px solid transparent;
 }
 
-/* Not in population (act === 0) */
+/* Not in population (act === 0) — hollow */
 .chipDefault {
-  background: var(--line-soft);
+  background: transparent;
+  border-color: var(--line-soft);
   color: var(--text-dim);
+  opacity: 0.65;
 }
 
-/* In population: IP or Denom */
+/* In population: IP or Denom — clearly filled */
 .chipIn {
   background: var(--bg-sunken);
-  color: var(--text-muted);
+  border-color: var(--line);
+  color: var(--text);
 }
 
 /* In population: exclusion type (denExc, numExc) */
@@ -50,10 +53,6 @@
   background: color-mix(in srgb, var(--err) 14%, transparent);
   border-color: color-mix(in srgb, var(--err) 30%, transparent);
   color: var(--err);
-}
-
-.val {
-  opacity: 0.7;
 }
 
 .exp {

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -166,7 +166,7 @@ function StatusPill({ kind, children, title }) {
   );
 }
 
-function FilterChip({ chipId, label, count, active, danger, onClick }) {
+function FilterChip({ chipId, label, count, detail, active, danger, onClick }) {
   const cls = [
     styles.chip,
     active && danger ? styles.chipDangerActive : active ? styles.chipActive : '',
@@ -175,6 +175,7 @@ function FilterChip({ chipId, label, count, active, danger, onClick }) {
     <button className={cls} onClick={() => onClick(chipId)} aria-pressed={active}>
       {label}
       {count != null && <span className={styles.chipCount}>{count}</span>}
+      {detail && <span className={styles.chipDetail}>{detail}</span>}
     </button>
   );
 }
@@ -183,14 +184,19 @@ function PopDesc({ text }) {
   const [expanded, setExpanded] = useState(false);
   if (!text) return null;
   return (
-    <button
-      className={`${styles.popDesc} ${expanded ? styles.popDescExpanded : ''}`}
-      onClick={e => { e.stopPropagation(); setExpanded(v => !v); }}
-      type="button"
-      title={expanded ? undefined : text}
-    >
-      {text}
-    </button>
+    <span className={styles.popDescWrap}>
+      <button
+        className={`${styles.popDesc} ${expanded ? styles.popDescExpanded : ''}`}
+        onClick={e => { e.stopPropagation(); setExpanded(v => !v); }}
+        type="button"
+        title={expanded ? undefined : text}
+      >
+        {text}
+      </button>
+      {!expanded && (
+        <span className={styles.popDescMore} aria-hidden="true">more ▾</span>
+      )}
+    </span>
   );
 }
 
@@ -210,13 +216,6 @@ function ExpandedPanel({ row, expectedLoaded, colSpan, popDescriptions, definedP
       .catch(err => setResError(err.message || 'Failed to load'))
       .finally(() => setResLoading(false));
   }, [row.resultId]);
-
-  const missDiff = !row.error && expectedLoaded && row.match === false && row.exp
-    ? POP_BREAKDOWN
-        .filter(({ key }) => (row.act[key] ?? 0) !== (row.exp[key] ?? 0))
-        .map(({ key, label }) => `${label}: ${row.exp[key]}→${row.act[key]}`)
-        .join(' · ')
-    : null;
 
   const verdictPill = row.error
     ? <StatusPill kind="error">{row.error}</StatusPill>
@@ -291,7 +290,7 @@ function ExpandedPanel({ row, expectedLoaded, colSpan, popDescriptions, definedP
                 <b>{row.name || '—'}</b>
               </div>
               <div className={styles.kvRow}>
-                <span className={styles.kvKey}>FHIR ID</span>
+                <span className={styles.kvKey}>Patient ID</span>
                 <span className={styles.kvIdRow}>
                   <span className={styles.mono} style={{ fontSize: 12 }}>{row.patientId || '—'}</span>
                   {row.patientId && <CopyIdButton id={row.patientId} />}
@@ -301,12 +300,6 @@ function ExpandedPanel({ row, expectedLoaded, colSpan, popDescriptions, definedP
                 <div className={styles.kvRow}>
                   <span className={styles.kvKey}>Error</span>
                   <span className={styles.errorText}>{row.errorMessage || row.error}</span>
-                </div>
-              )}
-              {missDiff && (
-                <div className={`${styles.kvRow} ${styles.kvRowDiff}`}>
-                  <span className={`${styles.kvKey} ${styles.kvKeyErr}`}>Diff</span>
-                  <span className={styles.diffText}>{missDiff}</span>
                 </div>
               )}
             </div>
@@ -387,7 +380,7 @@ export default function ResultsPage() {
   const { jobId: routeJobId } = useParams();
   const navigate = useNavigate();
   const toast = useToast();
-  const { query } = useSearch();
+  const { query, setQuery } = useSearch();
 
   const [jobs, setJobs] = useState([]);
   const [selectedJobId, setSelectedJobId] = useState(routeJobId || '');
@@ -445,18 +438,19 @@ export default function ResultsPage() {
     setError(null);
     setExpandedId(null);
     try {
-      const [resultsData, cmpData] = await Promise.all([
-        getResults(selectedJobId),
-        getJobComparison(selectedJobId).catch(() => null),
-      ]);
+      const promises = [getResults(selectedJobId)];
+      if (adminSettings.comparison_enabled) {
+        promises.push(getJobComparison(selectedJobId).catch(() => null));
+      }
+      const [resultsData, cmpData = null] = await Promise.all(promises);
       setResults(resultsData);
-      setComparisonData(cmpData);
+      setComparisonData(adminSettings.comparison_enabled ? cmpData : null);
     } catch (err) {
       setError(err.message || 'Error loading results');
     } finally {
       setLoading(false);
     }
-  }, [selectedJobId]);
+  }, [selectedJobId, adminSettings.comparison_enabled]);
 
   useEffect(() => { loadResults(); }, [loadResults]);
 
@@ -537,9 +531,9 @@ export default function ResultsPage() {
     const ref = `Patient/${r.patient_id}`;
     const cmp = compareByRef.get(ref);
     const errorPhase = r.error_phase;
-    const phaseLabel = errorPhase === 'gather'         ? 'gather failed'
-      : errorPhase === 'gather_partial' ? 'partial data'
-      : errorPhase === 'evaluate'       ? 'eval failed'
+    const phaseLabel = errorPhase === 'gather'         ? "Couldn't fetch patient data"
+      : errorPhase === 'gather_partial' ? 'Some data missing'
+      : errorPhase === 'evaluate'       ? 'Calculation failed'
       : (r.populations?.error === true || r.status === 'error') ? 'error'
       : null;
     return {
@@ -563,7 +557,9 @@ export default function ResultsPage() {
     : allRows;
 
   // Chip counts
-  const failures   = allRows.filter(isFailure).length;
+  const failures    = allRows.filter(isFailure).length;
+  const errorCount  = allRows.filter(r => r.error !== null).length;
+  const missCount   = allRows.filter(r => r.error === null && r.match === false).length;
 
   useEffect(() => {
     if (loading) return;
@@ -618,9 +614,15 @@ export default function ResultsPage() {
   // Column count for colSpan in expanded rows
   const colCount = showStatusCol ? 5 : 4;
 
+  const CHIP_LABEL = {
+    failures: 'Failures', all: 'All patients', num: 'In numerator',
+    denom: 'Denom only', excl: 'Excluded', notden: 'Not in denom',
+  };
+
   const CHIP_DEFS = expectedLoaded
     ? [
-        { id: 'failures', label: 'Failures',    count: chipCounts.failures, danger: true },
+        { id: 'failures', label: 'Failures', count: chipCounts.failures, danger: true,
+          detail: errorCount > 0 && missCount > 0 ? `${errorCount} err · ${missCount} miss` : null },
         { id: 'all',      label: 'All patients', count: chipCounts.all },
         { id: 'num',      label: 'In numerator', count: chipCounts.num },
         { id: 'denom',    label: 'Denom only',   count: chipCounts.denom },
@@ -800,18 +802,21 @@ export default function ResultsPage() {
 
             {/* Legend strip */}
             {expectedLoaded && (
-              <div className={styles.legendStrip}>
-                <span className={styles.legendLabel}>Comparing actual results to expected fixture · per-patient verdict:</span>
-                <span className={styles.legendItem}>
-                  <StatusPill kind="match">match</StatusPill>
-                  <span className={styles.legendDesc}>all 5 populations agree</span>
-                </span>
-                <span className={styles.legendItem}>
-                  <StatusPill kind="miss">mismatch · Denom</StatusPill>
-                  <span className={styles.legendDesc}>disagrees on listed population(s)</span>
-                </span>
-                <span className={styles.legendHint}>IP · Denom · Denom Exclusion · Numer · Numer Exclusion</span>
-              </div>
+              <details className={styles.legendDetails}>
+                <summary className={styles.legendSummary}>How to read results ▸</summary>
+                <div className={styles.legendStrip}>
+                  <span className={styles.legendLabel}>Per-patient verdict comparing actual vs. expected fixture:</span>
+                  <span className={styles.legendItem}>
+                    <StatusPill kind="match">✓ match</StatusPill>
+                    <span className={styles.legendDesc}>all 5 populations agree</span>
+                  </span>
+                  <span className={styles.legendItem}>
+                    <StatusPill kind="miss">! N mismatched</StatusPill>
+                    <span className={styles.legendDesc}>N populations differ — click row for breakdown</span>
+                  </span>
+                  <span className={styles.legendHint}>IP · Denom · DnEx · Numer · NmEx</span>
+                </div>
+              </details>
             )}
 
             {/* Table */}
@@ -829,9 +834,18 @@ export default function ResultsPage() {
                 {visibleRows.length === 0 ? (
                   <tr>
                     <td colSpan={colCount} className={styles.emptyRow}>
-                      {q
-                        ? `No patients match "${q}".`
-                        : 'No patients match this filter.'}
+                      <div>
+                        {q
+                          ? `No patients match "${q}".`
+                          : `No patients in '${CHIP_LABEL[activeFilter] || activeFilter}'.`}
+                      </div>
+                      <button
+                        className={styles.clearFiltersBtn}
+                        onClick={() => { setFilter('all'); setQuery(''); }}
+                        type="button"
+                      >
+                        Clear filters
+                      </button>
                     </td>
                   </tr>
                 ) : (
@@ -843,8 +857,15 @@ export default function ResultsPage() {
                     // Status pill content
                     let pill = null;
                     if (isError) {
-                      const errTitle = row.errorMessage ? row.errorMessage.slice(0, 200) : row.error;
-                      pill = <StatusPill kind="error" title={errTitle}>⚠ {row.error}</StatusPill>;
+                      const excerpt = row.errorMessage
+                        ? row.errorMessage.slice(0, 60) + (row.errorMessage.length > 60 ? '…' : '')
+                        : null;
+                      pill = (
+                        <span className={styles.errorPillGroup}>
+                          <StatusPill kind="error">⚠ {row.error}</StatusPill>
+                          {excerpt && <span className={styles.errorExcerpt}>{excerpt}</span>}
+                        </span>
+                      );
                     } else if (expectedLoaded) {
                       if (row.match === true) {
                         pill = (
@@ -853,25 +874,23 @@ export default function ResultsPage() {
                           </StatusPill>
                         );
                       } else if (row.match === false) {
-                        const diffCodes = row.mismatches && row.mismatches.length > 0
-                          ? row.mismatches.map(m => {
-                              if (m === 'initial-population')     return 'IP';
-                              if (m === 'denominator')            return 'Denom';
-                              if (m === 'denominator-exclusion')  return 'DnEx';
-                              if (m === 'numerator')              return 'Numer';
-                              if (m === 'numerator-exclusion')    return 'NmEx';
-                              return m;
-                            }).join(', ')
-                          : POP_BREAKDOWN
-                              .filter(({ key }) => (row.act[key] ?? 0) !== (row.exp?.[key] ?? 0))
-                              .map(({ key }) => key === 'ip' ? 'IP' : key === 'den' ? 'Denom' : key === 'denExc' ? 'DnEx' : key === 'num' ? 'Numer' : 'NmEx')
-                              .join(', ');
+                        const mismatchCount = row.mismatches?.length > 0
+                          ? row.mismatches.length
+                          : POP_BREAKDOWN.filter(({ key }) => (row.act[key] ?? 0) !== (row.exp?.[key] ?? 0)).length;
+                        const diffCodes = row.mismatches?.map(m => {
+                          if (m === 'initial-population')     return 'IP';
+                          if (m === 'denominator')            return 'Denom';
+                          if (m === 'denominator-exclusion')  return 'DnEx';
+                          if (m === 'numerator')              return 'Numer';
+                          if (m === 'numerator-exclusion')    return 'NmEx';
+                          return m;
+                        }).join(', ') || null;
                         pill = (
                           <StatusPill
                             kind="miss"
-                            title={`Calculated result disagrees with fixture on: ${diffCodes}. Click row to see actual vs expected per population.`}
+                            title={diffCodes ? `Disagrees on: ${diffCodes}. Click row to see breakdown.` : 'Click row to see breakdown.'}
                           >
-                            ! mismatch{diffCodes ? ` · ${diffCodes}` : ''}
+                            ! {mismatchCount} mismatched
                           </StatusPill>
                         );
                       }
@@ -888,6 +907,15 @@ export default function ResultsPage() {
                         <tr
                           className={rowCls}
                           onClick={() => setExpandedId(isExpanded ? null : row.resultId)}
+                          tabIndex={0}
+                          role="button"
+                          aria-expanded={isExpanded}
+                          onKeyDown={(e) => {
+                            if (e.key === ' ' || e.key === 'Enter') {
+                              e.preventDefault();
+                              setExpandedId(isExpanded ? null : row.resultId);
+                            }
+                          }}
                         >
                           <td>
                             <span className={styles.expandToggle}>

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -1,12 +1,14 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './ResultsPage.module.css';
-import { getJobs, getResults, getResult, createJob, getMeasureReportBundle } from '../api/client';
+import {
+  getJobs, getResults, createJob, getMeasureReportBundle,
+  getJobComparison, getAdminSettings, getEvaluatedResources,
+} from '../api/client';
 import { useToast } from '../components/Toast';
-import PatientDetail from '../components/PatientDetail';
-import ComparisonView from '../components/ComparisonView';
+import PopulationDots from '../components/PopulationDots';
 import DistBar from '../components/DistBar';
-import { CheckIcon, XIcon } from '../components/Icons';
+import { CheckIcon, WarnIcon } from '../components/Icons';
 import { useSearch } from '../contexts/SearchContext';
 import { extractCmsId, cleanMeasureName, measureOptionLabel, measureDisplayLabel } from '../utils/measureFormat';
 
@@ -20,7 +22,7 @@ function timeAgo(dateStr) {
 }
 
 function exportCsv(patients, measureId, measureName, period) {
-  const header = ['Patient ID', 'Name', 'Initial Population', 'Denominator', 'Numerator', 'Denom Exclusion'];
+  const header = ['Patient ID', 'Name', 'Initial Population', 'Denominator', 'Numerator', 'Denom Exclusion', 'Numer Exclusion'];
   const rows = patients.map(p => [
     p.patient_id || p.id || '',
     p.patient_name || p.name || '',
@@ -28,6 +30,7 @@ function exportCsv(patients, measureId, measureName, period) {
     p.populations?.denominator ? 'Yes' : 'No',
     p.populations?.numerator ? 'Yes' : 'No',
     p.populations?.denominator_exclusion ? 'Yes' : 'No',
+    p.populations?.numerator_exclusion ? 'Yes' : 'No',
   ]);
   const csv = [header, ...rows].map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
   const blob = new Blob([csv], { type: 'text/csv' });
@@ -41,25 +44,344 @@ function exportCsv(patients, measureId, measureName, period) {
   URL.revokeObjectURL(url);
 }
 
-const FILTER_OPTIONS = [
-  { value: 'all', label: 'All Patients' },
-  { value: 'numerator', label: 'In Numerator' },
-  { value: 'denominator_only', label: 'Denominator (not Numerator)' },
-  { value: 'excluded', label: 'Denominator Exclusion' },
-  { value: 'not_in_denominator', label: 'Not in Denominator' },
+/**
+ * Map server-side population shape to normalized PopulationCounts.
+ * Handles both underscore keys (from /results) and hyphen keys (from /jobs/:id/comparison).
+ * @returns {{ ip: 0|1, den: 0|1, denExc: 0|1, num: 0|1, numExc: 0|1 }}
+ */
+function toCounts(populations) {
+  if (!populations) return { ip: 0, den: 0, denExc: 0, num: 0, numExc: 0 };
+  return {
+    ip:     (populations.initial_population     || populations['initial-population'])     ? 1 : 0,
+    den:    populations.denominator                                                       ? 1 : 0,
+    denExc: (populations.denominator_exclusion  || populations['denominator-exclusion'])  ? 1 : 0,
+    num:    populations.numerator                                                         ? 1 : 0,
+    numExc: (populations.numerator_exclusion    || populations['numerator-exclusion'])    ? 1 : 0,
+  };
+}
+
+const POP_BREAKDOWN = [
+  { key: 'ip',     label: 'Initial Population',    apiKey: 'initial-population' },
+  { key: 'den',    label: 'Denominator',           apiKey: 'denominator' },
+  { key: 'denExc', label: 'Denominator Exclusion', apiKey: 'denominator-exclusion' },
+  { key: 'num',    label: 'Numerator',             apiKey: 'numerator' },
+  { key: 'numExc', label: 'Numerator Exclusion',   apiKey: 'numerator-exclusion' },
 ];
 
-function applyFilter(patients, filter) {
-  if (filter === 'all') return patients;
-  return patients.filter(p => {
-    const pop = p.populations || {};
-    if (filter === 'numerator') return pop.numerator;
-    if (filter === 'denominator_only') return pop.denominator && !pop.numerator;
-    if (filter === 'excluded') return pop.denominator_exclusion;
-    if (filter === 'not_in_denominator') return !pop.denominator;
-    return true;
-  });
+function isFailure(row) {
+  return row.error !== null || row.match === false;
 }
+
+function translateResource(resource) {
+  if (!resource) return null;
+  const type = resource.resourceType;
+  if (type === 'Observation') {
+    const code = resource.code?.coding?.[0]?.display || resource.code?.text || 'Observation';
+    const value = resource.valueQuantity
+      ? `${resource.valueQuantity.value}${resource.valueQuantity.unit ? ' ' + resource.valueQuantity.unit : ''}`
+      : resource.valueCodeableConcept?.text || resource.valueString || '';
+    const date = resource.effectiveDateTime || resource.issued || '';
+    const dateStr = date ? ` (${new Date(date).toLocaleDateString()})` : '';
+    return { label: code, value: `${value}${dateStr}` };
+  }
+  if (type === 'Condition') {
+    const name = resource.code?.coding?.[0]?.display || resource.code?.text || 'Condition';
+    const status = resource.clinicalStatus?.coding?.[0]?.code || '';
+    const onset = resource.onsetDateTime || '';
+    const onsetStr = onset ? ` since ${new Date(onset).toLocaleDateString()}` : '';
+    return { label: 'Diagnosis', value: `${name} (${status}${onsetStr})` };
+  }
+  if (type === 'Procedure') {
+    const name = resource.code?.coding?.[0]?.display || resource.code?.text || 'Procedure';
+    const date = resource.performedDateTime || resource.performedPeriod?.start || '';
+    const dateStr = date ? ` (${new Date(date).toLocaleDateString()})` : '';
+    return { label: 'Procedure', value: `${name}${dateStr}` };
+  }
+  if (type === 'Encounter') {
+    const encType = resource.type?.[0]?.coding?.[0]?.display || resource.type?.[0]?.text || 'Encounter';
+    const date = resource.period?.start || '';
+    const dateStr = date ? ` (${new Date(date).toLocaleDateString()})` : '';
+    return { label: 'Encounter', value: `${encType}${dateStr}` };
+  }
+  if (type === 'MedicationRequest') {
+    const med = resource.medicationCodeableConcept?.coding?.[0]?.display || resource.medicationCodeableConcept?.text || 'Medication';
+    const date = resource.authoredOn || '';
+    const dateStr = date ? ` (${new Date(date).toLocaleDateString()})` : '';
+    return { label: 'Medication', value: `${med}${dateStr}` };
+  }
+  const display = resource.code?.coding?.[0]?.display || resource.code?.text || type || 'Resource';
+  return { label: type || 'Resource', value: display };
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function TruncatedId({ id }) {
+  const [copied, setCopied] = useState(false);
+  if (!id) return <span className={styles.mono} style={{ fontSize: 12 }}>—</span>;
+  const short = id.length > 14 ? `${id.slice(0, 8)}…${id.slice(-6)}` : id;
+  const copy = (e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(id).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+  return (
+    <button className={styles.idCopyBtn} title={id} onClick={copy} type="button">
+      {copied ? 'copied' : short}
+    </button>
+  );
+}
+
+function CopyIdButton({ id }) {
+  const [copied, setCopied] = useState(false);
+  if (!id) return null;
+  const copy = (e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(id).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+  return (
+    <button className={styles.copyIconBtn} title="Copy FHIR ID" onClick={copy} type="button" aria-label="Copy FHIR ID">
+      {copied
+        ? <span style={{ fontSize: 10, color: 'var(--accent)' }}>✓</span>
+        : <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="4" y="4" width="7" height="7" rx="1.2" />
+            <path d="M8 4V2.5A1.5 1.5 0 006.5 1H2.5A1.5 1.5 0 001 2.5v4A1.5 1.5 0 002.5 8H4" />
+          </svg>
+      }
+    </button>
+  );
+}
+
+function StatusPill({ kind, children, title }) {
+  const cls = kind === 'match' ? styles.pillMatch
+    : kind === 'miss'  ? styles.pillMiss
+    : kind === 'error' ? styles.pillError
+    : styles.pillNeutral;
+  return (
+    <span className={`${styles.pill} ${cls}`} title={title} style={{ cursor: title ? 'help' : undefined }}>
+      {children}
+    </span>
+  );
+}
+
+function FilterChip({ chipId, label, count, active, danger, onClick }) {
+  const cls = [
+    styles.chip,
+    active && danger ? styles.chipDangerActive : active ? styles.chipActive : '',
+  ].filter(Boolean).join(' ');
+  return (
+    <button className={cls} onClick={() => onClick(chipId)} aria-pressed={active}>
+      {label}
+      {count != null && <span className={styles.chipCount}>{count}</span>}
+    </button>
+  );
+}
+
+function PopDesc({ text }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!text) return null;
+  return (
+    <button
+      className={`${styles.popDesc} ${expanded ? styles.popDescExpanded : ''}`}
+      onClick={e => { e.stopPropagation(); setExpanded(v => !v); }}
+      type="button"
+      title={expanded ? undefined : text}
+    >
+      {text}
+    </button>
+  );
+}
+
+function ExpandedPanel({ row, expectedLoaded, colSpan, popDescriptions, definedPops }) {
+  const [resources, setResources] = useState(null);
+  const [resLoading, setResLoading] = useState(true);
+  const [resError, setResError] = useState(null);
+  const [showRawFhir, setShowRawFhir] = useState(false);
+  const [expandedRaw, setExpandedRaw] = useState({});
+
+  useEffect(() => {
+    if (!row.resultId) return;
+    setResLoading(true);
+    setResError(null);
+    getEvaluatedResources(row.resultId)
+      .then(data => setResources(data))
+      .catch(err => setResError(err.message || 'Failed to load'))
+      .finally(() => setResLoading(false));
+  }, [row.resultId]);
+
+  const missDiff = !row.error && expectedLoaded && row.match === false && row.exp
+    ? POP_BREAKDOWN
+        .filter(({ key }) => (row.act[key] ?? 0) !== (row.exp[key] ?? 0))
+        .map(({ key, label }) => `${label}: ${row.exp[key]}→${row.act[key]}`)
+        .join(' · ')
+    : null;
+
+  const verdictPill = row.error
+    ? <StatusPill kind="error">{row.error}</StatusPill>
+    : !expectedLoaded
+      ? null
+      : row.match
+        ? <StatusPill kind="match">match</StatusPill>
+        : <StatusPill kind="miss">mismatch</StatusPill>;
+
+  const resourceList = Array.isArray(resources) ? resources : (resources?.resources || []);
+
+  return (
+    <tr className={styles.expandedRow}>
+      <td colSpan={colSpan}>
+        <div className={styles.expandedInner}>
+          {/* Left: population breakdown */}
+          <div className={styles.miniCard}>
+            <div className={styles.miniHead}>
+              <span>Population breakdown</span>
+              {verdictPill}
+            </div>
+            <table className={styles.miniTable}>
+              <thead>
+                <tr>
+                  <th>Population</th>
+                  <th className={styles.numCell}>Actual</th>
+                  {expectedLoaded && <th className={styles.numCell}>Expected</th>}
+                  {expectedLoaded && <th className={styles.numCell}></th>}
+                </tr>
+              </thead>
+              <tbody>
+                {POP_BREAKDOWN.filter(({ apiKey }) =>
+                  !definedPops || definedPops.includes(apiKey)
+                ).map(({ key, label, apiKey }) => {
+                  const a = row.act[key] ?? 0;
+                  const e = row.exp != null ? (row.exp[key] ?? 0) : null;
+                  const ok = !expectedLoaded || row.error || a === e;
+                  const desc = popDescriptions?.[apiKey] || null;
+                  return (
+                    <tr key={key} className={!ok ? styles.miniRowMiss : ''}>
+                      <td>
+                        <div>{label}</div>
+                        <PopDesc text={desc} />
+                      </td>
+                      <td className={`${styles.numCell} ${!ok ? styles.numCellMiss : ''}`}>{a}</td>
+                      {expectedLoaded && (
+                        <td className={styles.numCell}>{row.error ? '—' : (e ?? '—')}</td>
+                      )}
+                      {expectedLoaded && (
+                        <td className={styles.numCell}>
+                          {!row.error && (ok
+                            ? <CheckIcon className={styles.iconOk} />
+                            : <WarnIcon className={styles.iconErr} />
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Right: patient context + evaluated resources */}
+          <div className={styles.miniCard}>
+            <div className={styles.miniHead}>
+              <span>Patient context</span>
+            </div>
+            <div className={styles.kvBody}>
+              <div className={styles.kvRow}>
+                <span className={styles.kvKey}>Patient</span>
+                <b>{row.name || '—'}</b>
+              </div>
+              <div className={styles.kvRow}>
+                <span className={styles.kvKey}>FHIR ID</span>
+                <span className={styles.kvIdRow}>
+                  <span className={styles.mono} style={{ fontSize: 12 }}>{row.patientId || '—'}</span>
+                  {row.patientId && <CopyIdButton id={row.patientId} />}
+                </span>
+              </div>
+              {row.error && (
+                <div className={styles.kvRow}>
+                  <span className={styles.kvKey}>Error</span>
+                  <span className={styles.errorText}>{row.errorMessage || row.error}</span>
+                </div>
+              )}
+              {missDiff && (
+                <div className={`${styles.kvRow} ${styles.kvRowDiff}`}>
+                  <span className={`${styles.kvKey} ${styles.kvKeyErr}`}>Diff</span>
+                  <span className={styles.diffText}>{missDiff}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Evaluated resources */}
+            <div className={styles.resSection}>
+              <div className={styles.resSectionHead}>
+                <span>Evaluated resources</span>
+                {!resLoading && !resError && resourceList.length > 0 && (
+                  <button
+                    className={styles.rawFhirToggle}
+                    onClick={() => setShowRawFhir(v => !v)}
+                    type="button"
+                  >
+                    {showRawFhir ? 'Clinical view' : 'Raw FHIR'}
+                  </button>
+                )}
+              </div>
+
+              {resLoading && (
+                <div className={styles.resList}>
+                  {[1, 2, 3].map(i => <div key={i} className={styles.resSkeleton} />)}
+                </div>
+              )}
+
+              {resError && (
+                <div className={styles.resEmpty}>Clinical data unavailable.</div>
+              )}
+
+              {!resLoading && !resError && !showRawFhir && (
+                <div className={styles.resList}>
+                  {resourceList.length === 0
+                    ? <div className={styles.resEmpty}>No evaluated resources.</div>
+                    : resourceList.map((res, i) => {
+                        const t = translateResource(res);
+                        if (!t) return null;
+                        return (
+                          <div key={i} className={styles.resRow}>
+                            <span className={styles.resLabel}>{t.label}</span>
+                            <span className={styles.resValue}>{t.value}</span>
+                          </div>
+                        );
+                      })
+                  }
+                </div>
+              )}
+
+              {!resLoading && !resError && showRawFhir && (
+                <div className={styles.resList}>
+                  {resourceList.map((res, i) => (
+                    <div key={i} className={styles.rawBlock}>
+                      <button
+                        className={styles.rawToggle}
+                        onClick={() => setExpandedRaw(p => ({ ...p, [i]: !p[i] }))}
+                        type="button"
+                      >
+                        <span>{expandedRaw[i] ? '▾' : '▸'}</span>
+                        <span>{res.resourceType || 'Resource'}{res.id ? `/${res.id}` : ''}</span>
+                      </button>
+                      {expandedRaw[i] && (
+                        <pre className={styles.rawJson}>{JSON.stringify(res, null, 2)}</pre>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function ResultsPage() {
   const { jobId: routeJobId } = useParams();
@@ -70,15 +392,26 @@ export default function ResultsPage() {
   const [jobs, setJobs] = useState([]);
   const [selectedJobId, setSelectedJobId] = useState(routeJobId || '');
   const [results, setResults] = useState(null);
+  const [comparisonData, setComparisonData] = useState(null);
+  const [adminSettings, setAdminSettings] = useState({ comparison_enabled: false, validation_enabled: false });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [selectedPatient, setSelectedPatient] = useState(null);
-  const [patientDetail, setPatientDetail] = useState(null);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [populationFilter, setPopulationFilter] = useState('all');
+  const [expandedId, setExpandedId] = useState(null);
+  const [filter, setFilter] = useState('all');
   const [rerunning, setRerunning] = useState(false);
   const [bundleDownloading, setBundleDownloading] = useState(false);
 
+  const filterInitRef = useRef(null);
+
+  // Admin settings
+  useEffect(() => {
+    getAdminSettings().then(setAdminSettings).catch(() => {});
+    const h = (e) => setAdminSettings(e.detail);
+    window.addEventListener('admin-settings-changed', h);
+    return () => window.removeEventListener('admin-settings-changed', h);
+  }, []);
+
+  // Jobs list
   useEffect(() => {
     async function loadJobs() {
       try {
@@ -105,13 +438,19 @@ export default function ResultsPage() {
     loadJobs();
   }, [navigate, routeJobId, selectedJobId]);
 
+  // Results + comparison
   const loadResults = useCallback(async () => {
-    if (!selectedJobId) { setResults(null); setLoading(false); return; }
+    if (!selectedJobId) { setResults(null); setComparisonData(null); setLoading(false); return; }
     setLoading(true);
     setError(null);
+    setExpandedId(null);
     try {
-      const data = await getResults(selectedJobId);
-      setResults(data);
+      const [resultsData, cmpData] = await Promise.all([
+        getResults(selectedJobId),
+        getJobComparison(selectedJobId).catch(() => null),
+      ]);
+      setResults(resultsData);
+      setComparisonData(cmpData);
     } catch (err) {
       setError(err.message || 'Error loading results');
     } finally {
@@ -121,34 +460,15 @@ export default function ResultsPage() {
 
   useEffect(() => { loadResults(); }, [loadResults]);
 
+  // Derived: expectedLoaded
+  const expectedLoaded = adminSettings.comparison_enabled && !!comparisonData?.has_expected;
+
+
   const handleJobChange = (e) => {
     const id = e.target.value;
     setSelectedJobId(id);
-    setPopulationFilter('all');
     navigate(`/results/${id}`, { replace: true });
   };
-
-  const handleViewPatient = async (patient) => {
-    setSelectedPatient(patient);
-    if (patient.result_id || patient.id) {
-      setDetailLoading(true);
-      try {
-        const detail = await getResult(patient.result_id || patient.id);
-        setPatientDetail(detail);
-      } catch {
-        setPatientDetail(patient);
-      } finally {
-        setDetailLoading(false);
-      }
-    } else {
-      setPatientDetail(patient);
-    }
-  };
-
-  const closeDetail = useCallback(() => {
-    setSelectedPatient(null);
-    setPatientDetail(null);
-  }, []);
 
   const handleRerun = async () => {
     if (!selectedJob) return;
@@ -181,10 +501,10 @@ export default function ResultsPage() {
       const a = document.createElement('a');
       a.href = url;
       const mid = (selectedJob?.measure_id || 'measure').replace(/[^a-zA-Z0-9-_]/g, '-');
-      const period = selectedJob?.period_start && selectedJob?.period_end
+      const periodStr = selectedJob?.period_start && selectedJob?.period_end
         ? `${selectedJob.period_start}-to-${selectedJob.period_end}`
         : 'unknown-period';
-      a.download = `measure-report-${mid}-${period}-job-${selectedJobId}.json`;
+      a.download = `measure-report-${mid}-${periodStr}-job-${selectedJobId}.json`;
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {
@@ -194,32 +514,131 @@ export default function ResultsPage() {
     }
   };
 
+  // ─── Derived data ───────────────────────────────────────────────────────────
+
   const selectedJob = jobs.find(j => String(j.id) === String(selectedJobId));
   const populations = results?.populations || {};
-  const allPatients = results?.patients || [];
-  const patients = applyFilter(allPatients, populationFilter);
-  const measureName = results?.measure_name || selectedJob?.measure_name || selectedJob?.measure_id || '';
-  const period = selectedJob?.period_start && selectedJob?.period_end
-    ? `${selectedJob.period_start} → ${selectedJob.period_end}` : '';
-
-  const ip = populations.initial_population;
+  const ip  = populations.initial_population;
   const den = populations.denominator;
   const num = populations.numerator;
   const exc = populations.denominator_exclusion;
   const perfRate = results?.performance_rate;
+  const measureName = results?.measure_name || selectedJob?.measure_name || selectedJob?.measure_id || '';
+  const period = selectedJob?.period_start && selectedJob?.period_end
+    ? `${selectedJob.period_start} → ${selectedJob.period_end}` : '';
+  const completedAgo = selectedJob?.completed_at ? timeAgo(selectedJob.completed_at) : null;
 
-  const q = query.trim().toLowerCase();
-  const filteredPatients = patients.filter(p => {
-    if (!q) return true;
-    const name = (p.patient_name || p.name || '').toLowerCase();
-    const id = (p.patient_id || p.id || '').toLowerCase();
-    return name.includes(q) || id.includes(q);
+  // Build rows (actuals + comparison join)
+  const compareByRef = comparisonData?.patients
+    ? new Map(comparisonData.patients.map(p => [p.subject_reference, p]))
+    : new Map();
+
+  const allRows = (results?.patients || []).map(r => {
+    const ref = `Patient/${r.patient_id}`;
+    const cmp = compareByRef.get(ref);
+    const errorPhase = r.error_phase;
+    const phaseLabel = errorPhase === 'gather'         ? 'gather failed'
+      : errorPhase === 'gather_partial' ? 'partial data'
+      : errorPhase === 'evaluate'       ? 'eval failed'
+      : (r.populations?.error === true || r.status === 'error') ? 'error'
+      : null;
+    return {
+      resultId:    r.id,
+      patientId:   r.patient_id,
+      name:        r.patient_name || r.name || '',
+      error:       phaseLabel,
+      errorMessage: r.error_message || null,
+      act:         toCounts(r.populations),
+      exp:         cmp?.expected ? toCounts(cmp.expected) : undefined,
+      match:       cmp ? cmp.match : undefined,
+      mismatches:  cmp?.mismatches || [],
+    };
   });
 
-  const completedAgo = selectedJob?.completed_at ? timeAgo(selectedJob.completed_at) : null;
+  const showStatusCol = expectedLoaded || allRows.some(r => r.error !== null);
+
+  // Sort: failures first when expectedLoaded
+  const sortedRows = expectedLoaded
+    ? [...allRows].sort((a, b) => Number(!isFailure(a)) - Number(!isFailure(b)))
+    : allRows;
+
+  // Chip counts
+  const failures   = allRows.filter(isFailure).length;
+
+  useEffect(() => {
+    if (loading) return;
+    if (filterInitRef.current === selectedJobId) return;
+    filterInitRef.current = selectedJobId;
+    setFilter(expectedLoaded && failures > 0 ? 'failures' : 'all');
+  }, [loading, selectedJobId, expectedLoaded, failures]);
+
+  const chipCounts = {
+    all:    allRows.length,
+    failures,
+    num:    allRows.filter(r => r.act.num).length,
+    denom:  allRows.filter(r => r.act.den && !r.act.num).length,
+    excl:   allRows.filter(r => r.act.denExc).length,
+    notden: allRows.filter(r => !r.act.den).length,
+  };
+
+  // Normalize filter: if chip isn't in current list, fall back to 'all'
+  const chips = expectedLoaded
+    ? ['failures', 'all', 'num', 'denom', 'excl']
+    : ['all', 'num', 'denom', 'excl', 'notden'];
+  const activeFilter = chips.includes(filter) ? filter : 'all';
+
+  // Apply filter
+  const filteredRows = sortedRows.filter(row => {
+    switch (activeFilter) {
+      case 'failures': return isFailure(row);
+      case 'num':      return row.act.num;
+      case 'denom':    return row.act.den && !row.act.num;
+      case 'excl':     return row.act.denExc;
+      case 'notden':   return !row.act.den;
+      default:         return true;
+    }
+  });
+
+  // Search
+  const q = query.trim().toLowerCase();
+  const visibleRows = filteredRows.filter(row => {
+    if (!q) return true;
+    return row.name.toLowerCase().includes(q) || (row.patientId || '').toLowerCase().includes(q);
+  });
+
+  // Patients card header pill — only show comparison language when comparison is enabled
+  const headerPill = !adminSettings.comparison_enabled
+    ? null
+    : expectedLoaded
+      ? failures > 0
+        ? <StatusPill kind="miss">{failures} need review</StatusPill>
+        : <StatusPill kind="match">All match expected</StatusPill>
+      : <StatusPill kind="neutral">actual only · no expected loaded</StatusPill>;
+
+  // Column count for colSpan in expanded rows
+  const colCount = showStatusCol ? 5 : 4;
+
+  const CHIP_DEFS = expectedLoaded
+    ? [
+        { id: 'failures', label: 'Failures',    count: chipCounts.failures, danger: true },
+        { id: 'all',      label: 'All patients', count: chipCounts.all },
+        { id: 'num',      label: 'In numerator', count: chipCounts.num },
+        { id: 'denom',    label: 'Denom only',   count: chipCounts.denom },
+        { id: 'excl',     label: 'Excluded',     count: chipCounts.excl },
+      ]
+    : [
+        { id: 'all',    label: 'All patients',  count: chipCounts.all },
+        { id: 'num',    label: 'In numerator',  count: chipCounts.num },
+        { id: 'denom',  label: 'Denom only',    count: chipCounts.denom },
+        { id: 'excl',   label: 'Excluded',      count: chipCounts.excl },
+        { id: 'notden', label: 'Not in denom',  count: chipCounts.notden },
+      ];
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
 
   return (
     <div className={styles.page}>
+      {/* Page header */}
       <div className={styles.pageHeader}>
         <div>
           {measureName && <div className={styles.eyebrow}>{measureDisplayLabel(selectedJob?.measure_id, measureName)}</div>}
@@ -249,15 +668,15 @@ export default function ResultsPage() {
             <>
               <button
                 className={styles.btnGhost}
-                onClick={() => exportCsv(allPatients, selectedJob?.measure_id, measureName, period)}
-                disabled={allPatients.length === 0}
+                onClick={() => exportCsv(results.patients || [], selectedJob?.measure_id, measureName, period)}
+                disabled={(results.patients || []).length === 0}
               >
                 Export CSV
               </button>
               <button
                 className={styles.btnGhost}
                 onClick={handleDownloadBundle}
-                disabled={allPatients.length === 0 || bundleDownloading}
+                disabled={(results.patients || []).length === 0 || bundleDownloading}
                 aria-busy={bundleDownloading}
               >
                 {bundleDownloading ? 'Downloading…' : 'Download FHIR JSON'}
@@ -277,6 +696,7 @@ export default function ResultsPage() {
         </div>
       </div>
 
+      {/* Loading skeleton */}
       {loading && (
         <div role="status" aria-label="Loading results">
           <div className={styles.cardsRow}>
@@ -285,6 +705,7 @@ export default function ResultsPage() {
         </div>
       )}
 
+      {/* Error */}
       {!loading && error && (
         <div className={styles.errorState} role="alert">
           <p>Error loading results</p>
@@ -293,6 +714,7 @@ export default function ResultsPage() {
         </div>
       )}
 
+      {/* Empty */}
       {!loading && !error && !selectedJobId && (
         <div className={styles.emptyState}>
           <p>No results yet.</p>
@@ -300,11 +722,11 @@ export default function ResultsPage() {
         </div>
       )}
 
+      {/* Content */}
       {!loading && !error && selectedJobId && results && (
         <>
-          {/* Top stat cards */}
+          {/* Stat cards */}
           <div className={styles.cardsRow}>
-            {/* Performance rate card */}
             <div className={styles.card}>
               <div className={styles.cardTopRow}>
                 <div>
@@ -324,7 +746,6 @@ export default function ResultsPage() {
               </div>
             </div>
 
-            {/* Populations card */}
             <div className={styles.card}>
               <div className={styles.cardTopRow}>
                 <div className={styles.cardEyebrow}>Populations</div>
@@ -355,100 +776,154 @@ export default function ResultsPage() {
             </div>
           </div>
 
-          {/* Patients table */}
-          <div className={styles.card}>
+          {/* Patients card */}
+          <div className={`${styles.card} ${styles.cardFlush}`}>
+            {/* Table header */}
             <div className={styles.tableHeader}>
               <span className={styles.tableTitle}>Patients</span>
-              <span className={styles.tableBadge}>
-                {filteredPatients.length !== allPatients.length
-                  ? `${filteredPatients.length} / ${allPatients.length}`
-                  : allPatients.length.toLocaleString()}
-              </span>
-              <div className={styles.tableActions}>
-                <select
-                  className={styles.filterSelect}
-                  value={populationFilter}
-                  onChange={e => setPopulationFilter(e.target.value)}
-                  aria-label="Filter by population"
-                >
-                  {FILTER_OPTIONS.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
+              <span className={styles.tableBadge}>{allRows.length.toLocaleString()}</span>
+              <span className={styles.headerPill}>{headerPill}</span>
+              <div className={styles.chipsRow}>
+                {CHIP_DEFS.map(c => (
+                  <FilterChip
+                    key={c.id}
+                    chipId={c.id}
+                    label={c.label}
+                    count={c.count}
+                    active={activeFilter === c.id}
+                    danger={c.danger}
+                    onClick={setFilter}
+                  />
+                ))}
               </div>
             </div>
+
+            {/* Legend strip */}
+            {expectedLoaded && (
+              <div className={styles.legendStrip}>
+                <span className={styles.legendLabel}>Comparing actual results to expected fixture · per-patient verdict:</span>
+                <span className={styles.legendItem}>
+                  <StatusPill kind="match">match</StatusPill>
+                  <span className={styles.legendDesc}>all 5 populations agree</span>
+                </span>
+                <span className={styles.legendItem}>
+                  <StatusPill kind="miss">mismatch · Denom</StatusPill>
+                  <span className={styles.legendDesc}>disagrees on listed population(s)</span>
+                </span>
+                <span className={styles.legendHint}>IP · Denom · Denom Exclusion · Numer · Numer Exclusion</span>
+              </div>
+            )}
+
+            {/* Table */}
             <table aria-label="Patient results">
               <thead>
                 <tr>
-                  <th style={{ width: 130 }}>Patient ID</th>
+                  <th style={{ width: 32 }}></th>
+                  <th style={{ width: 160 }}>Patient ID</th>
                   <th>Name</th>
-                  <th style={{ width: 80, textAlign: 'center' }}>Denom</th>
-                  <th style={{ width: 80, textAlign: 'center' }}>Numer</th>
-                  <th style={{ width: 80, textAlign: 'center' }}>Excl.</th>
+                  {showStatusCol && <th style={{ width: 140 }}>Status</th>}
+                  <th style={{ width: 340 }}>Population summary</th>
                 </tr>
               </thead>
               <tbody>
-                {filteredPatients.length === 0 ? (
-                  <tr><td colSpan={5} className={styles.emptyRow}>
-                    {q
-                      ? `No patients match "${q}".`
-                      : populationFilter !== 'all'
-                        ? 'No patients match this filter.'
-                        : 'No individual patient results available.'}
-                  </td></tr>
+                {visibleRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={colCount} className={styles.emptyRow}>
+                      {q
+                        ? `No patients match "${q}".`
+                        : 'No patients match this filter.'}
+                    </td>
+                  </tr>
                 ) : (
-                  filteredPatients.map((patient, i) => {
-                    const isError = patient.populations?.error === true || patient.status === 'error';
-                    const phase = patient.error_phase;
-                    const phaseLabel = phase === 'gather' ? 'gather failed'
-                      : phase === 'gather_partial' ? 'partial data'
-                      : phase === 'evaluate' ? 'eval failed'
-                      : isError ? 'error' : null;
+                  visibleRows.map(row => {
+                    const isExpanded = expandedId === row.resultId;
+                    const isMismatch = !row.error && expectedLoaded && row.match === false;
+                    const isError = row.error !== null;
+
+                    // Status pill content
+                    let pill = null;
+                    if (isError) {
+                      const errTitle = row.errorMessage ? row.errorMessage.slice(0, 200) : row.error;
+                      pill = <StatusPill kind="error" title={errTitle}>⚠ {row.error}</StatusPill>;
+                    } else if (expectedLoaded) {
+                      if (row.match === true) {
+                        pill = (
+                          <StatusPill kind="match" title="All 5 populations (IP, Denom, Denom Exclusion, Numer, Numer Exclusion) match the expected fixture for this patient.">
+                            ✓ match
+                          </StatusPill>
+                        );
+                      } else if (row.match === false) {
+                        const diffCodes = row.mismatches && row.mismatches.length > 0
+                          ? row.mismatches.map(m => {
+                              if (m === 'initial-population')     return 'IP';
+                              if (m === 'denominator')            return 'Denom';
+                              if (m === 'denominator-exclusion')  return 'DnEx';
+                              if (m === 'numerator')              return 'Numer';
+                              if (m === 'numerator-exclusion')    return 'NmEx';
+                              return m;
+                            }).join(', ')
+                          : POP_BREAKDOWN
+                              .filter(({ key }) => (row.act[key] ?? 0) !== (row.exp?.[key] ?? 0))
+                              .map(({ key }) => key === 'ip' ? 'IP' : key === 'den' ? 'Denom' : key === 'denExc' ? 'DnEx' : key === 'num' ? 'Numer' : 'NmEx')
+                              .join(', ');
+                        pill = (
+                          <StatusPill
+                            kind="miss"
+                            title={`Calculated result disagrees with fixture on: ${diffCodes}. Click row to see actual vs expected per population.`}
+                          >
+                            ! mismatch{diffCodes ? ` · ${diffCodes}` : ''}
+                          </StatusPill>
+                        );
+                      }
+                    }
+
+                    const rowCls = [
+                      styles.patientRow,
+                      isMismatch ? styles.rowMiss : '',
+                      isError    ? styles.rowError : '',
+                    ].filter(Boolean).join(' ');
+
                     return (
-                      <tr
-                        key={patient.patient_id || patient.id || i}
-                        className={`${styles.patientRow} ${isError ? styles.patientRowError : ''}`}
-                        onClick={() => handleViewPatient(patient)}
-                      >
-                        <td data-label="Patient ID"><span className={styles.mono}>{patient.patient_id || patient.id || '--'}</span></td>
-                        <td data-label="Name" className={styles.patientName}>
-                          {patient.patient_name || patient.name || '--'}
-                          {isError && <span className={styles.errorBadge}>Error</span>}
-                          {isError && phaseLabel && <span className={styles.errorPhaseLabel}>{phaseLabel}</span>}
-                          {!isError && phase === 'gather_partial' && <span className={styles.warnBadge}>Partial data</span>}
-                        </td>
-                        {isError ? (
-                          <>
-                            <td data-label="Denom" className={styles.popCell} colSpan={3}>
-                              <span className={styles.errorPhaseLabel} title={patient.error_message || ''}>
-                                {patient.error_message ? patient.error_message.slice(0, 60) : 'See details'}
-                              </span>
-                            </td>
-                          </>
-                        ) : (
-                          <>
-                            <td data-label="Denom" className={styles.popCell}>{patient.populations?.denominator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
-                            <td data-label="Numer" className={styles.popCell}>{patient.populations?.numerator ? <CheckIcon className={styles.iconOk} /> : <XIcon className={styles.iconDim} />}</td>
-                            <td data-label="Excl." className={styles.popCell}>{patient.populations?.denominator_exclusion ? <CheckIcon className={styles.iconWarn} /> : <XIcon className={styles.iconDim} />}</td>
-                          </>
+                      <React.Fragment key={row.resultId}>
+                        <tr
+                          className={rowCls}
+                          onClick={() => setExpandedId(isExpanded ? null : row.resultId)}
+                        >
+                          <td>
+                            <span className={styles.expandToggle}>
+                              {isExpanded
+                                ? <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"><path d="M2 4l3.5 3.5L9 4" /></svg>
+                                : <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"><path d="M4 2l3.5 3.5L4 9" /></svg>
+                              }
+                            </span>
+                          </td>
+                          <td className={styles.idCell}><TruncatedId id={row.patientId} /></td>
+                          <td className={styles.patientName}>{row.name || '—'}</td>
+                          {showStatusCol && <td>{pill}</td>}
+                          <td>
+                            <PopulationDots
+                              act={row.act}
+                              exp={expectedLoaded && !row.error ? row.exp : undefined}
+                            />
+                          </td>
+                        </tr>
+                        {isExpanded && (
+                          <ExpandedPanel
+                            row={row}
+                            expectedLoaded={expectedLoaded}
+                            colSpan={colCount}
+                            popDescriptions={results?.population_descriptions}
+                            definedPops={results?.defined_populations}
+                          />
                         )}
-                      </tr>
+                      </React.Fragment>
                     );
                   })
                 )}
               </tbody>
             </table>
           </div>
-
-          <ComparisonView jobId={selectedJobId} />
         </>
-      )}
-
-      {selectedPatient && (
-        <PatientDetail
-          result={detailLoading ? null : (patientDetail || selectedPatient)}
-          onClose={closeDetail}
-        />
       )}
     </div>
   );

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './ResultsPage.module.css';
 import {
@@ -182,18 +182,29 @@ function FilterChip({ chipId, label, count, detail, active, danger, onClick }) {
 
 function PopDesc({ text }) {
   const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      setIsClamped(ref.current.scrollHeight > ref.current.clientHeight);
+    }
+  }, [text]);
+
   if (!text) return null;
   return (
     <span className={styles.popDescWrap}>
       <button
+        ref={ref}
         className={`${styles.popDesc} ${expanded ? styles.popDescExpanded : ''}`}
-        onClick={e => { e.stopPropagation(); setExpanded(v => !v); }}
+        onClick={isClamped || expanded ? e => { e.stopPropagation(); setExpanded(v => !v); } : undefined}
         type="button"
         title={expanded ? undefined : text}
+        style={isClamped || expanded ? undefined : { cursor: 'default', pointerEvents: 'none' }}
       >
         {text}
       </button>
-      {!expanded && (
+      {!expanded && isClamped && (
         <span className={styles.popDescMore} aria-hidden="true">more ▾</span>
       )}
     </span>
@@ -534,7 +545,7 @@ export default function ResultsPage() {
     const phaseLabel = errorPhase === 'gather'         ? "Couldn't fetch patient data"
       : errorPhase === 'gather_partial' ? 'Some data missing'
       : errorPhase === 'evaluate'       ? 'Calculation failed'
-      : (r.populations?.error === true || r.status === 'error') ? 'error'
+      : (r.populations?.error === true || r.status === 'error') ? 'Unknown error'
       : null;
     return {
       resultId:    r.id,

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -180,10 +180,16 @@
 .popVal[data-tone="warn"] { color: var(--warn); }
 
 /* Patients table card */
+.cardFlush {
+  padding: 0;
+  overflow: hidden;
+}
+
 .tableHeader {
   display: flex;
   align-items: center;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 8px 10px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--line);
 }
@@ -203,11 +209,149 @@
   color: var(--text-dim);
 }
 
+.headerPill {
+  display: inline-flex;
+  align-items: center;
+}
+
 .tableActions {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+/* Filter chips */
+.chipsRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--bg-elevated);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chip:hover {
+  background: var(--bg-sunken);
+  color: var(--text);
+}
+
+.chipActive {
+  background: var(--text);
+  color: var(--bg-elevated);
+  border-color: var(--text);
+}
+
+.chipActive:hover {
+  background: var(--text);
+  color: var(--bg-elevated);
+}
+
+.chipDangerActive {
+  background: var(--err);
+  border-color: var(--err);
+  color: #fff;
+}
+
+.chipDangerActive:hover {
+  background: var(--err);
+  color: #fff;
+}
+
+.chipCount {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+.chipActive .chipCount,
+.chipDangerActive .chipCount {
+  opacity: 0.85;
+}
+
+/* Status pills */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.pillMatch {
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+  color: var(--ok);
+}
+
+.pillMiss {
+  background: color-mix(in srgb, var(--err) 12%, transparent);
+  color: var(--err);
+}
+
+.pillError {
+  background: color-mix(in srgb, var(--warn) 14%, transparent);
+  color: oklch(0.5 0.14 70);
+}
+
+.pillNeutral {
+  background: var(--line-soft);
+  color: var(--text-dim);
+}
+
+/* Legend strip */
+.legendStrip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  padding: 10px 16px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.legendLabel {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legendDesc {
+  color: var(--text-dim);
+}
+
+.legendHint {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
 }
 
 .btnGhost {
@@ -288,51 +432,211 @@
   font-weight: 500;
 }
 
-.popCell {
-  text-align: center;
-}
-
 .iconOk { color: var(--ok); }
 .iconWarn { color: var(--warn); }
 .iconDim { color: var(--text-dim); }
 .iconErr { color: var(--err); }
 
-.errorBadge {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 1px 6px;
-  border-radius: 3px;
-  background: color-mix(in srgb, var(--err) 12%, transparent);
-  color: var(--err);
-  margin-left: 6px;
-  vertical-align: middle;
-}
-
-.errorPhaseLabel {
-  font-size: 11px;
-  color: var(--text-dim);
-  margin-left: 4px;
-}
-
-.patientRowError td {
+/* Mismatch row tint */
+.rowMiss {
   background: color-mix(in srgb, var(--err) 4%, transparent);
 }
 
-.patientRowError:hover td {
-  background: color-mix(in srgb, var(--err) 8%, transparent);
+.rowMiss:hover td {
+  background: color-mix(in srgb, var(--err) 7%, transparent);
 }
 
-.warnBadge {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 1px 6px;
+/* Error row tint */
+.rowError {
+  background: color-mix(in srgb, var(--warn) 4%, transparent);
+}
+
+.rowError:hover td {
+  background: color-mix(in srgb, var(--warn) 7%, transparent);
+}
+
+/* Expand toggle chevron cell */
+.expandToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  color: var(--text-dim);
   border-radius: 3px;
-  background: color-mix(in srgb, #b08000 10%, transparent);
-  color: #7a5c00;
-  margin-left: 6px;
-  vertical-align: middle;
+}
+
+.patientRow:hover .expandToggle {
+  color: var(--text);
+}
+
+/* Expanded row drawer */
+.expandedRow > td {
+  padding: 0 !important;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line);
+}
+
+.expandedInner {
+  padding: 16px 20px 18px 48px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+/* Mini card used inside expanded panel */
+.miniCard {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+
+.miniHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.monoNote {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.openDetailLink {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: default;
+  opacity: 0.6;
+}
+
+/* Mini population breakdown table */
+.miniTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.miniTable th {
+  padding: 8px 16px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+}
+
+.miniTable td {
+  padding: 9px 16px;
+  font-size: 13px;
+  color: var(--text);
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.miniTable tr:last-child td {
+  border-bottom: none;
+}
+
+.numCell {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  width: 60px;
+}
+
+.numCellMiss {
+  color: var(--err);
+  font-weight: 600;
+}
+
+.miniRowMiss {
+  background: color-mix(in srgb, var(--err) 4%, transparent);
+}
+
+.popDesc {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.4;
+  margin-top: 2px;
+  font-style: italic;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  font-family: inherit;
+}
+
+.popDescExpanded {
+  display: block;
+  overflow: visible;
+  -webkit-line-clamp: unset;
+  -webkit-box-orient: unset;
+  cursor: pointer;
+}
+
+/* Patient context kv rows */
+.kvBody {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.kvRow {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.kvKey {
+  color: var(--text-dim);
+  min-width: 64px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.kvKeyErr {
+  color: var(--err);
+}
+
+.kvRowDiff {
+  margin-top: 4px;
+  padding: 8px 10px;
+  background: var(--err-wash);
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--err) 22%, transparent);
+}
+
+.errorText {
+  color: var(--err);
+  font-size: 11px;
+}
+
+.diffText {
+  color: var(--err);
+  font-size: 12px;
 }
 
 .emptyRow {
@@ -456,4 +760,174 @@
   .popCell {
     text-align: left;
   }
+}
+
+/* Truncated patient ID copy button */
+.idCell {
+  overflow: hidden;
+  max-width: 160px;
+}
+
+.idCopyBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: copy;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  display: block;
+  line-height: inherit;
+  text-align: left;
+}
+
+.idCopyBtn:hover {
+  color: var(--text);
+}
+
+/* Copy icon button in expanded panel */
+.kvIdRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.copyIconBtn {
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.copyIconBtn:hover {
+  color: var(--text);
+  background: var(--line-soft);
+}
+
+/* Evaluated resources section inside expanded panel */
+.resSection {
+  border-top: 1px solid var(--line-soft);
+}
+
+.resSectionHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.rawFhirToggle {
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-muted);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.rawFhirToggle:hover {
+  background: var(--line-soft);
+  color: var(--text);
+}
+
+.resList {
+  padding: 8px 0;
+}
+
+.resRow {
+  display: flex;
+  gap: 12px;
+  padding: 5px 12px;
+  font-size: 12px;
+}
+
+.resLabel {
+  color: var(--text-dim);
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.resValue {
+  color: var(--text);
+  flex: 1;
+}
+
+.resSkeleton {
+  height: 14px;
+  margin: 7px 12px;
+  border-radius: 4px;
+  background: var(--line-soft);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.resEmpty {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.rawBlock {
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.rawBlock:last-child {
+  border-bottom: none;
+}
+
+.rawToggle {
+  background: none;
+  border: none;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  color: var(--text-muted);
+  display: flex;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+}
+
+.rawToggle:hover {
+  color: var(--text);
+  background: var(--line-soft);
+}
+
+.rawJson {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 8px 12px;
+  overflow-x: auto;
+  white-space: pre;
+  background: var(--bg-sunken);
+  border-top: 1px solid var(--line-soft);
+  margin: 0;
 }

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -697,26 +697,9 @@
   flex-shrink: 0;
 }
 
-.kvKeyErr {
-  color: var(--err);
-}
-
-.kvRowDiff {
-  margin-top: 4px;
-  padding: 8px 10px;
-  background: var(--err-wash);
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--err) 22%, transparent);
-}
-
 .errorText {
   color: var(--err);
   font-size: 11px;
-}
-
-.diffText {
-  color: var(--err);
-  font-size: 12px;
 }
 
 .emptyRow {

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -284,6 +284,13 @@
   opacity: 0.85;
 }
 
+.chipDetail {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  opacity: 0.6;
+  margin-left: 2px;
+}
+
 /* Status pills */
 .pill {
   display: inline-flex;
@@ -318,7 +325,61 @@
   color: var(--text-dim);
 }
 
-/* Legend strip */
+/* Error pill + inline excerpt */
+.errorPillGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.errorExcerpt {
+  font-size: 11px;
+  color: var(--text-muted);
+  max-width: 240px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Clear filters button */
+.clearFiltersBtn {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  background: transparent;
+}
+
+.clearFiltersBtn:hover {
+  background: var(--bg-sunken);
+  color: var(--text);
+}
+
+/* Legend strip (collapsed inside <details>) */
+.legendDetails {
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.legendSummary {
+  padding: 6px 16px;
+  font-size: 11px;
+  color: var(--text-dim);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.legendSummary::-webkit-details-marker { display: none; }
+
+.legendSummary:hover {
+  color: var(--text-muted);
+}
+
 .legendStrip {
   display: flex;
   align-items: center;
@@ -426,6 +487,11 @@
 
 .patientRow:hover td {
   background: var(--bg-sunken);
+}
+
+.patientRow:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .patientName {
@@ -591,6 +657,20 @@
   -webkit-line-clamp: unset;
   -webkit-box-orient: unset;
   cursor: pointer;
+}
+
+.popDescWrap {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+}
+
+.popDescMore {
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 /* Patient context kv rows */
@@ -926,8 +1006,15 @@
   color: var(--text-muted);
   padding: 8px 12px;
   overflow-x: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
   background: var(--bg-sunken);
   border-top: 1px solid var(--line-soft);
   margin: 0;
+}
+
+@media (max-width: 1024px) {
+  .expandedInner {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -84,6 +84,20 @@ export default function SettingsPage() {
     }
   };
 
+  const handleToggleComparison = async (enabled) => {
+    setAdminSaving(true);
+    try {
+      const updated = await updateAdminSettings({ comparison_enabled: enabled });
+      setAdminSettings(updated);
+      window.dispatchEvent(new CustomEvent('admin-settings-changed', { detail: updated }));
+      toast.success(enabled ? 'Comparison enabled' : 'Comparison disabled');
+    } catch (err) {
+      toast.error(err.message || 'Failed to update setting');
+    } finally {
+      setAdminSaving(false);
+    }
+  };
+
   const TABS = [
     { id: 'connections', label: 'Connections' },
     { id: 'status', label: 'System Status' },
@@ -213,6 +227,20 @@ export default function SettingsPage() {
                   <Toggle
                     checked={adminSettings?.validation_enabled ?? false}
                     onChange={handleToggleValidation}
+                    disabled={adminSaving}
+                  />
+                </div>
+                <div className={styles.adminRow}>
+                  <div className={styles.adminRowInfo}>
+                    <div className={styles.adminRowLabel}>Comparison</div>
+                    <div className={styles.adminRowDesc}>
+                      Show expected vs. actual match/mismatch status per patient on the Results page.
+                      Useful for development; hide for end users.
+                    </div>
+                  </div>
+                  <Toggle
+                    checked={adminSettings?.comparison_enabled ?? false}
+                    onChange={handleToggleComparison}
                     disabled={adminSaving}
                   />
                 </div>


### PR DESCRIPTION
## Summary

- **Results page redesign (Approach B):** replaces the flat per-row boolean display with a `PopulationDots` chip summary (IP / Denom / DenEx / Numer / NmEx) and an inline row-expansion drawer that shows a per-population breakdown table with FHIR criterion descriptions + a patient context card; removes the `PatientDetail` modal and `ComparisonView` block entirely
- **Comparison mode:** new `comparison_enabled` admin toggle (Settings → Admin) gates match/mismatch status pills, failures-first sort, and filter chips; when enabled and expected results are loaded, each row shows `✓ match`, `! mismatch · <pops>`, or `⚠ error · <phase>`
- **Error display improvements:** `sanitize_error()` now intercepts `httpx` network exceptions before string-coercing (human-readable "Service is unreachable" / "Request timed out"); `OperationOutcomeView` shows friendly code labels, hides redacted `[host]` URLs, truncates long diagnostics with show-more, and uses plain `<pre>` for raw FHIR (removing `dangerouslySetInnerHTML`); DB-disconnect hint added to `/health` error_details
- **UX polish (follow-up feedback round):**
  - `PopulationDots` chips: filled = in population, hollow = not in population (no numeric value displayed); `aria-label` with English membership summary added
  - Error phase labels rewritten to plain English ("Couldn't fetch patient data", "Some data missing", "Calculation failed")
  - Error pill shows 60-char inline excerpt of the error message
  - Mismatch pill shows count ("! 2 mismatched") instead of population code list
  - Legend strip collapsed by default (`<details>/<summary>`)
  - Patient rows keyboard-accessible (`tabIndex`, `role="button"`, Space/Enter handler)
  - Population description gets 2-line clamp with "more ▾" affordance
  - Raw JSON overflow fixed (`white-space: pre-wrap` + `word-break: break-word`)
  - "FHIR ID" → "Patient ID" rename in expanded row detail panel
  - Empty state per filter shows contextual message + clear-filters button
  - Failures chip shows `"N err · N miss"` breakdown

## Related issue

<!-- no linked issue — design-handoff driven -->

## Type of change

- [x] New feature
- [x] Bug fix

## Checklist

- [x] Tests added or updated (4 new `comparison_enabled` unit tests in `test_routes_settings.py`)
- [ ] docs/ updated (no architecture change; existing API extended with new optional fields)
- [x] No new ADRs needed
- [x] Security implications considered — `dangerouslySetInnerHTML` removed; `sanitize_error` already redacts URLs

## Test plan

- [x] `cd backend && ruff check app/ tests/ && ruff format --check app/ tests/` — clean
- [x] `cd backend && python3 -m pytest tests/ --ignore=tests/integration` — 438 passed
- [x] `./scripts/run-integration-tests.sh --ignore=...` (CI-equivalent suite) — all passed
- [ ] **Validator path:** toggle `comparison_enabled` ON → run job → status pills visible, failures sort first, Failures chip active, row click opens inline drawer (not modal)
- [ ] **Engineer path:** toggle OFF → "actual only" header, 4 filter chips, no status column
- [ ] **Error rows:** job with a known `error_phase` → amber `⚠ error · <phase>` pill + warn-tinted row
- [ ] Settings → Admin → Comparison toggle saves and broadcasts `admin-settings-changed`