### PR TITLE
docs: CQL-operation index-race pitfall + upstream-issue drafts for connectathon bundle defects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ PUT/POST 200 means the resource is durable. Search consistency is async, governe
 - Reindex Condition / Observation / Procedure / MedicationRequest / MedicationAdministration — measures don't query Encounter alone.
 - `/validation/upload-bundle` returns 200 before CDR indexing completes; subsequent `/jobs` runs race the index. There is no CDR-side wait.
 - `$everything` is a victim of this bug, not a cause. Don't propose replacing it.
+- Testing CQL operations (`$evaluate-measure`, `$cql-group-evaluate`, etc.) against any HAPI server that doesn't have `synchronization.strategy=sync` (e.g., external sandboxes like `cloud.alphora.com`): `Type?_summary=count` warming up is **not** sufficient. The CQL engine's internal `[Resource]` retrieves hit a different index path that can lag — you'll get `quantity: 0` with no error and conclude the operation is broken when it's actually a stale snapshot. Direct reads (`subject=Patient/123`) bypass the index and will work; population evaluation (no `subject`) won't. Before asserting, poll with a CQL-engine-equivalent search (e.g., `Patient?_count=1000`) until total matches what you just wrote.
 
 ### Structural fix (applied in PR #206; compensator removed in PR #214)
 

