### PR TITLE
fix(tests): full CDR $reindex with job-completion gating for jobs pipeline

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -43,6 +43,8 @@ SKIP_MESSAGE = (
 # all three return results before allowing tests to proceed.
 _REINDEX_POLL_INTERVAL = 1  # seconds between probe checks
 _REINDEX_TIMEOUT = 300  # seconds before giving up
+# CDR has no persistent Lucene; full reindex takes ~4 min on typical hardware.
+_CDR_REINDEX_TIMEOUT = 600  # seconds before giving up on CDR full reindex
 
 # HAPI's in-memory ValueSet expansion is capped at 1000 codes (HAPI-0831).  ValueSets
 # with >1000 codes must be pre-expanded by HAPI's background scheduler before the CQL
@@ -98,6 +100,56 @@ def _wait_for_valueset_expansion(base_url: str, large_valueset_ids: list[str]) -
             f"{_VALUESET_EXPANSION_TIMEOUT}s for {len(pending)} ValueSet(s): {sorted(pending)[:5]}. "
             f"Tests may fail with IP=0 if large ValueSets are still unexpanded."
         )
+
+
+def _trigger_cdr_full_reindex_and_wait(cdr_url: str) -> None:
+    """Trigger a full $reindex on CDR and wait for the job to complete.
+
+    CDR uses an in-memory Lucene backend (no persistent directory) so patient-reference
+    searches — required by $everything — return 0 on startup until the index is rebuilt.
+    Unlike the measure engine, CDR has no CR/DEQM jobs, so reindexing all types at once
+    (including Procedure, MedicationRequest, MedicationAdministration) is safe.
+
+    Completion is detected by the $hapi.fhir.reindex-status endpoint returning a Bundle
+    (job report) instead of an OperationOutcome (in-progress).
+    """
+    import re as _re
+    import warnings as _warnings
+
+    import httpx as _httpx
+
+    headers = {"Content-Type": "application/fhir+json"}
+
+    r = _httpx.post(f"{cdr_url}/$reindex", json={"resourceType": "Parameters"}, headers=headers, timeout=30)
+    if r.status_code >= 400:
+        _warnings.warn(f"Full $reindex at {cdr_url} returned {r.status_code}: {r.text[:200]}")
+        return
+
+    try:
+        diag = r.json().get("issue", [{}])[0].get("diagnostics", "")
+        m = _re.search(r"_jobId=([a-f0-9-]+)", diag)
+        if not m:
+            _warnings.warn(f"No job ID in $reindex response at {cdr_url}; CDR reference-param index may be incomplete")
+            return
+        job_id = m.group(1)
+    except Exception as exc:
+        _warnings.warn(f"Could not parse $reindex response at {cdr_url}: {exc}")
+        return
+
+    deadline = time.monotonic() + _CDR_REINDEX_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            status = _httpx.get(f"{cdr_url}/$hapi.fhir.reindex-status?_jobId={job_id}", timeout=10)
+            if status.status_code == 200 and status.json().get("resourceType") == "Bundle":
+                return
+        except Exception:
+            pass
+        time.sleep(5)
+
+    _warnings.warn(
+        f"CDR full $reindex at {cdr_url} did not complete within {_CDR_REINDEX_TIMEOUT}s. "
+        "Tests may fail with incorrect populations if the CDR reference-param index is incomplete."
+    )
 
 
 def _trigger_reindex_and_wait(base_url: str, probe_patient_id: str, probe_encounter_id: str) -> None:
@@ -294,9 +346,14 @@ def _load_seed_data(_require_infrastructure):
         except Exception:
             pass
 
+        # CDR: full reindex with job-completion gating — covers all types including
+        # Procedure, MedReq, MedAdmin which $everything needs. CDR has no cr.enabled
+        # so reindexing all types at once is safe here.
+        _trigger_cdr_full_reindex_and_wait(TEST_CDR_URL)
+        # MEASURE: Enc/Obs/Cond only — explicit reindex of Proc/MedReq/MedAdmin causes
+        # HAPI to restart async jobs, producing 500 errors on in-flight CQL evaluations.
         if probe_patient_id and probe_encounter_id:
-            for target in (TEST_CDR_URL, TEST_MEASURE_URL):
-                _trigger_reindex_and_wait(target, probe_patient_id, probe_encounter_id)
+            _trigger_reindex_and_wait(TEST_MEASURE_URL, probe_patient_id, probe_encounter_id)
         return
 
     measure_bundle_path = SEED_DIR / "measure-bundle.json"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -44,6 +44,12 @@ services:
       - hapi.fhir.maximum_expansion_size=50000
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.search.enabled=true
+      - spring.jpa.properties.hibernate.search.backend.type=lucene
+      - spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
+      - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
+      - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+      - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
       - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
 
   hapi-fhir-measure:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,12 @@ services:
       - hapi.fhir.maximum_expansion_size=50000 # Connectathon ValueSets exceed HAPI's default expansion limit.
       - spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
       - spring.datasource.driverClassName=org.h2.Driver
