### PR TITLE
docs(security): extend ADR-008 for Dependabot alert #28 (CVE-2026-6402)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -78,6 +78,8 @@ This log records significant technical and process choices with their rationale.
 
 **Alternatives considered:** Upgrading or replacing `react-scripts` (CRA successor migration) — deferred as a multi-week refactor unrelated to these alerts. Accepting 5.x with a broken dev server — rejected because it masks a real developer experience regression behind a green CI build.
 
+**Follow-up (2026-05-18):** Alert #28 (`GHSA-79cf-xcqc-c78w` / CVE-2026-6402) is a bypass of the v5.2.1 fix from GHSA-4v9v-hfq4-rm2v (alert #7): browsers don't send `Sec-Fetch-*` headers over plain HTTP, so the header-based block introduced in 5.2.1 is ineffective on the non-HTTPS default. The patched version is `5.2.4`, still 5.x, so the `react-scripts@5.0.1` 4.x-API incompatibility and the CI-stays-green-while-npm-start-breaks failure mode are unchanged. Production image (`serve@14` on static `build/`) still doesn't include webpack-dev-server. Alert #28 dismissed with `dismissed_reason=not_used` under the same rationale. This is the third iteration of this vulnerability class on the same dev-only dependency — future alerts in this family will follow the same disposition until `react-scripts` is replaced.
+
 ---
 
 ## ADR-009: Bundle chunking is per-CDR-connection, not global (2026-05-16)


### PR DESCRIPTION
## Summary

- Extends ADR-008 in `docs/decisions.md` with a follow-up paragraph covering Dependabot alert #28 (`GHSA-79cf-xcqc-c78w` / CVE-2026-6402).
- No code changes — docs only.

**Background:** Alert #28 is a bypass of the v5.2.1 fix (CVE-2025-30359, alert #7). The `Sec-Fetch-*` header check introduced in 5.2.1 is absent over plain HTTP, so the fix is ineffective on the non-HTTPS default. Patched in 5.2.4 (still 5.x — same `react-scripts@5.0.1` 4.x-API incompatibility as before). `webpack-dev-server` remains dev-only and absent from the production image (`serve@14` on static `build/`). Same `not_used` dismissal rationale applies.

The alert will be dismissed via the GitHub API immediately after this merges.

## Test plan

- [ ] `grep -n "ADR-008\|Follow-up" docs/decisions.md` — follow-up paragraph visible at line ~81, dated 2026-05-18.
- [ ] No code files changed (`git diff HEAD~1 --name-only` shows only `docs/decisions.md`).
- [ ] After merge: dismiss alert #28 with `dismissed_reason=not_used` and verify `gh api repos/Bellese/Lenny/dependabot/alerts/28 --jq .state` returns `"dismissed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)