### PR TITLE
docs: user-facing notes for max_bundle_entries (post-#321)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ class TSConfig(Base, ConnectionConfigMixin):  # example: terminology server
     )
 
     ts_url: Mapped[str] = mapped_column(String, nullable=False)
-    # Add kind-specific columns here. CDR has `is_read_only`; MCS has none.
+    # Add kind-specific columns here. CDR has `is_read_only` and `max_bundle_entries`; MCS has none.
     # Resist adding fields that "feel useful" — every column is a forward-compat
     # liability. Add only what the kind genuinely needs.
 ```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ By default, Lenny uses a bundled CDR with test data. To connect to your organiza
 1. Go to Settings
 2. Enter your CDR URL
 3. Select auth type (None, Basic Auth, or Bearer Token)
-4. Click "Test Connection" to verify
-5. Save
+4. *(Optional)* If your CDR rejects bundles above a fixed entry count (Firely Sandbox = 200, AWS HealthLake and others have similar caps), set **Max resources per bundle** to that limit. Leave blank for HAPI and other servers that accept full bundles.
+5. Click "Test Connection" to verify
+6. Save
 
 Auth credentials (passwords, bearer tokens) are encrypted at rest using Fernet (AES-128-CBC + HMAC-SHA256). **Set `CDR_FERNET_KEY` in `.env` before saving a custom CDR — generate one with `python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`.** See `.env.example` and `docs/architecture.md` for the production SSM/Docker-secrets pipeline.
 


### PR DESCRIPTION
Follow-up to #321 — flagged by `/document-release` after the merge of v0.0.17.16 landed in prod.

## Summary

- **README.md** — adds an optional step #4 under "Connecting Your CDR" pointing users at the new "Max resources per bundle" field for CDRs that enforce a per-bundle entry cap (Firely Sandbox = 200, AWS HealthLake similar). Before this, a user setting up Firely Sandbox follows the recipe verbatim, hits the cap on their first bundle upload, and has no docs trail to the fix #321 already shipped.
- **CONTRIBUTING.md** — the "How to add a connection kind" recipe used CDR's `is_read_only` as the lone example of a kind-specific column. CDR now has two such columns; the comment is updated so the next contributor adding a TS/MR/MRR kind sees the right pattern.

No code, no schema, no version bump. Two files, four lines changed.

## Test plan

- [x] `git diff --stat` shows exactly 2 files / +4 / -3.
- [x] README's "Connecting Your CDR" reads cleanly with the inserted step.
- [x] CONTRIBUTING's "How to add a connection kind" recipe still aligns with the actual `CDRConfig` model (now has `is_read_only` + `max_bundle_entries` per `backend/app/models/config.py:18-38`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)