### PR TITLE
fix: add missing /groups serve.json rewrite causing direct-nav 404

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -149,6 +149,12 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Test
+        working-directory: frontend
+        run: npm test -- --watchAll=false
+        env:
+          CI: true
+
       - name: Build
         working-directory: frontend
         run: npm run build

--- a/frontend/public/serve.json
+++ b/frontend/public/serve.json
@@ -3,6 +3,7 @@
     { "source": "/", "destination": "/index.html" },
     { "source": "/measures", "destination": "/index.html" },
     { "source": "/jobs", "destination": "/index.html" },
+    { "source": "/groups", "destination": "/index.html" },
     { "source": "/results", "destination": "/index.html" },
     { "source": "/results/:jobId", "destination": "/index.html" },
     { "source": "/validation", "destination": "/index.html" },

--- a/frontend/src/App.routes.test.js
+++ b/frontend/src/App.routes.test.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+// This guard validates only the *literal string* route paths currently used in
+// App.js against frontend/public/serve.json's rewrite sources (see #383). It does
+// not model full react-router / serve-handler (path-to-regexp + minimatch)
+// matching semantics — those two libraries do not share a common route-matching
+// grammar. `/results/:jobId` compares equal only because both spell a single
+// dynamic segment as `:jobId` today; that's a coincidence of the current route
+// set, not a guarantee for future shapes (wildcards, optional segments, nested
+// routes). If a route is added that this guard can't parse as a plain
+// `path="/literal"` string, the test below fails loudly rather than silently
+// under-counting — update this file's regex when that happens.
+
+describe('App — route / serve.json rewrite parity (#383)', () => {
+  const appSource = fs.readFileSync(path.join(__dirname, 'App.js'), 'utf8');
+  const serveConfig = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'public', 'serve.json'), 'utf8'),
+  );
+
+  const routeTagCount = (appSource.match(/<Route\b/g) || []).length;
+  const routePaths = [...appSource.matchAll(/<Route\b[^>]*\bpath="([^"]*)"/g)].map(
+    (m) => m[1],
+  );
+
+  test('every <Route> in App.js has a literal, parseable path="..." attribute', () => {
+    // If this fails, a route was added with a non-literal path (a constant,
+    // single quotes, an expression) that the regex above can't see. Fix the
+    // regex rather than ignoring the failure — an unparsed route is exactly
+    // how #383 happened.
+    expect(routePaths.length).toBe(routeTagCount);
+  });
+
+  test('at least 8 routes are registered', () => {
+    // Guards against an App.js refactor (e.g. moving routes into a config
+    // object) silently reducing this file's extraction to zero routes, which
+    // would make the parity checks below vacuously pass.
+    expect(routePaths.length).toBeGreaterThanOrEqual(8);
+  });
+
+  const appRouteSet = new Set(routePaths.filter((p) => !p.includes('*')));
+  const serveSourceSet = new Set(
+    (serveConfig.rewrites || [])
+      .map((r) => r.source)
+      .filter((s) => !s.includes('*')),
+  );
+
+  test('every non-splat App.js route has a matching serve.json rewrite', () => {
+    const missing = [...appRouteSet].filter((p) => !serveSourceSet.has(p));
+    expect(missing).toEqual([]);
+  });
+
+  test('every serve.json rewrite corresponds to a real App.js route (no dead entries)', () => {
+    const dead = [...serveSourceSet].filter((s) => !appRouteSet.has(s));
+    expect(dead).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add the missing `/groups` rewrite to `frontend/public/serve.json`. `serve` runs deliberately without `-s` (see b8a3808), so every client-side route needs an explicit rewrite entry; PR #326 added the `/groups` route and nav link but never added the matching rewrite, so a refresh, bookmark, or shared link to `/groups` hard-404s in production while client-side nav works fine.
- Add `frontend/src/App.routes.test.js`: a parity guard asserting every `<Route>` path in `App.js` has a matching `serve.json` rewrite and vice versa. Fails loud (route-tag count must equal extracted-path count, minimum 8 routes) so an unparseable route shape fails the test instead of silently narrowing the guard, rather than a general react-router/serve-handler equivalence claim.
- Wire `npm test` into the `Frontend Build` CI job (previously `npm ci && npm run build` only — none of the 6 pre-existing frontend test files, or this new one, ever ran in CI). Confirmed all 7 suites (92 tests) pass locally before adding this step.

## Related issue

Closes #383

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI/CD
- [ ] Chore (deps, tooling, lockfile)

## Checklist

- [x] Tests added or updated
- [ ] docs/ updated (if architecture or API changed) — N/A, no architecture change
- [x] No new ADRs needed
- [x] Security implications considered — N/A, static rewrite config + test/CI change only

## Test plan

- [x] `cd frontend && npm ci && CI=true npm test -- --watchAll=false` — 7 suites, 92 tests, all green
- [x] Proved the new guard is meaningful: reverted only the `serve.json` line, reran, confirmed `App.routes.test.js` fails with the exact missing-path diff, restored the fix, confirmed green again
- [x] `docker compose up -d --build` (full stack per `.env.example`), then:
  - `curl http://localhost:3001/groups` → `200 text/html` (was `404`)
  - Swept every route (`/`, `/measures`, `/jobs`, `/groups`, `/groups/`, `/results`, `/results/:jobId`, `/validation`, `/settings`) plus `/groups?x=1` → all `200 text/html`
  - Confirmed b8a3808's intent preserved: `http://localhost:3001/nope.png` still returns a real `404` (not a silently-swallowed `200` app-shell fallback), `manifest.json` and the built JS bundle still serve correctly
- [x] Browser check via headless Chromium: fresh navigation to `/groups` loads the app shell with no console errors; enabled the `groups_enabled` admin toggle in Settings, clicked "Groups" in the sidebar nav, then hard-refreshed on `/groups` — the exact user path that was 404ing before this fix — loads correctly, no console errors

Follow-up filed separately (not in this PR): #384 tracks collapsing `App.js`'s 5-way route-path duplication (`<Route>` JSX, `ALL_NAV_ITEMS`, `PAGE_TITLE`, `SEARCH_PLACEHOLDER`, `serve.json`) into one shared `ROUTES` constant.