### PR TITLE
docs(upstream-issues): mark CMS130 draft as filed (cqframework/dqm-content-qicore-2025#49)

### DIFF
--- a/docs/upstream-issues/cms130-dementia-condition.md
+++ b/docs/upstream-issues/cms130-dementia-condition.md
@@ -1,9 +1,9 @@
-# Draft upstream issue — CMS130 dementia Condition code mismatch
+# Upstream issue — CMS130 dementia Condition code mismatch
 
-**Status:** draft, not yet submitted
+**Status:** **filed 2026-05-17** as [cqframework/dqm-content-qicore-2025#49](https://github.com/cqframework/dqm-content-qicore-2025/issues/49)
 **Target repo:** `cqframework/dqm-content-qicore-2025`
-**Suggested title:** `CMS130 test case: Condition.code does not match test-case description ("dementia") — exclusion not reproducible from patient resources`
-**Suggested labels:** `bug`, `content`
+**Title:** `CMS130 test case: Condition.code does not match test-case description ("dementia") — exclusion not reproducible from patient resources`
+**Labels:** `bug`, `content`
 
 ---
 


### PR DESCRIPTION
The CMS130 dementia-Condition upstream draft has been filed: [cqframework/dqm-content-qicore-2025#49](https://github.com/cqframework/dqm-content-qicore-2025/issues/49).

Updates the local file's status header so future readers see it's been submitted, with a link to the live tracking issue. No content changes to the body of the draft.

The sibling CMS122 AI+Frailty MedicationRequest draft (`cms122-ai-frailty-medicationrequest-period.md`) remains a draft — different defect class, still under evaluation.

## Test plan

- [x] Issue is visible at the linked URL with title, body, and labels (`bug`, `content`) matching the draft.
- [x] Local draft's status line now reads "filed 2026-05-17 as ...#49".

🤖 Generated with [Claude Code](https://claude.com/claude-code)