### PR TITLE
v0.0.19.1 fix(ui): table horizontal scroll + measure column min-width (#Jobs #Measures #Results)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.19.1] - 2026-05-18
+
+### Fixed
+- **Jobs / Measures / Results: table content no longer clipped at narrow viewports.** Added an inner `tableScroll` wrapper (`overflow-x: auto`) inside each table card so a horizontal scrollbar appears when the viewport is between 820px and ~1100px — rightmost columns (Status, Duration, Actions) are now reachable by scroll instead of being silently hidden. Fixes the Duration column appearing missing on prod for users with narrower windows.
+- **Jobs / Measures: Measure column now has a 260px minimum width.** Long CMS measure names like "Diabetes: Glycemic Status Assessment Greater Than 9%" no longer squeeze to 5–6 lines; they render in ≤2 lines at typical desktop widths.
+- **Jobs: Period column wraps cleanly.** Each date value stays on one line; the break only happens at the " – " separator between start and end dates.
+- **Jobs: Cohort column truncated at 145px.** Prevents long camelCase cohort identifiers from pushing the table past the card width.
+- **Mobile stacked layout unaffected.** The `@media (max-width: 820px)` stacked-card treatment on all three pages is preserved exactly.
+
 ## [0.0.18.1] - 2026-05-18
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lenny-frontend",
-  "version": "0.0.19.0",
+  "version": "0.0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lenny-frontend",
-      "version": "0.0.19.0",
+      "version": "0.0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenny-frontend",
-  "version": "0.0.19.0",
+  "version": "0.0.19.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -306,9 +306,11 @@ export default function JobsPage() {
       {/* Jobs table */}
       {loading && (
         <div className={styles.card} role="status" aria-label="Loading jobs">
-          <table><thead><tr><th>Measure</th><th>Period</th><th>Cohort</th><th>Patients</th><th>Status</th><th>Queued</th><th>Started</th><th>Duration</th><th style={{ width: 50 }}></th></tr></thead>
-            <tbody>{[1,2,3].map(i => (<tr key={i}>{[180,100,80,80,40,80,80,60,50].map((w,j) => (<td key={j}><div className="skeleton" style={{ height: 14, width: w }} /></td>))}</tr>))}</tbody>
-          </table>
+          <div className={styles.tableScroll}>
+            <table><thead><tr><th className={styles.measureCell}>Measure</th><th>Period</th><th>Cohort</th><th>Patients</th><th>Status</th><th>Queued</th><th>Started</th><th>Duration</th><th style={{ width: 50 }}></th></tr></thead>
+              <tbody>{[1,2,3].map(i => (<tr key={i}>{[180,100,80,80,40,80,80,60,50].map((w,j) => (<td key={j}><div className="skeleton" style={{ height: 14, width: w }} /></td>))}</tr>))}</tbody>
+            </table>
+          </div>
         </div>
       )}
 
@@ -325,10 +327,11 @@ export default function JobsPage() {
             <span className={styles.cardTitle}>All jobs</span>
             <span className={styles.cardCount}>{filteredJobs.length}</span>
           </div>
+          <div className={styles.tableScroll}>
           <table aria-label="Calculation jobs">
             <thead>
               <tr>
-                <th>Measure</th>
+                <th className={styles.measureCell}>Measure</th>
                 <th>Period</th>
                 <th>Cohort</th>
                 <th>Patients</th>
@@ -356,14 +359,16 @@ export default function JobsPage() {
                       onClick={() => complete && navigate(`/results/${job.id}`)}
                       style={{ cursor: complete ? 'pointer' : 'default' }}
                     >
-                      <td data-label="Measure">
+                      <td data-label="Measure" className={styles.measureCell}>
                         <div className={styles.jobMeta}>
                           <div className={styles.jobName}>{getMeasureName(job)}</div>
                           <div className={`${styles.mono} ${styles.jobId}`}>{job.id}</div>
                         </div>
                       </td>
                       <td data-label="Period" className={`${styles.mono} ${styles.periodCell}`}>
-                        {job.period_start && job.period_end ? `${job.period_start} – ${job.period_end}` : '--'}
+                        {job.period_start && job.period_end
+                          ? <><span style={{whiteSpace:'nowrap'}}>{job.period_start}</span>{' – '}<span style={{whiteSpace:'nowrap'}}>{job.period_end}</span></>
+                          : '--'}
                       </td>
                       <td data-label="Cohort" className={styles.cohortCell}>{getCohortName(job)}</td>
                       <td data-label="Patients" className={styles.patientCountCell}>{getPatientCount(job)}</td>
@@ -392,6 +397,7 @@ export default function JobsPage() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/JobsPage.module.css
+++ b/frontend/src/pages/JobsPage.module.css
@@ -225,6 +225,14 @@
   box-shadow: var(--shadow-card);
 }
 
+.tableScroll {
+  overflow-x: auto;
+}
+
+.measureCell {
+  min-width: 260px;
+}
+
 .cardHeader {
   display: flex;
   align-items: center;
@@ -275,13 +283,20 @@
   flex-shrink: 0;
   white-space: nowrap;
 }
-.periodCell { color: var(--text-muted); white-space: nowrap; }
-.cohortCell,
+.periodCell { color: var(--text-muted); }
+.cohortCell {
+  font-size: 12px;
+  color: var(--text-muted);
+  max-width: 145px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .patientCountCell {
   font-size: 12px;
   color: var(--text-muted);
 }
-.dateCell { font-size: 12px; color: var(--text-dim); white-space: nowrap; }
+.dateCell { font-size: 12px; color: var(--text-dim); }
 
 .emptyRow {
   text-align: center;
@@ -522,7 +537,12 @@
     white-space: normal;
   }
 
-  .cohortCell,
+  .cohortCell {
+    max-width: none;
+    overflow: visible;
+    text-overflow: clip;
+    color: var(--text);
+  }
   .patientCountCell {
     color: var(--text);
   }
@@ -571,5 +591,13 @@
 
   .sheetFooter {
     flex-direction: column-reverse;
+  }
+
+  .tableScroll {
+    overflow-x: visible;
+  }
+
+  .measureCell {
+    min-width: 0;
   }
 }

--- a/frontend/src/pages/MeasuresPage.js
+++ b/frontend/src/pages/MeasuresPage.js
@@ -139,10 +139,11 @@ export default function MeasuresPage() {
 
       {loading && (
         <div className={styles.card} role="status" aria-label="Loading measures">
+          <div className={styles.tableScroll}>
           <table>
             <thead>
               <tr>
-                <th>ID</th><th>Measure</th><th>Version</th><th>Status</th><th style={{ textAlign: 'right' }}>Actions</th>
+                <th>ID</th><th className={styles.measureCell}>Measure</th><th>Version</th><th>Status</th><th style={{ textAlign: 'right' }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -155,6 +156,7 @@ export default function MeasuresPage() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 
@@ -168,11 +170,12 @@ export default function MeasuresPage() {
 
       {!loading && !error && (
         <div className={styles.card}>
+          <div className={styles.tableScroll}>
           <table aria-label="Loaded measures">
             <thead>
               <tr>
                 <th style={{ width: 120 }}>ID</th>
-                <th>Measure</th>
+                <th className={styles.measureCell}>Measure</th>
                 <th style={{ width: 90 }}>Version</th>
                 <th style={{ width: 100 }}>Status</th>
                 <th style={{ width: 100, textAlign: 'right' }}>Actions</th>
@@ -189,7 +192,7 @@ export default function MeasuresPage() {
                 visible.map((measure, i) => (
                   <tr key={measure.id || i} className={styles.row}>
                     <td data-label="ID"><span className={styles.mono}>{extractCmsId(measure.id) || measure.id || '--'}</span></td>
-                    <td data-label="Measure" className={styles.measureName}>{getMeasureDisplayName(measure)}</td>
+                    <td data-label="Measure" className={`${styles.measureName} ${styles.measureCell}`}>{getMeasureDisplayName(measure)}</td>
                     <td data-label="Version" className={styles.mono} style={{ color: 'var(--text-muted)' }}>{getMeasureVersion(measure)}</td>
                     <td data-label="Status"><StatusBadge status={getMeasureStatus(measure)} /></td>
                     <td data-label="Actions">
@@ -212,6 +215,7 @@ export default function MeasuresPage() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/MeasuresPage.module.css
+++ b/frontend/src/pages/MeasuresPage.module.css
@@ -63,6 +63,14 @@
   box-shadow: var(--shadow-card);
 }
 
+.tableScroll {
+  overflow-x: auto;
+}
+
+.measureCell {
+  min-width: 260px;
+}
+
 .row:hover td {
   background: var(--bg-sunken);
 }
@@ -292,5 +300,13 @@
 
   .actionGroup {
     justify-content: flex-start;
+  }
+
+  .tableScroll {
+    overflow-x: visible;
+  }
+
+  .measureCell {
+    min-width: 0;
   }
 }

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -841,6 +841,7 @@ export default function ResultsPage() {
             )}
 
             {/* Table */}
+            <div className={styles.tableScroll}>
             <table aria-label="Patient results">
               <thead>
                 <tr>
@@ -971,6 +972,7 @@ export default function ResultsPage() {
                 )}
               </tbody>
             </table>
+            </div>
           </div>
         </>
       )}

--- a/frontend/src/pages/ResultsPage.module.css
+++ b/frontend/src/pages/ResultsPage.module.css
@@ -185,6 +185,10 @@
   overflow: hidden;
 }
 
+.tableScroll {
+  overflow-x: auto;
+}
+
 .tableHeader {
   display: flex;
   align-items: center;
@@ -822,6 +826,10 @@
 
   .popCell {
     text-align: left;
+  }
+
+  .tableScroll {
+    overflow-x: visible;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Horizontal scroll restored on narrow viewports.** Wraps each table in a `tableScroll` div (`overflow-x: auto`) inside the card. The card's `overflow: hidden` (for rounded corners) was silently clipping columns (Status, Duration, Actions) at 820–1100px viewports. Now those columns are reachable by scroll. This also restores the Duration column on Jobs/Results for users whose window isn't full-width — the column was rendered but clipped.
- **Measure column min-width 260px (Jobs + Measures).** Long CMS names like "Diabetes: Glycemic Status Assessment Greater Than 9%" previously squeezed to 5–6 lines when neighboring nowrap columns hogged horizontal space. Now they render in ≤2 lines.
- **Period cell keeps dates non-breaking; cohort truncated at 145px.** Period dates no longer split mid-ISO-string; cohort column uses ellipsis so it doesn't push the table past card width at 1280px.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (N/A — CSS/JSX layout fix, no logic changed; 88/88 frontend tests pass)
- [x] docs/ updated (N/A)
- [x] No new ADRs needed
- [x] Security implications considered (N/A)

## Test plan

- [ ] **Default desktop (>1100px):** Measure cells on `/jobs` and `/measures` show CMS names in ≤2 lines. No horizontal scrollbar. Duration column on Jobs visible.
- [ ] **Narrow desktop (~900px, between 820–1100px):** Horizontal scrollbar appears inside the table card on `/jobs`, `/measures`, and a `/results/:id` for a completed job. Card header stays fixed; rightmost columns reachable by scroll.
- [ ] **Mobile (≤820px):** Stacked-card layout still renders on all three pages — each row is a vertical list with `data-label` chips, no horizontal scroll, no regression.