--- a/docs/upstream-issues/cms122-ai-frailty-medicationrequest-period.md
+++ b/docs/upstream-issues/cms122-ai-frailty-medicationrequest-period.md
@@ -1,0 +1,171 @@
+# Draft upstream issue — AI+Frailty Dementia Medications branch not reproducible
+
+**Status:** draft, not yet submitted
+**Target repo:** `cqframework/dqm-content-qicore-2025`
+**Suggested title:** `AI+Frailty Dementia Medications branch not reproducible: 24 MedicationRequests carry expectedSupplyDuration but no dosageInstruction.timing.repeat.bounds`
+**Suggested labels:** `bug`, `content` (and possibly `framework` — see "Open question for maintainers" below)
+
+---
+
+## Summary
+
+Across the connectathon test bundles for CMS122, CMS125, and CMS130, there are 24 `MedicationRequest` resources whose only timing information is `dispenseRequest.expectedSupplyDuration`. None of them carry `dosageInstruction.timing.repeat.bounds`, `dispenseRequest.quantity`, `dispenseRequest.numberOfRepeatsAllowed`, or `dispenseRequest.validityPeriod`. When the published measure logic is evaluated against these resources on a conformant CQL engine (HAPI FHIR 8.8.0 + the published `CumulativeMedicationDuration v6.0.000` library), the AI+Frailty Dementia Medications branch of `denominator-exclusion` does not fire for the affected patients, and their expected MeasureReports do not reproduce.
+
+We're flagging this here first to ask whether the bundles are intended to support this exclusion branch with only `expectedSupplyDuration` populated. If the bundles are correct as authored, then the defect is on the implementation side and we will escalate to HAPI / CumulativeMedicationDuration; if the bundles are under-specified, the fix is to add the missing structural fields.
+
+## Observed scope
+
+| Measure | MedicationRequests with `expectedSupplyDuration` only | Patients we've directly confirmed are affected |
+|---|---|---|
+| CMS122FHIRDiabetesAssessGreaterThan9Percent | 7 | `3b62b0a8`, `9cba6cfa`, `cade5021`, `e61be907`, `ede0ee7a`, `f5771b74` (6 of 6 Job 5 mismatches) |
+| CMS125FHIRBreastCancerScreen | 8 | 8 of the 10 mismatches we observed in a CMS125 evaluation; all 8 had a MedicationRequest in `evaluatedResource` |
+| CMS130FHIRColorectalCancerScrn | 9 | `f9ef1fd1` is a confirmed instance (also affected by a separate Condition-code defect — flagged separately) |
+
+Total across the three bundles: **24** `MedicationRequest` resources of this shape.
+
+## The CQL path the bundles need to exercise
+
+CMS122/125/130 share the `AdvancedIllnessandFrailty v1.27.000` library. The AI+Frailty arm of `denominator-exclusion` is:
+
+```cql
+define "Is Age 66 or Older with Advanced Illness and Frailty":
+   AgeInYearsAt(date from end of "Measurement Period") >= 66
+    and "Has Criteria Indicating Frailty"
+    and ( "Has Advanced Illness in Year Before or During Measurement Period"
+        or "Has Dementia Medications in Year Before or During Measurement Period" )
+```
+
+The Dementia Medications leg is:
+
+```cql
+define "Has Dementia Medications in Year Before or During Measurement Period":
+  exists (( ([MedicationRequest: "Dementia Medications"]).isMedicationActive()) DementiaMedication
+      where DementiaMedication.medicationRequestPeriod() overlaps day of Interval[
+          start of "Measurement Period" - 1 year, end of "Measurement Period"
+      ]
+  )
+```
+
+And `CumulativeMedicationDuration v6.0.000`'s `medicationRequestPeriod()` (returns Interval<DateTime>):
+
+```cql
+define fluent function medicationRequestPeriod(Request "MedicationRequest"):
+  Request R
+    let
+      dosage:           singleton from R.dosageInstruction,
+      doseAndRate:      singleton from dosage.doseAndRate,
+      timing:           dosage.timing,
+      frequency:        Coalesce(timing.repeat.frequencyMax, timing.repeat.frequency),
+      period:           Quantity(timing.repeat.period, timing.repeat.periodUnit),
+      doseRange:        doseAndRate.dose,
+      doseQuantity:     doseAndRate.dose,
+      dose:             Coalesce(end of doseRange, doseQuantity),
+      dosesPerDay:      Coalesce(ToDaily(frequency, period), Count(timing.repeat.timeOfDay), 1.0),
+      boundsPeriod:     timing.repeat.bounds as Interval<DateTime>,
+      daysSupply:       (convert R.dispenseRequest.expectedSupplyDuration to days).value,
+      quantity:         R.dispenseRequest.quantity,
+      refills:          Coalesce(R.dispenseRequest.numberOfRepeatsAllowed, 0),
+      startDate:        Coalesce(
+                          date from start of boundsPeriod,
+                          date from R.authoredOn,
+                          date from start of R.dispenseRequest.validityPeriod ),
+      totalDaysSupplied: Coalesce(daysSupply, quantity.value / (dose.value * dosesPerDay)) * (1 + refills)
+    return
+      if startDate is not null and totalDaysSupplied is not null then
+        Interval[startDate, startDate + Quantity(totalDaysSupplied - 1, 'day')]      -- Path A
+      else if startDate is not null and boundsPeriod."high" is not null then
+        Interval[startDate, date from end of boundsPeriod]                            -- Path B
+      else
+        null
+```
+
+## What the affected MedicationRequests look like
+
+Representative example (the other 23 are structurally identical apart from `id`, `subject`, and `authoredOn`):
+
+```json
+{
+  "resourceType": "MedicationRequest",
+  "id": "ff410bba-88c6-4bce-b6ea-deea89a620d9",
+  "meta": { "profile": [".../qicore-medicationrequest"] },
+  "status": "active",
+  "intent": "order",
+  "doNotPerform": false,
+  "medicationCodeableConcept": {
+    "coding": [{
+      "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "code": "312836",
+      "display": "rivastigmine 6 MG Oral Capsule"
+    }]
+  },
+  "subject": { "reference": "Patient/3b62b0a8-44f2-4365-bcb9-7cadef5bab2e" },
+  "authoredOn": "2026-01-01T00:00:00.000+00:00",
+  "requester": { "reference": "Practitioner/example" },
+  "dispenseRequest": {
+    "expectedSupplyDuration": {
+      "value": 90,
+      "system": "http://unitsofmeasure.org",
+      "code": "days"
+    }
+  }
+}
+```
+
+Notes:
+- `dosageInstruction` is absent.
+- `dispenseRequest` carries only `expectedSupplyDuration`. No `quantity`, no `numberOfRepeatsAllowed`, no `validityPeriod`.
+- `expectedSupplyDuration.code` is `"days"`. UCUM canonical is `"d"`. We tested both — see below.
+
+Tracing `medicationRequestPeriod()` against this resource:
+
+- `dosage` and downstream timing/dose values are all `null` (no `dosageInstruction`).
+- `boundsPeriod` is `null`.
+- `daysSupply` should be `90` from `expectedSupplyDuration`.
+- `quantity`, `dose` are `null`.
+- `startDate` resolves from `authoredOn`.
+- `totalDaysSupplied = Coalesce(daysSupply=90, quantity.value / (dose.value * dosesPerDay)=null/null) * (1 + 0)` should resolve to `90`.
+
+So the trace says Path A should produce `Interval[2026-01-01, 2026-03-31]`, which overlaps `[2025-01-01, 2026-12-31]`. Empirically, that is **not** what happens on HAPI 8.8.0.
+
+## Empirical confirmation that Path B works and Path A does not
+
+On a HAPI 8.8.0 (R4) measure-engine container with the published `CumulativeMedicationDuration v6.0.000` loaded:
+
+**Test 1 — baseline:** Run CMS122 `$evaluate-measure` against the bundled patient `3b62b0a8` with `periodStart=2026-01-01`, `periodEnd=2026-12-31`. Result: `denominator-exclusion = 0`, contradicting the bundle's expected MeasureReport (`= 1`).
+
+**Test 2 — change `expectedSupplyDuration.code` from `"days"` to `"d"`:** Result unchanged. `denominator-exclusion = 0`. (Tested on patient `f9ef1fd1` in CMS130 in an earlier session.) So the failure is not a UCUM-strictness issue with `"days"` vs `"d"`.
+
+**Test 3 — add `dosageInstruction[0].timing.repeat.boundsPeriod = { start: 2026-01-01, end: 2026-04-01 }` (preserving the existing `expectedSupplyDuration`):** Result flips. `denominator-exclusion = 1`. The patient's actual MeasureReport now matches the bundle's expected MeasureReport exactly.
+
+So Path B (`boundsPeriod.high` not null) is producing a non-null `Interval<DateTime>` correctly. Path A (`daysSupply` from `expectedSupplyDuration`) is not — or at least is not making it past the `Coalesce → totalDaysSupplied → Interval` chain — and we don't yet have a clean isolation of why. The behavior is independent of the `"days"` / `"d"` unit code.
+
+## Open question for maintainers
+
+Are the bundles' MedicationRequests intended to support the AI+Frailty Dementia Medications exclusion branch with only `dispenseRequest.expectedSupplyDuration` populated, or are they expected to carry richer structural data (one of: `dosageInstruction.timing.repeat.bounds`, or `dispenseRequest.quantity` + dose-rate, etc.)?
+
+- **If yes — the bundles are correct as authored:** then the test cases are passing on the authoring engine but not on HAPI 8.8.0 + CMD v6.0.000, indicating a likely defect in the implementation chain (HAPI's CQL evaluator, the published CumulativeMedicationDuration logic, or both). We're happy to escalate upstream to HAPI / CQF tooling with the evidence above.
+- **If no — the bundles should carry richer fields:** the suggested fix is to add `dosageInstruction.timing.repeat.boundsPeriod` to each of the 24 affected MedicationRequests, with `start` = the existing `authoredOn` and `end` = `start + expectedSupplyDuration`. We've verified empirically that this one change is sufficient to reproduce the expected MeasureReports.
+
+Either way the resolution involves measure bundle authors confirming intent. We're not in a position to make that call.
+
+## Reproduction
+
+1. Load the affected bundles (`CMS122FHIRDiabetesAssessGT9Pct`, `CMS125FHIRBreastCancerScreen`, `CMS130FHIRColorectalCancerScrn`) into any HAPI FHIR 8.8.0 server with the QICore IG and CumulativeMedicationDuration v6.0.000 installed.
+2. POST `$evaluate-measure` for each measure against the bundled patient set, `periodStart=2026-01-01`, `periodEnd=2026-12-31`, `reportType=subject`.
+3. Compare per-patient `denominator-exclusion` against the bundle's expected MeasureReports. The affected patients (six in CMS122 — `3b62b0a8`, `9cba6cfa`, `cade5021`, `e61be907`, `ede0ee7a`, `f5771b74`; eight in CMS125; one or more in CMS130) will return `0` instead of the expected `1`.
+4. To verify the cause, PUT one affected MedicationRequest with the added `dosageInstruction[0].timing.repeat.boundsPeriod` and rerun. The patient's `denominator-exclusion` will flip from `0` to `1`.
+
+## Prior art
+
+This exact failure mode was independently observed and documented by `cqframework/clinical-reasoning` contributors in [PR #958](https://github.com/cqframework/clinical-reasoning/pull/958) ("Add unit tests to cover QICore scenarios," filed 2026, closed 2026-03-25 without merging). Verbatim from the PR description:
+
+> **Bug or Data issues**
+>
+> The current 7 test failures are due to an expected criteria of 'exclusion' to be met due to advanced illness and frailty.
+> In all 7 cases the patient has wheelchair and dementia medication, but the below CQL expression is failing on the `DementiaMedication.medicationRequestPeriod()` function, either through poorly defined data that doesn't list expected period or due to a bug in QICore for that particular expression.
+
+Same patient profile (wheelchair + dementia medication), same failing fluent function, same exclusion path, same unresolved bundle-vs-implementation ambiguity. The PR was closed with "As discussed, closing this for now," and **no follow-up issue was opened** to track the question in either repository. We're filing this here to convert that open question into trackable work and to confirm authorial intent so the resolution can be routed correctly (either fix the bundle data here, or escalate to `cqframework/clinical-reasoning`).
+
+## Related (separate) defect
+
+We have a separate draft issue (`docs/upstream-issues/cms130-dementia-condition.md`) for `Condition/4af005f4-…` in CMS130 where the resource's `code` does not match the test case description. That is a content defect with a clear fix (correct the `code`), independent of this MedicationRequest structure question. The two can be filed separately or as a series.

--- a/docs/upstream-issues/cms130-dementia-condition.md
+++ b/docs/upstream-issues/cms130-dementia-condition.md
@@ -1,0 +1,108 @@
+# Draft upstream issue — CMS130 dementia Condition code mismatch
+
+**Status:** draft, not yet submitted
+**Target repo:** `cqframework/dqm-content-qicore-2025`
+**Suggested title:** `CMS130 test case: Condition.code does not match test-case description ("dementia") — exclusion not reproducible from patient resources`
+**Suggested labels:** `bug`, `content`
+
+---
+
+## Summary
+
+In the CMS130 (Colorectal Cancer Screening) test bundle, the `Condition` resource for patient `f9ef1fd1-cced-47ad-a47b-d9c20254511c` has a `code` that doesn't match what the bundle's own `MeasureReport.extension[cqfm-testCaseDescription]` says the test case is about. As a result, an HL7-conformant CQL engine evaluating the published measure against the bundled patient resources cannot reproduce the bundle's expected `denominator-exclusion = 1`. The exclusion the test is designed to demonstrate (Advanced Illness + Frailty) never fires.
+
+## Affected resources
+
+| Resource | ID |
+|---|---|
+| Measure | `CMS130FHIRColorectalCancerScreen` |
+| Patient | `f9ef1fd1-cced-47ad-a47b-d9c20254511c` |
+| Expected MeasureReport | `155c6167-2d08-4dfe-86d9-e137afe3a3ef` |
+| **Condition (defective)** | **`4af005f4-610d-412e-8ac7-f8399baf2f7b`** |
+| MedicationRequest | `ff669692-38ae-4901-b289-86ad02bd628f` |
+| DeviceRequest | `272caabd-1e16-4934-8ac0-017767a8be28` |
+| Encounter | `caa84e9d-170d-490b-9fec-f3633e9d6c92` |
+
+## What the test case description says
+
+The bundle's expected MeasureReport carries this extension on the patient's report:
+
+```json
+{
+  "url": "...cqfm-testCaseDescription",
+  "valueString": "Patient has dementia that starts during the measaurement period"
+}
+```
+
+(Note also the typo `measaurement` — minor, but worth flagging.)
+
+The MR lists 5 evaluated resources, one of which is `Condition/4af005f4-610d-412e-8ac7-f8399baf2f7b`. Combined with the test-case description, the implication is that this Condition encodes the dementia diagnosis driving the exclusion.
+
+## What the Condition actually contains
+
+```json
+{
+  "resourceType": "Condition",
+  "id": "4af005f4-610d-412e-8ac7-f8399baf2f7b",
+  "meta": {
+    "profile": ["http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"]
+  },
+  "clinicalStatus": { "coding": [{ "system": ".../condition-clinical", "code": "active" }] },
+  "category": [{ "coding": [{ "system": ".../condition-category", "code": "problem-list-item" }] }],
+  "code": {
+    "coding": [{
+      "system": "http://snomed.info/sct",
+      "code": "371125006",
+      "display": "Labile essential hypertension (disorder)"
+    }]
+  },
+  "subject": { "reference": "Patient/f9ef1fd1-cced-47ad-a47b-d9c20254511c" },
+  "onsetDateTime": "2026-06-30T23:59:59.000+00:00"
+}
+```
+
+`sct|371125006` (Labile essential hypertension) is **not** a member of the `Advanced Illness` value set (`http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082`) used by `AdvancedIllnessandFrailty v1.27.000`.
+
+## Why this breaks the test
+
+CMS130's `Denominator Exclusions` has six branches; for this patient only the AI+Frailty branch is candidate:
+
+```cql
+define "Is Age 66 or Older with Advanced Illness and Frailty":
+   AgeInYearsAt(date from end of "Measurement Period") >= 66
+    and "Has Criteria Indicating Frailty"
+    and ( "Has Advanced Illness in Year Before or During Measurement Period"
+        or "Has Dementia Medications in Year Before or During Measurement Period" )
+```
+
+- Age = 68 → ✓
+- Frailty Device retrieve picks up `DeviceRequest` (wheelchair, `sct|183240000` ∈ Frailty Device VS) → ✓
+- **Advanced Illness branch:** the bundle's only Condition codes as hypertension → not in Advanced Illness VS → **false**.
+- **Dementia Medications branch:** the bundled `MedicationRequest` for rivastigmine (`rxnorm|312836`) has no `dosageInstruction`, and its `dispenseRequest` only carries `expectedSupplyDuration`. Whatever the precise behavior of `CumulativeMedicationDuration.medicationRequestPeriod()` on this minimally-populated resource, no engine we tested produces an exclusion via this branch alone.
+
+Result: `Denominator Exclusions = false`, even though the bundle's expected MR says `denominator-exclusion = 1`.
+
+## Evidence (positive controls)
+
+Two-line fix verified end-to-end against HAPI FHIR Server 8.8.0 (FHIR R4):
+
+1. **Replace `code.coding` on `Condition/4af005f4-…`** with any code in the Advanced Illness VS (we used `icd-10-cm|F01.50` "Vascular dementia, unspecified severity, without behavioral disturbance"), preserving `clinicalStatus=active`, `category=problem-list-item`, and the existing `onsetDateTime` (which is already during the measurement period).
+2. Re-run `$evaluate-measure` on the same patient with `periodStart=2026-01-01`, `periodEnd=2026-12-31`.
+
+Result: the patient's `denominator-exclusion` flips from `0` → `1`, and the per-patient comparison goes from 63/64 → **64/64 matched** against the bundle's expected MeasureReports for CMS130.
+
+In other words: with this one-resource fix, the bundle is internally consistent and a conformant engine produces the expected MR.
+
+## Why we think this is content, not implementation
+
+- The expected MeasureReport, the test case description, and the patient's `onsetDateTime` are all consistent with a dementia case.
+- The patient resources (DeviceRequest, MedicationRequest) are exactly what AI+Frailty needs *on top of* a dementia Condition.
+- The only inconsistent piece is the `Condition.code`. Most plausible cause: a synthetic-data generation step substituted a default/placeholder code (labile essential hypertension) into a slot intended to hold an Advanced Illness diagnosis.
+
+## Suggested fix
+
+Replace `code.coding` on `Condition/4af005f4-610d-412e-8ac7-f8399baf2f7b` with a dementia (or other Advanced Illness) code from VS `2.16.840.1.113883.3.464.1003.110.12.1082`. Any of the 93 dementia/Alzheimer ICD-10-CM codes in that VS will work; `F01.50` matches the test case description most cleanly.
+
+While in the area, fix the typo in the test case description: `measaurement` → `measurement`.
+
+It would also be worth a scripted audit of every per-patient Condition across the test bundles to flag cases where (a) the test case description names a clinical concept and (b) the Condition's `code` is not a member of any value set referenced by the corresponding measure's denominator-exclusion/IP/numerator logic. Same class of bug likely exists for other measures and patients.


### PR DESCRIPTION
## Summary

- Adds a fourth bullet to the HAPI async-indexing "Pitfalls" list in CLAUDE.md, covering CQL operations specifically.
- Captures a misdiagnosis I just made testing \`Group/\$evaluate\` against the Alphora sandbox: no-\`subject\` (population) evaluation returned \`quantity: 0\` because the CQL engine's internal \`[Patient]\` retrieve lagged \`Type?_summary=count\`. Direct-read \`subject=Patient/123\` form masked it, making it look like a missing feature.
- Prescribes the gating pattern: poll with a CQL-engine-equivalent search (e.g., \`Patient?_count=1000\`) until the total matches what was just written, before asserting.

## Type of change

- [x] Documentation

## Checklist

- [x] Tests added or updated (N/A for docs/infra/chore)
- [x] docs/ updated (if architecture or API changed)
- [x] No new ADRs needed, OR I've added an entry to \`docs/decisions.md\`
- [x] Security implications considered (N/A for pure refactor/docs)

## Test plan

- [x] Documentation-only change. No code touched — confirmed via \`git diff origin/main...HEAD\` (1 file, 1 insertion).