### PR TITLE
fix(tests): update CMS122 measure ID to canonical form in integration tests

### DIFF
--- a/backend/tests/integration/test_fhir_operations.py
+++ b/backend/tests/integration/test_fhir_operations.py
@@ -37,7 +37,7 @@ async def test_list_measures(measure_url):
     assert bundle["resourceType"] == "Bundle"
     entries = bundle.get("entry", [])
     measure_ids = [e["resource"]["id"] for e in entries if e.get("resource", {}).get("resourceType") == "Measure"]
-    assert "CMS122FHIRDiabetesAssessGT9Pct" in measure_ids, f"Expected CMS122 measure in {measure_ids}"
+    assert "CMS122FHIRDiabetesAssessGreaterThan9Percent" in measure_ids, f"Expected CMS122 measure in {measure_ids}"
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +196,7 @@ async def test_evaluate_measure(measure_url, cdr_url):
 
         try:
             report = await evaluate_measure(
-                measure_id="CMS122FHIRDiabetesAssessGT9Pct",
+                measure_id="CMS122FHIRDiabetesAssessGreaterThan9Percent",
                 patient_id="6f0553ac-e12a-4af5-ad27-05339f4b4ec0",
                 period_start="2025-01-01",
                 period_end="2025-12-31",

--- a/backend/tests/integration/test_full_workflow.py
+++ b/backend/tests/integration/test_full_workflow.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.integration
 async def _create_job(db_session, **overrides) -> Job:
     """Insert a Job row and return it."""
     defaults = {
-        "measure_id": "CMS122FHIRDiabetesAssessGT9Pct",
+        "measure_id": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
         "measure_name": "CMS122 Diabetes HbA1c Poor Control",
         "period_start": "2025-01-01",
         "period_end": "2025-12-31",
@@ -49,7 +49,7 @@ async def test_create_and_run_job(integration_client, db_session, integration_se
     resp = await integration_client.post(
         "/jobs",
         json={
-            "measure_id": "CMS122FHIRDiabetesAssessGT9Pct",
+            "measure_id": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
             "measure_name": "CMS122 Diabetes HbA1c Poor Control",
             "period_start": "2025-01-01",
             "period_end": "2025-12-31",
@@ -108,7 +108,7 @@ async def test_results_aggregate_populations(integration_client, db_session, int
     resp = await integration_client.post(
         "/jobs",
         json={
-            "measure_id": "CMS122FHIRDiabetesAssessGT9Pct",
+            "measure_id": "CMS122FHIRDiabetesAssessGreaterThan9Percent",
             "period_start": "2025-01-01",
             "period_end": "2025-12-31",
             "cdr_url": TEST_CDR_URL,
@@ -189,7 +189,7 @@ async def test_patient_drill_down(integration_client, db_session):
 
     # Create a job to hang the result on
     job = Job(
-        measure_id="CMS122FHIRDiabetesAssessGT9Pct",
+        measure_id="CMS122FHIRDiabetesAssessGreaterThan9Percent",
         period_start="2025-01-01",
         period_end="2025-12-31",
         cdr_url=TEST_CDR_URL,
@@ -224,7 +224,7 @@ async def test_partial_failure_handling(integration_client, db_session):
     """If a batch is marked as failed, the results endpoint still returns partial data."""
     # Create a completed job with one result
     job = Job(
-        measure_id="CMS122FHIRDiabetesAssessGT9Pct",
+        measure_id="CMS122FHIRDiabetesAssessGreaterThan9Percent",
         period_start="2025-01-01",
         period_end="2025-12-31",
         cdr_url=TEST_CDR_URL,


### PR DESCRIPTION
## Summary

- PR #319 renamed the CMS122 measure resource ID from `CMS122FHIRDiabetesAssessGT9Pct` → `CMS122FHIRDiabetesAssessGreaterThan9Percent` in `seed/measure-bundle.json` to align with the MADiE canonical form
- Two integration test files still asserted the old short ID, causing `test_list_measures` and `test_evaluate_measure` to fail in CI on every PR since #319 merged (runs #26044153372 and #26044246955)
- `test_services_validation.py` also references the old ID but intentionally (it tests the canonical-URL clash guard with the abbreviated ID as a simulated "stale HAPI state") — left unchanged

## Changes

- `backend/tests/integration/test_fhir_operations.py`: 2 occurrences updated (the two failing assertions)
- `backend/tests/integration/test_full_workflow.py`: 5 occurrences updated (excluded from CI-equivalent runs via `--ignore` but would fail if run)

## Test plan

- [ ] CI integration tests pass (this fixes the root cause directly)
- [ ] Unit suite unaffected (stale ID in `test_services_validation.py` is intentional; no production code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)