### PR TITLE
feat(jobs): UX polish for Duration column — format, historical fallback, Results page

### DIFF
--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -389,7 +389,7 @@ export default function JobsPage() {
                       <td data-label="Status"><StatusBadge status={job.status} /></td>
                       <td data-label="Queued" className={styles.dateCell}>{formatDateTime(job.created_at)}</td>
                       <td data-label="Started" className={styles.dateCell}>{job.started_at ? formatDateTime(job.started_at) : '—'}</td>
-                      <td data-label="Duration" className={styles.dateCell}>{formatDuration(job.started_at, job.completed_at)}</td>
+                      <td data-label="Duration" className={styles.dateCell}>{formatDuration(job.started_at || (job.completed_at ? job.created_at : null), job.completed_at)}</td>
                       <td data-label="Actions">
                         <KebabMenu items={[
                           { label: 'View results', icon: <ViewIcon />, disabled: !complete, onClick: () => navigate(`/results/${job.id}`) },

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -11,12 +11,7 @@ import { useSearch } from '../contexts/SearchContext';
 import PeriodPicker from '../components/PeriodPicker';
 import { extractCmsId, measureDisplayLabel, measureOptionLabel, findMatchingGroup } from '../utils/measureFormat';
 import { isActuallyRunning, isRunning, isComplete, selectActiveJob } from '../utils/jobStatus';
-
-function formatDateTime(dateStr) {
-  if (!dateStr) return '--';
-  const d = new Date(dateStr);
-  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-}
+import { formatDateTime, formatDuration } from '../utils/dateFormat';
 
 function formatElapsed(startStr) {
   if (!startStr) return '--';
@@ -24,20 +19,6 @@ function formatElapsed(startStr) {
   const m = Math.floor(diff / 60);
   const s = diff % 60;
   return `${m}m ${String(s).padStart(2, '0')}s`;
-}
-
-export function formatDuration(startStr, endStr, nowFn) {
-  if (!startStr) return '—';
-  const end = endStr ? new Date(endStr) : new Date((nowFn || Date.now)());
-  const diffSec = Math.max(0, Math.floor((end - new Date(startStr)) / 1000));
-  if (diffSec < 3600) {
-    const m = Math.floor(diffSec / 60);
-    const s = diffSec % 60;
-    return `${m}:${String(s).padStart(2, '0')}`;
-  }
-  const h = Math.floor(diffSec / 3600);
-  const m = Math.floor((diffSec % 3600) / 60);
-  return `${h}h ${m}m`;
 }
 
 function estimateRemaining(startStr, progress) {

--- a/frontend/src/pages/JobsPage.test.js
+++ b/frontend/src/pages/JobsPage.test.js
@@ -1,4 +1,4 @@
-import { formatDuration } from './JobsPage';
+import { formatDuration } from '../utils/dateFormat';
 
 describe('formatDuration', () => {
   it('returns em-dash when startStr is null', () => {
@@ -9,16 +9,16 @@ describe('formatDuration', () => {
     expect(formatDuration(undefined, '2024-01-01T00:01:30Z')).toBe('—');
   });
 
-  it('sub-hour: 1m 30s yields 1:30', () => {
+  it('sub-hour: 1m 30s yields 1m 30s', () => {
     const start = '2024-01-01T00:00:00Z';
     const end = '2024-01-01T00:01:30Z';
-    expect(formatDuration(start, end)).toBe('1:30');
+    expect(formatDuration(start, end)).toBe('1m 30s');
   });
 
-  it('exactly 0 seconds yields 0:00', () => {
+  it('exactly 0 seconds yields 0m 00s', () => {
     const start = '2024-01-01T00:00:00Z';
     const end = '2024-01-01T00:00:00Z';
-    expect(formatDuration(start, end)).toBe('0:00');
+    expect(formatDuration(start, end)).toBe('0m 00s');
   });
 
   it('exactly 1 hour (3600s) yields 1h 0m', () => {
@@ -33,28 +33,28 @@ describe('formatDuration', () => {
     expect(formatDuration(start, end)).toBe('1h 1m');
   });
 
-  it('clock-skew: end before start clamps to 0:00', () => {
+  it('clock-skew: end before start clamps to 0m 00s', () => {
     const start = '2024-01-01T01:00:00Z';
     const end = '2024-01-01T00:59:00Z';
-    expect(formatDuration(start, end)).toBe('0:00');
+    expect(formatDuration(start, end)).toBe('0m 00s');
   });
 
   it('live tick: null endStr uses nowFn', () => {
     const start = '2024-01-01T00:00:00Z';
     const nowMs = new Date('2024-01-01T00:01:30Z').getTime();
     const nowFn = () => nowMs;
-    expect(formatDuration(start, null, nowFn)).toBe('1:30');
+    expect(formatDuration(start, null, nowFn)).toBe('1m 30s');
   });
 
   it('zero-pads seconds below 10', () => {
     const start = '2024-01-01T00:00:00Z';
     const end = '2024-01-01T00:01:05Z';
-    expect(formatDuration(start, end)).toBe('1:05');
+    expect(formatDuration(start, end)).toBe('1m 05s');
   });
 
   it('59 minutes 59 seconds stays sub-hour', () => {
     const start = '2024-01-01T00:00:00Z';
     const end = new Date(new Date(start).getTime() + 3599 * 1000).toISOString();
-    expect(formatDuration(start, end)).toBe('59:59');
+    expect(formatDuration(start, end)).toBe('59m 59s');
   });
 });

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -11,6 +11,7 @@ import DistBar from '../components/DistBar';
 import { CheckIcon, WarnIcon } from '../components/Icons';
 import { useSearch } from '../contexts/SearchContext';
 import { extractCmsId, cleanMeasureName, measureOptionLabel, measureDisplayLabel } from '../utils/measureFormat';
+import { formatDateTime, formatDuration } from '../utils/dateFormat';
 
 function timeAgo(dateStr) {
   if (!dateStr) return null;
@@ -660,6 +661,15 @@ export default function ResultsPage() {
           {completedAgo && (
             <div className={styles.sub}>
               <span className={styles.completeBadge}>Complete</span>{' '}Calculated {completedAgo}
+            </div>
+          )}
+          {selectedJob && (
+            <div className={styles.sub}>
+              <span>Queued {formatDateTime(selectedJob.created_at)}</span>
+              {' · '}
+              <span>Started {selectedJob.started_at ? formatDateTime(selectedJob.started_at) : '—'}</span>
+              {' · '}
+              <span>Duration {formatDuration(selectedJob.started_at || (selectedJob.completed_at ? selectedJob.created_at : null), selectedJob.completed_at)}</span>
             </div>
           )}
         </div>

--- a/frontend/src/utils/dateFormat.js
+++ b/frontend/src/utils/dateFormat.js
@@ -1,0 +1,19 @@
+export function formatDateTime(dateStr) {
+  if (!dateStr) return '--';
+  const d = new Date(dateStr);
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+export function formatDuration(startStr, endStr, nowFn) {
+  if (!startStr) return '—';
+  const end = endStr ? new Date(endStr) : new Date((nowFn || Date.now)());
+  const diffSec = Math.max(0, Math.floor((end - new Date(startStr)) / 1000));
+  if (diffSec < 3600) {
+    const m = Math.floor(diffSec / 60);
+    const s = diffSec % 60;
+    return `${m}m ${String(s).padStart(2, '0')}s`;
+  }
+  const h = Math.floor(diffSec / 3600);
+  const m = Math.floor((diffSec % 3600) / 60);
+  return `${h}h ${m}m`;
+}


### PR DESCRIPTION
## Summary

Follow-up polish to #340 (Duration column on Runs list). Two commits approved via local UI review after #340 merged.

- **Historical rows fallback**: rows created before `started_at` existed showed `—` for Duration. Now falls back to `created_at` as an approximate start for completed jobs where `started_at IS NULL`, so users see a ballpark duration instead of nothing.
- **Format clarification**: duration format changed from `4:00` to `4m 00s` so the unit is unambiguous. Also adds **Queued / Started / Duration** to the Results page header so users can see timing after drilling into a result.

## Test plan

- [x] `formatDuration` unit tests pass with new `Xm XXs` format strings (88/88 frontend tests green)
- [x] Backend unit suite passes (489 tests)
- [x] Local stack: Duration column shows approximate duration for historical rows; Results page header shows timing metadata
- [x] User approved UI locally before this PR was opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)