### PR TITLE
refactor: collapse App.js's 5-way route-path duplication into one ROUTES constant

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,46 +1,14 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Routes, Route, NavLink, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import styles from './App.module.css';
-import MeasuresPage from './pages/MeasuresPage';
-import JobsPage from './pages/JobsPage';
-import GroupsPage from './pages/GroupsPage';
-import ResultsPage from './pages/ResultsPage';
-import SettingsPage from './pages/SettingsPage';
-import ValidationPage from './pages/ValidationPage';
+import { ROUTES } from './routes';
 import { getHealth, getAdminSettings } from './api/client';
 import {
-  MeasuresIcon, JobsIcon, ResultsIcon, ValidateIcon,
   SettingsIcon, SearchIcon, XIcon, SunIcon, MoonIcon, GithubIcon,
 } from './components/Icons';
 import HealthChipGroup from './components/HealthChipGroup';
 import SearchContext from './contexts/SearchContext';
 import pkg from '../package.json';
-
-const ALL_NAV_ITEMS = [
-  { path: '/measures',   label: 'Measures',   Icon: MeasuresIcon,  kbd: 'M', feature: null },
-  { path: '/jobs',       label: 'Jobs',        Icon: JobsIcon,      kbd: 'J', feature: null },
-  { path: '/groups',     label: 'Groups',      Icon: JobsIcon,      kbd: 'G', feature: 'groups' },
-  { path: '/results',    label: 'Results',     Icon: ResultsIcon,   kbd: 'E', feature: null },
-  { path: '/validation', label: 'Validation',  Icon: ValidateIcon,  kbd: 'V', feature: 'validation' },
-];
-
-const PAGE_TITLE = {
-  '/measures': 'Measures',
-  '/jobs': 'Jobs',
-  '/groups': 'Groups',
-  '/results': 'Results',
-  '/validation': 'Validation',
-  '/settings': 'Settings',
-};
-
-const SEARCH_PLACEHOLDER = {
-  '/measures': 'Search measures…',
-  '/jobs': 'Search jobs…',
-  '/groups': 'Search groups…',
-  '/results': 'Search patients…',
-  '/validation': 'Search validation runs…',
-  '/settings': 'Search…',
-};
 
 const HEALTH_KINDS = [
   { kind: 'cdr', healthKey: 'cdr', settingsHash: '#cdr-connections' },
@@ -189,21 +157,24 @@ export default function App() {
         return;
       }
       if (!isInput && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-        if (e.key === 'm' || e.key === 'M') navigate('/measures');
-        else if (e.key === 'j' || e.key === 'J') navigate('/jobs');
-        else if (e.key === 'e' || e.key === 'E') navigate('/results');
-        else if ((e.key === 'v' || e.key === 'V') && features.validation) navigate('/validation');
-        else if ((e.key === 'g' || e.key === 'G') && features.groups) navigate('/groups');
+        // Feature-filtered inside the effect (not the render body) so this
+        // array's identity doesn't change every render — [navigate, features]
+        // stays the full dependency list and the listener isn't re-subscribed
+        // on every keystroke.
+        const shortcutRoutes = ROUTES.filter(r => r.nav && (!r.feature || features[r.feature]));
+        const match = shortcutRoutes.find(r => r.nav.kbd.toLowerCase() === e.key.toLowerCase());
+        if (match) navigate(match.path);
       }
     };
     window.addEventListener('keydown', h);
     return () => window.removeEventListener('keydown', h);
   }, [navigate, features]);
 
-  const navItems = ALL_NAV_ITEMS.filter(({ feature }) => !feature || features[feature]);
+  const navItems = ROUTES.filter(r => r.nav && (!r.feature || features[r.feature]));
   const basePath = '/' + location.pathname.split('/')[1];
-  const pageTitle = PAGE_TITLE[basePath] || 'Lenny';
-  const searchPlaceholder = SEARCH_PLACEHOLDER[basePath] || 'Search…';
+  const activeRoute = ROUTES.find(r => r.path === basePath);
+  const pageTitle = activeRoute?.title || 'Lenny';
+  const searchPlaceholder = activeRoute?.searchPlaceholder || 'Search…';
   const cdrChip = chips.cdr;
   const cdrOk = cdrChip.state === 'healthy';
 
