### PR TITLE
fix(validation): repair broken run_validation call signatures

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -1236,7 +1236,7 @@ async def run_validation(validation_run_id: int) -> None:
 
             # Best-effort for validation: stale resources are worse than ideal, but
             # aborting prevents patient-level comparison entirely on slow HAPI deletes.
-            await wipe_patient_data(strict=False)
+            await wipe_patient_data(base_url=settings.MEASURE_ENGINE_URL, strict=False)
             if await _stop_or_delete_validation_run(validation_run_id):
                 return
 
@@ -1248,7 +1248,8 @@ async def run_validation(validation_run_id: int) -> None:
                 async with semaphore:
                     if await _stop_or_delete_validation_run(validation_run_id):
                         return set()
-                    resources = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
+                    gather_result = await strategy.gather_patient_data(cdr_url, patient_ref, auth_headers)
+                    resources = gather_result.resources
                     if resources:
                         await push_resources(resources)
                     return {

--- a/backend/tests/test_services_validation.py
+++ b/backend/tests/test_services_validation.py
@@ -7,8 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy import func, select
 
+from app.config import settings
 from app.models.validation import ExpectedResult, ValidationResult, ValidationRun, ValidationStatus
-from app.services.fhir_client import BundleUploadResult
+from app.services.fhir_client import BundleUploadResult, GatherResult
 from app.services.validation import (
     _assert_no_canonical_url_clash,
     _classify_bundle_entries,
@@ -1054,7 +1055,9 @@ class TestRunValidation:
         await test_session.refresh(run)
 
         strategy = MagicMock()
-        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
+        strategy.gather_patient_data = AsyncMock(
+            return_value=GatherResult(resources=[{"resourceType": "Patient", "id": "patient-1"}])
+        )
 
         def make_ctx():
             return self._make_session_ctx(test_session)
@@ -1125,6 +1128,11 @@ class TestRunValidation:
         assert rows[1].status == "error"
         assert "Measure not found on engine after reload attempt" in rows[1].error_message
         mock_wipe.assert_awaited_once()
+        # Regression guard: the pre-push wipe must target the measure engine explicitly
+        # (wipe_patient_data requires the keyword-only base_url argument).
+        _, wipe_kwargs = mock_wipe.await_args
+        assert wipe_kwargs.get("base_url") == settings.MEASURE_ENGINE_URL
+        assert wipe_kwargs.get("strict") is False
         mock_push.assert_awaited_once()
         # Warmup burst adds 1 call per measure + 1 main eval = 2 total
         assert mock_evaluate.await_count == 2
@@ -1175,7 +1183,9 @@ class TestRunValidation:
         monkeypatch.setattr("app.services.validation.settings.MAX_WORKERS", 2)
 
         strategy = MagicMock()
-        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
+        strategy.gather_patient_data = AsyncMock(
+            return_value=GatherResult(resources=[{"resourceType": "Patient", "id": "patient-1"}])
+        )
 
         def make_ctx():
             return self._make_session_ctx(test_session)
@@ -1280,7 +1290,7 @@ class TestRunValidation:
         async def gather_side_effect(cdr_url, patient_ref, auth_headers):
             if patient_ref == "patient-2":
                 raise RuntimeError("CDR connection refused")
-            return [{"resourceType": "Patient", "id": patient_ref}]
+            return GatherResult(resources=[{"resourceType": "Patient", "id": patient_ref}])
 
         strategy = MagicMock()
         strategy.gather_patient_data = AsyncMock(side_effect=gather_side_effect)
@@ -1359,7 +1369,9 @@ class TestRunValidation:
         monkeypatch.setattr("app.services.validation.settings.MEASURE_ENGINE_URL", "http://measure/fhir")
 
         strategy = MagicMock()
-        strategy.gather_patient_data = AsyncMock(return_value=[{"resourceType": "Patient", "id": "patient-1"}])
+        strategy.gather_patient_data = AsyncMock(
+            return_value=GatherResult(resources=[{"resourceType": "Patient", "id": "patient-1"}])
+        )
 
         def make_ctx():
             return self._make_session_ctx(test_session)


### PR DESCRIPTION
## Summary

- The validation-run path (`run_validation` in `backend/app/services/validation.py`) had drifted out of sync with two refactors in `fhir_client.py`, so **every validation run crashed** — it never produced results.
- Fix 1: `wipe_patient_data()` gained a required keyword-only `base_url` arg; the call site omitted it → run failed instantly with `missing 1 required keyword-only argument: 'base_url'`.
- Fix 2: `gather_patient_data()` now returns a `GatherResult` dataclass; the code used it as a plain resource list → every patient errored with `'GatherResult' object is not iterable`.

Both fixes mirror the correct usage already present in `orchestrator.py` (`base_url=settings.MEASURE_ENGINE_URL`, and `gather_result.resources`).

## Related issue

<!-- none -->

## Type of change

- [x] Bug fix

## Root cause / why it wasn't caught

`TestRunValidation` mocked the **old** contracts — `gather_patient_data` returning a `list`, and only asserting `wipe_patient_data` was "called once". So the unit tests passed against code that could never work at runtime. This PR updates the mocks to return `GatherResult` and strengthens the wipe assertion to require `base_url=MEASURE_ENGINE_URL`, so the regression cannot recur silently.

## Checklist

- [x] Tests added or updated (updated `TestRunValidation` mocks + wipe regression guard)
- [ ] docs/ updated (no architecture/API change)
- [x] No new ADRs needed
- [x] Security implications considered (N/A — internal call-signature fix)

## Test plan

Run locally (all green):

- **Lint:** `cd backend && ruff check app/ tests/ && ruff format --check app/ tests/` → clean
- **Unit:** `cd backend && python3 -m pytest tests/ --ignore=tests/integration` → **503 passed**
- **CI-equivalent integration:** `USE_PREBAKED=1 ./scripts/run-integration-tests.sh --ignore=...` (the six PR-check ignores) → **29 passed, 7 skipped**

End-to-end: uploaded `CMS1028FHIRPCSevereOBComps` (141 test patients) via `/validation/upload-bundle`, then `POST /validation/run` — previously crashed before any results; now completes and returns per-patient pass/fail/error (43 pass / 2 fail / 96 eval-error). The remaining eval errors are a separate measure-evaluation issue, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)