+      - spring.jpa.properties.hibernate.search.enabled=true
+      - spring.jpa.properties.hibernate.search.backend.type=lucene
+      - spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$$HapiLuceneAnalysisConfigurer
+      - spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
+      - spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+      - spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
       - spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
       - JAVA_TOOL_OPTIONS=-Xmx1g -Xms256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/hapi/heapdump.hprof
 

--- a/docker/hapi-cdr-seeded.Dockerfile
+++ b/docker/hapi-cdr-seeded.Dockerfile
@@ -1,12 +1,12 @@
 # hapi-cdr-seeded.Dockerfile
 #
 # Configuration-only layer on top of hapiproject/hapi:v8.8.0-1.
-# The seeded H2 database is baked in by the bake-hapi-image.yml workflow via
-# "docker run → seed from runner → docker stop → docker commit", NOT by a
+# The seeded H2 database and Lucene index are baked in by the bake-hapi-image.yml
+# workflow via "docker run → seed from runner → docker stop → docker commit", NOT by a
 # Dockerfile RUN step (the base image is distroless — no shell available).
 #
 # When running this image, do NOT mount a volume over /data/hapi — that would
-# shadow the baked H2 files committed by the bake workflow.
+# shadow the baked H2 and Lucene files committed by the bake workflow.
 # The wiring PR must remove the test_cdrdata volume mount from docker-compose.test.yml.
 
 FROM hapiproject/hapi:v8.8.0-1
@@ -25,4 +25,10 @@ ENV hapi.fhir.enforce_referential_integrity_on_write=false
 ENV hapi.fhir.maximum_expansion_size=50000
 ENV spring.datasource.url=jdbc:h2:file:/data/hapi/h2;DB_CLOSE_ON_EXIT=FALSE
 ENV spring.datasource.driverClassName=org.h2.Driver
+ENV spring.jpa.properties.hibernate.search.enabled=true
+ENV spring.jpa.properties.hibernate.search.backend.type=lucene
+ENV spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers\$HapiLuceneAnalysisConfigurer
+ENV spring.jpa.properties.hibernate.search.backend.directory.root=/data/hapi/lucene
+ENV spring.jpa.properties.hibernate.search.backend.lucene_version=LUCENE_CURRENT
+ENV spring.jpa.properties.hibernate.search.backend.io.refresh_interval=100
 ENV spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync


### PR DESCRIPTION
## Problem

\`test_full_jobs_pipeline.py\` has never passed since it was added (commit \`aa5738c\`, May 3 2026). Every run produced 0 populations for most patients despite the prebaked CDR having all clinical data seeded.

**Root cause:** CDR was the only HAPI service with **in-memory Lucene** (\`directory.root\` not configured). On container start the Lucene index is empty. HAPI kicks off a background reindex (~4 min), but \`\$everything\` — called for every patient in every job — chains into \`Encounter?patient=X\` which requires the Lucene reference-param index. Until reindex completes, those searches return 0 results, so jobs see 0 clinical data and produce 0 populations. This affects **both prod and tests** on every container restart.

## Fix (2 commits)

**Commit 1 — persistent Lucene in CDR** (\`fix(hapi)\`): Add the full Lucene block (\`enabled\`, \`type\`, \`analysis.configurer\`, \`directory.root=/data/hapi/lucene\`, \`lucene_version\`, \`io.refresh_interval\`) to CDR in all three config surfaces: \`hapi-cdr-seeded.Dockerfile\`, \`docker-compose.yml\`, \`docker-compose.test.yml\`. CDR now matches the measure engine's existing Lucene setup. After the bake-hapi-image.yml run triggered by this PR, the CDR prebaked image will have the Lucene index committed at \`/data/hapi/lucene\` alongside the H2 database — no reindex on startup.

**Commit 2 — conftest reindex gate** (\`fix(tests)\`): While `:latest\` still carries the old in-memory image (before the bake completes), \`_trigger_cdr_full_reindex_and_wait\` makes the test fixture wait for the CDR reindex job to fully complete (polls \`\$hapi.fhir.reindex-status?_jobId=\` until \`resourceType == "Bundle"\`, 600 s timeout) before any test runs. This also serves as a permanent safety net for stale images.

## Test plan

- [x] \`USE_PREBAKED=1 ./scripts/run-integration-tests.sh tests/integration/test_full_jobs_pipeline.py -k CMS130 -v\` → **1 passed (64 patients, strict=true) in 6:29** on a clean test stack (before the re-bake)
- [x] CI-equivalent integration suite (vanilla HAPI) → **31 passed, 3 skipped, 0 failures in 19:56**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] bake-hapi-image.yml triggered — new CDR image will have Lucene baked in; re-run \`test_full_jobs_pipeline.py\` after bake to confirm zero-reindex startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)