@@ -279,7 +250,7 @@ export default function App() {
             <span>Close</span>
           </button>
           <div className={styles.navGroupLabel}>Workspace</div>
-          {navItems.map(({ path, label, Icon, kbd }) => (
+          {navItems.map(({ path, nav: { label, Icon, kbd } }) => (
             <NavLink
               key={path}
               to={path}
@@ -332,14 +303,13 @@ export default function App() {
         {/* Main content */}
         <main className={styles.main} role="main">
           <Routes>
-            <Route path="/" element={<Navigate to="/measures" replace />} />
-            <Route path="/measures" element={<MeasuresPage />} />
-            <Route path="/jobs" element={<JobsPage />} />
-            <Route path="/groups" element={<GroupsPage />} />
-            <Route path="/results" element={<ResultsPage />} />
-            <Route path="/results/:jobId" element={<ResultsPage />} />
-            <Route path="/validation" element={<ValidationPage />} />
-            <Route path="/settings" element={<SettingsPage />} />
+            {ROUTES.map(({ path, redirectTo, Component }) => (
+              <Route
+                key={path}
+                path={path}
+                element={redirectTo ? <Navigate to={redirectTo} replace /> : <Component />}
+              />
+            ))}
           </Routes>
         </main>
       </div>

--- a/frontend/src/App.routes.test.js
+++ b/frontend/src/App.routes.test.js
@@ -1,57 +1,89 @@
 import fs from 'fs';
 import path from 'path';
+import { ROUTES } from './routes';
 
-// This guard validates only the *literal string* route paths currently used in
-// App.js against frontend/public/serve.json's rewrite sources (see #383). It does
-// not model full react-router / serve-handler (path-to-regexp + minimatch)
-// matching semantics — those two libraries do not share a common route-matching
+// This guard validates real route data (ROUTES, from ./routes.js) against
+// public/serve.json's rewrite list, plus a source-text check that App.js has
+// no route left un-derived from ROUTES (see #383, #384). It does not model
+// full react-router / serve-handler (path-to-regexp + minimatch) matching
+// semantics — those two libraries do not share a common route-matching
 // grammar. `/results/:jobId` compares equal only because both spell a single
-// dynamic segment as `:jobId` today; that's a coincidence of the current route
-// set, not a guarantee for future shapes (wildcards, optional segments, nested
-// routes). If a route is added that this guard can't parse as a plain
-// `path="/literal"` string, the test below fails loudly rather than silently
-// under-counting — update this file's regex when that happens.
+// dynamic segment as `:jobId` today; that's a coincidence of the current
+// route set, not a guarantee for future shapes (wildcards, optional
+// segments, nested routes).
 
-describe('App — route / serve.json rewrite parity (#383)', () => {
+describe('App — route / serve.json rewrite parity (#383, #384)', () => {
   const appSource = fs.readFileSync(path.join(__dirname, 'App.js'), 'utf8');
   const serveConfig = JSON.parse(
     fs.readFileSync(path.join(__dirname, '..', 'public', 'serve.json'), 'utf8'),
   );
 
-  const routeTagCount = (appSource.match(/<Route\b/g) || []).length;
-  const routePaths = [...appSource.matchAll(/<Route\b[^>]*\bpath="([^"]*)"/g)].map(
-    (m) => m[1],
-  );
-
-  test('every <Route> in App.js has a literal, parseable path="..." attribute', () => {
-    // If this fails, a route was added with a non-literal path (a constant,
-    // single quotes, an expression) that the regex above can't see. Fix the
-    // regex rather than ignoring the failure — an unparsed route is exactly
-    // how #383 happened.
-    expect(routePaths.length).toBe(routeTagCount);
+  test('App.js has no hand-written literal-path <Route> — every route comes from ROUTES', () => {
+    // If this fails, someone added a route straight into the JSX instead of
+    // to ROUTES, bypassing the sidebar/title/placeholder derivation *and*
+    // this parity guard — exactly how #383 happened. Matches any literal
+    // path spelling (`path="/foo"`, `path='/foo'`, `path={'/foo'}`,
+    // `path={"/foo"}`, `` path={`/foo`} ``) but not App.js's own legitimate
+    // `path={path}` (an identifier reference into the ROUTES.map loop) or
+    // MenuIcon's unrelated inline `<path d="...">` SVG element.
+    const literalRoutePaths = [...appSource.matchAll(
+      /<Route\b[^>]*\bpath=(?:"[^"]*"|'[^']*'|\{\s*(?:"[^"]*"|'[^']*'|`[^`]*`)\s*\})/g,
+    )];
+    expect(literalRoutePaths).toEqual([]);
   });
 
   test('at least 8 routes are registered', () => {
-    // Guards against an App.js refactor (e.g. moving routes into a config
-    // object) silently reducing this file's extraction to zero routes, which
-    // would make the parity checks below vacuously pass.
-    expect(routePaths.length).toBeGreaterThanOrEqual(8);
+    // Guards against ROUTES being silently gutted, which would make the
+    // parity checks below vacuously pass.
+    expect(ROUTES.length).toBeGreaterThanOrEqual(8);
   });
 
-  const appRouteSet = new Set(routePaths.filter((p) => !p.includes('*')));
+  test('every route path is unique', () => {
+    const paths = ROUTES.map((r) => r.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  test('every nav route has a unique keyboard shortcut (case-insensitive, matching App.js)', () => {
+    // App.js matches shortcuts case-insensitively (`kbd.toLowerCase() ===
+    // e.key.toLowerCase()`), so 'M' and 'm' would collide there even though
+    // they're distinct strings — normalize before comparing or this guard
+    // misses that ambiguity.
+    const kbds = ROUTES.filter((r) => r.nav).map((r) => r.nav.kbd.toLowerCase());
+    expect(new Set(kbds).size).toBe(kbds.length);
+  });
+
+  test('every non-redirect route resolves a title and searchPlaceholder via basePath', () => {
+    // Title/placeholder are looked up by basePath in App.js, which is why
+    // /results/:jobId intentionally carries neither of its own — it must
+    // resolve through the /results entry's basePath ('/results').
+    const unresolved = ROUTES.filter((r) => !r.redirectTo)
+      .map((r) => '/' + r.path.split('/')[1])
+      .filter((basePath) => {
+        const match = ROUTES.find((r) => r.path === basePath);
+        return !match?.title || !match?.searchPlaceholder;
+      });
+    expect(unresolved).toEqual([]);
+  });
+
+  const routeSet = new Set(ROUTES.map((r) => r.path).filter((p) => !p.includes('*')));
   const serveSourceSet = new Set(
     (serveConfig.rewrites || [])
       .map((r) => r.source)
       .filter((s) => !s.includes('*')),
   );
 
-  test('every non-splat App.js route has a matching serve.json rewrite', () => {
-    const missing = [...appRouteSet].filter((p) => !serveSourceSet.has(p));
+  test('every serve.json rewrite destination is /index.html', () => {
+    const wrong = (serveConfig.rewrites || []).filter((r) => r.destination !== '/index.html');
+    expect(wrong).toEqual([]);
+  });
+
+  test('every ROUTES path has a matching serve.json rewrite', () => {
+    const missing = [...routeSet].filter((p) => !serveSourceSet.has(p));
     expect(missing).toEqual([]);
   });
 
-  test('every serve.json rewrite corresponds to a real App.js route (no dead entries)', () => {
-    const dead = [...serveSourceSet].filter((s) => !appRouteSet.has(s));
+  test('every serve.json rewrite corresponds to a real ROUTES path (no dead entries)', () => {
+    const dead = [...serveSourceSet].filter((s) => !routeSet.has(s));
     expect(dead).toEqual([]);
   });
 });

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+import * as api from './api/client';
+
+// Render smoke test for the ROUTES-derived chrome (#384): sidebar nav,
+// header title, and search placeholder must all reflect ROUTES and the
+// feature flags, since none of that is covered by App.routes.test.js's
+// data-only parity checks. Pages themselves are stubbed — this test is
+// about App.js's derivation, not page behavior.
+jest.mock('./api/client');
+jest.mock('./pages/MeasuresPage', () => () => <div>Measures page</div>);
+jest.mock('./pages/JobsPage', () => () => <div>Jobs page</div>);
+jest.mock('./pages/GroupsPage', () => () => <div>Groups page</div>);
+jest.mock('./pages/ResultsPage', () => () => <div>Results page</div>);
+jest.mock('./pages/ValidationPage', () => () => <div>Validation page</div>);
+jest.mock('./pages/SettingsPage', () => () => <div>Settings page</div>);
+
+function renderApp(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+function mockSettings({ validation = false, groups = false } = {}) {
+  api.getHealth = jest.fn().mockResolvedValue({
+    cdr: { status: 'healthy' },
+    measure_engine: { status: 'healthy' },
+  });
+  api.getAdminSettings = jest.fn().mockResolvedValue({
+    validation_enabled: validation,
+    groups_enabled: groups,
+  });
+}
+
+describe('App — nav / title / search derivation from ROUTES', () => {
+  test('feature flags off: Groups and Validation are hidden, /jobs resolves its title and placeholder', async () => {
+    mockSettings({ validation: false, groups: false });
+
+    renderApp('/jobs');
+    await waitFor(() => expect(api.getAdminSettings).toHaveBeenCalled());
+
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(within(nav).getByRole('link', { name: /Measures/ })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /Jobs/ })).toBeInTheDocument();
+    expect(within(nav).getByRole('link', { name: /Results/ })).toBeInTheDocument();
+    expect(within(nav).queryByRole('link', { name: /Groups/ })).not.toBeInTheDocument();
+    expect(within(nav).queryByRole('link', { name: /Validation/ })).not.toBeInTheDocument();
+
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('Jobs')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search jobs…')).toBeInTheDocument();
+  });
+
+  test('feature flags on: Groups and Validation appear in nav, /groups resolves its title and placeholder', async () => {
+    mockSettings({ validation: true, groups: true });
+
+    renderApp('/groups');
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    await waitFor(() => expect(within(nav).getByRole('link', { name: /Groups/ })).toBeInTheDocument());
+    expect(within(nav).getByRole('link', { name: /Validation/ })).toBeInTheDocument();
+
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('Groups')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search groups…')).toBeInTheDocument();
+  });
+
+  test('/ redirects to /measures', async () => {
+    mockSettings();
+    renderApp('/');
+    expect(await screen.findByText('Measures page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,0 +1,75 @@
+import MeasuresPage from './pages/MeasuresPage';
+import JobsPage from './pages/JobsPage';
+import GroupsPage from './pages/GroupsPage';
+import ResultsPage from './pages/ResultsPage';
+import SettingsPage from './pages/SettingsPage';
+import ValidationPage from './pages/ValidationPage';
+import { MeasuresIcon, JobsIcon, ResultsIcon, ValidateIcon } from './components/Icons';
+
+// Single source of truth for every route in the app: the <Route> table, the
+// sidebar nav + keyboard shortcuts, the header title, the search placeholder,
+// and (validated by App.routes.test.js against public/serve.json) the
+// production `serve` SPA rewrite list. Adding a page means adding one entry
+// here — not touching five separate places (see #383, #384).
+//
+// Note: pages must not import this module — GroupsPage etc. are imported
+// *by* routes.js, so the reverse would be circular.
+//
+// Field semantics:
+// - `redirectTo`: this path renders a <Navigate> instead of a page component.
+// - `nav`: present only for routes that appear in the sidebar and own a
+//   keyboard shortcut (`kbd`). Omitted for `/settings` (rendered separately,
+//   with its own styling and no shortcut) and for `/results/:jobId`.
+// - `feature`: gates the *nav entry + keyboard shortcut* only. The <Route>
+//   itself is always registered; the page component (e.g. GroupsPage) is
+//   responsible for redirecting away if its own feature flag is off.
+// - `title` / `searchPlaceholder`: looked up by basePath ('/' + first path
+//   segment), which is why `/results/:jobId` omits them and resolves through
+//   the `/results` entry instead.
+export const ROUTES = [
+  { path: '/', redirectTo: '/measures' },
+  {
+    path: '/measures',
+    Component: MeasuresPage,
+    title: 'Measures',
+    searchPlaceholder: 'Search measures…',
+    nav: { label: 'Measures', Icon: MeasuresIcon, kbd: 'M' },
+  },
+  {
+    path: '/jobs',
+    Component: JobsPage,
+    title: 'Jobs',
+    searchPlaceholder: 'Search jobs…',
+    nav: { label: 'Jobs', Icon: JobsIcon, kbd: 'J' },
+  },
+  {
+    path: '/groups',
+    Component: GroupsPage,
+    title: 'Groups',
+    searchPlaceholder: 'Search groups…',
+    nav: { label: 'Groups', Icon: JobsIcon, kbd: 'G' },
+    feature: 'groups',
+  },
+  {
+    path: '/results',
+    Component: ResultsPage,
+    title: 'Results',
+    searchPlaceholder: 'Search patients…',
+    nav: { label: 'Results', Icon: ResultsIcon, kbd: 'E' },
+  },
+  { path: '/results/:jobId', Component: ResultsPage },
+  {
+    path: '/validation',
+    Component: ValidationPage,
+    title: 'Validation',
+    searchPlaceholder: 'Search validation runs…',
+    nav: { label: 'Validation', Icon: ValidateIcon, kbd: 'V' },
+    feature: 'validation',
+  },
+  {
+    path: '/settings',
+    Component: SettingsPage,
+    title: 'Settings',
+    searchPlaceholder: 'Search…',
+  },
+];


### PR DESCRIPTION
## Summary

- `frontend/src/App.js` spelled out the same route paths in five separate places (`<Route>` JSX, `ALL_NAV_ITEMS`, `PAGE_TITLE`, `SEARCH_PLACEHOLDER`, plus `serve.json` in a different file) with nothing keeping them in sync — that gap is what caused #383 (`/groups` added to the JSX and nav but never to `serve.json`, so direct navigation 404'd).
- New `frontend/src/routes.js` exports one `ROUTES` array; `App.js` now derives its `<Route>` table, sidebar nav, keyboard shortcuts, header title, and search placeholder from it instead of hand-maintaining six parallel lists (a sixth duplication site — the keyboard-shortcut `if/else` chain — was found and collapsed too).
- `App.routes.test.js` (added by #385 as an interim regex-over-source guard) is rewritten to validate the real `ROUTES` data against `serve.json` structurally, and now also asserts no hand-written `<Route path="...">` can bypass `ROUTES` in the first place (any literal-path spelling — double/single-quoted or `{...}`-wrapped) — closing the exact bypass #383 exploited.
- Pure refactor — no behavior change intended, and none found in review or testing.

## Related issue

Closes #384

## Type of change

- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated — rewrote `App.routes.test.js` as a structural guard, added `App.test.js` render smoke test
- [ ] docs/ updated (if architecture or API changed) — N/A, no architecture change
- [x] No new ADRs needed, OR I've added an entry to `docs/decisions.md`
- [x] Security implications considered (N/A for pure refactor/docs)

## Test plan

- [x] `cd frontend && npm test -- --watchAll=false` — 8 suites / 99 tests passing (up from 92 on baseline `main`)
- [x] `cd frontend && npm run build` — compiles cleanly, output 388B smaller gzipped
- [x] `cd backend && python3 -m pytest tests/ --ignore=tests/integration -v` — 503 passed (unaffected by this change, run to confirm)
- [x] `./scripts/run-integration-tests.sh` (CI-equivalent flags) — 33 passed, 3 skipped, 0 failed
- [x] Full production-path browser smoke walk against the local Docker stack (`docker compose up -d --build`, exercising the actual `serve` binary + `serve.json`): hard navigation to `/`, `/measures`, `/jobs`, `/groups`, `/results`, `/results/:jobId`, `/validation`, `/settings` all load the app shell (not a 404) with correct header title, search placeholder, and sidebar order; feature-flag gating (Groups/Validation nav visibility) and keyboard shortcuts (M/J/E navigate, G/V suppressed when flags off, all suppressed while the search box is focused) verified
- [x] Independent `/codex` review — found two real gaps (bypass-guard regex missed single-quoted/expression-literal paths; kbd-uniqueness check wasn't case-normalized to match `App.js`'s case-insensitive matching) — both fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QCHg8DX1rzgPDCm5CsHF7g