### PR TITLE
fix(test): add OBSENC eval gate probe for CMS529 to prevent indexing race

### DIFF
--- a/backend/tests/integration/test_golden_measures.py
+++ b/backend/tests/integration/test_golden_measures.py
@@ -449,6 +449,15 @@ def _load_golden_bundles_to_hapi(_require_infrastructure):
             "2026-07-01",
             "2027-06-30",
         ),
+        # OBSENC patient for CMS529 — different encounter class than the ACUTE probe above;
+        # HAPI may index OBSENC encounters on a separate path that lags behind ACUTE.
+        (
+            "CMS529",
+            "https://madie.cms.gov/Measure/CMSFHIR529HybridHospitalWideReadmission",
+            "2152d065-ba97-4334-a1e5-a9239e600906",
+            "2026-07-01",
+            "2027-06-30",
+        ),
     ]
     _loaded_bundle_names = {n for n, _ in _get_golden_bundles()}
     _active_gates = []
@@ -460,9 +469,10 @@ def _load_golden_bundles_to_hapi(_require_infrastructure):
         if not _ents:
             continue
         _mid = _ents[0]["resource"]["id"]
+        _gate_key = f"{_prefix}:{_mpat[:8]}"
         _active_gates.append(
             (
-                _prefix,
+                _gate_key,
                 f"{TEST_MEASURE_URL}/Measure/{_mid}/$evaluate-measure"
                 f"?subject=Patient/{_mpat}&periodStart={_pstart}&periodEnd={_pend}",
             )
@@ -471,7 +481,7 @@ def _load_golden_bundles_to_hapi(_require_infrastructure):
     if _active_gates:
         _gate_timeout = 600
         _gate_deadline = _time.monotonic() + _gate_timeout
-        _gate_pending = {prefix: url for prefix, url in _active_gates}
+        _gate_pending = {key: url for key, url in _active_gates}
         while _gate_pending and _time.monotonic() < _gate_deadline:
             _newly_done: set[str] = set()
             for _prefix, _gurl in list(_gate_pending.items()):


### PR DESCRIPTION
## Summary

- **Root cause:** `test_golden_measure_evaluates[CMS529FHIRHybridHospitalWideReadmission-bundle0]` fails because patient `2152d065` has an `OBSENC`-class encounter that HAPI indexes on a different path than `ACUTE` encounters. The existing eval gate only probed patient `1a527f21` (ACUTE class), so it could exit before the OBSENC patient's data was visible to the CQL engine — `$evaluate-measure` then returned `initial-population: 0` instead of `1`.
- **Fix:** Add a second CMS529 gate probe for patient `2152d065-ba97-4334-a1e5-a9239e600906` so both encounter classes must be indexable before tests run.
- **Latent bug fixed:** `_gate_pending` used prefix as the dict key, so a second entry for `CMS529` would silently overwrite the first. Keys are now `"{prefix}:{patient[:8]}"` — `CMS529:1a527f21` and `CMS529:2152d065` coexist.

Failure observed in run [#27524045343](https://github.com/Bellese/Lenny/actions/runs/27524045343).

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] All 477 unit tests pass locally
- [ ] CI integration suite passes (this PR triggered it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)