### PR TITLE
fix(ops): reclaim disk at deploy-start to prevent ENOSPC (#368)

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -3,13 +3,15 @@
 #
 # Boot flow (full deploy, no arguments):
 #   1. Preflight checks (root, fetch script present)
+#   1.5 Reclaim disk (docker image prune + builder prune --keep-storage 5GB)
 #   2. env -i → fetch-prod-secrets.sh (writes /run/leonard/env)
 #   3. Verify /run/leonard/env; extract POSTGRES_PASSWORD to Docker secret file
 #   4. docker compose up -d db
 #   5. Wait for db healthcheck to pass (12 × 5s = 60s max)
 #   6. scripts/reconcile-db-password.sh
-#   7. docker compose up -d (remaining services)
-#   8. Health check: curl https://api.lenny.bellese.dev/health (24 × 5s = 2 min max)
+#   7. docker compose pull (pre-built images)
+#   8. docker compose up -d --build (remaining services)
+#   9. Health check: curl https://api.lenny.bellese.dev/health (24 × 5s = 2 min max)
 #
 # --post-db-restart mode:
 #   Runs only steps 1–3 and 6 (preflight, fetch, extract secret, reconcile).
@@ -83,6 +85,29 @@ if [[ ! -f "$RECONCILE_SCRIPT" ]]; then
 fi
 if [[ ! -x "$RECONCILE_SCRIPT" ]]; then
     die 1 "reconcile-db-password.sh is not executable at '${RECONCILE_SCRIPT}'"
+fi
+
+# ── step 1.5: reclaim disk before deploy (full deploy only; self-healing) ─────
+# Every deploy's `pull` (step 7) orphans the previous :latest images and
+# `up --build` (step 8) adds BuildKit cache; with no cleanup step this exhausted
+# the 30 GB root volume and broke a deploy on ENOSPC (issue #368). Reclaim FIRST,
+# before secret-fetch (mktemp → root FS) and before pull/build, so each deploy
+# frees space before it consumes it. Skipped in --post-db-restart mode (no
+# pull/build there). Data-safe: `image prune -f` removes only dangling (untagged)
+# images; `builder prune` removes only build cache. Neither touches running
+# containers, in-use tagged images, or named volumes — HAPI H2 (cdrdata/
+# measuredata), Postgres (pgdata), and Caddy volumes are safe.
+# On failure (e.g. an unsupported flag) we WARN but continue — a cleanup hiccup
+# must not block an otherwise-healthy deploy, but it must be visible in the logs
+# (not silently swallowed) so a broken flag doesn't quietly recreate issue #368.
+if [[ "$POST_DB_RESTART" -eq 0 ]]; then
+    printf '[+] Reclaiming disk before deploy (dangling images + build cache)...\n'
+    docker image prune -f \
+        || printf '[!] WARNING: docker image prune failed — continuing deploy\n' >&2
+    docker builder prune -f --keep-storage 5GB \
+        || printf '[!] WARNING: docker builder prune failed — continuing deploy\n' >&2
+    printf '[+] Disk after reclaim:\n'
+    df -h /
 fi
 
 # ── step 2: fetch secrets ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Every deploy accumulates dangling images (from `pull` re-publishing `:latest`) and BuildKit cache (from `up --build`) with no cleanup, which exhausted the 30 GB root volume and broke a deploy on ENOSPC
- Adds a self-healing disk reclaim block (step 1.5) at the very start of the full deploy path — before secret-fetch and before all docker consumers — so each deploy frees space before it consumes it
- `docker image prune -f` removes dangling images; `docker builder prune -f --keep-storage 5GB` bounds build cache to ~5 GB warm; warn-and-continue on failure so a broken flag is visible in CloudWatch without blocking a deploy

## Related issue

Closes #368

## Type of change

- [x] Infrastructure / CI/CD

## Checklist

- [x] Tests added or updated (N/A — shell-only change, no Python modified)
- [x] docs/ updated (N/A — no architecture or API change)
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered — no `set -x`, no secret references in new lines; prune commands touch only dangling images and build cache, never named volumes (HAPI H2, Postgres, Caddy) or running containers

## Test plan

- [x] Lint (ruff check + format) — clean
- [x] Unit suite (`pytest --ignore=tests/integration`) — passed
- [x] Script Security Lint (`set -x` grep) — clean
- [x] Bash syntax (`bash -n scripts/deploy-prod.sh`) — clean
- [x] CI-equivalent integration suite (`./scripts/run-integration-tests.sh --ignore=...`) — passed
- [ ] **Post-merge (first deploy):** watch `/leonard/deploy` CloudWatch log group for `[+] Reclaiming disk before deploy...` line, confirm no `[!] WARNING: docker ... prune failed` line, and verify `df -h /` output shows freed space vs pre-deploy baseline. Deploy success alone is not sufficient — the reclaim must have actually run. (`AWS_PROFILE=leonard`)